### PR TITLE
Add ECMWF IFS ENS (coming soon) to catalog

### DIFF
--- a/_data/catalog.js
+++ b/_data/catalog.js
@@ -50,17 +50,19 @@ const models = {
     agency: "NOAA",
     type: "Regional Weather Model"
   },
-  "ecmwf-ifs": {
-    name: "ECMWF IFS",
-    shortName: "IFS",
+  "ecmwf-ifs-ens": {
+    name: "ECMWF IFS Ensemble (ENS)",
+    shortName: "IFS ENS",
     description: `
       <p>
        The Integrated Forecasting System (IFS) is a global forecast model developed 
-       by ECMWF. It consists of a numerical model of the Earth system, including an
-       atmospheric model at its heart, coupled with models of other Earth system 
+       by ECMWF. It consists of a numerical model of the Earth system, which includes
+       an atmospheric model at its heart, coupled with models of other Earth system 
        components such as the ocean. The data assimilation system combines 
        the latest weather observations with a recent forecast to obtain the best 
        possible estimate of the current state of the Earth system.
+       The IFS Ensemble (ENS) is one of several configurations of forecasts produced,
+       and contains 51 ensemble members (one control member and 50 perturbed members).
       </p>
     `,
     agency: "ECMWF",
@@ -421,12 +423,12 @@ ds["temperature_2m"].sel(init_time="2025-01-01T00", x=0, y=0, method="nearest").
     descriptionSummary: `
         <p>
         This dataset is an archive of past and present ECMWF IFS Ensemble (ENS) forecasts.
-        ENS is one of several configurations of forecasts produced by IFS.
         Forecasts are identified by an initialization time (<code>init_time</code>) 
         denoting the start time of the model run, as well as by the 
         <code>ensemble_member</code>. Along the <code>lead_time</code> dimension, 
         each forecast begins at a 3 hourly forecast step (0-144 hours) and switches 
         to a 6 hourly step for days 6 through 15 of the forecast (hours 144-360).
+        This dataset contains the 00 UTC initialization times only.
         </p>
       `,
     descriptionDetails: `
@@ -434,17 +436,16 @@ ds["temperature_2m"].sel(init_time="2025-01-01T00", x=0, y=0, method="nearest").
         <p>
         The source grib files this archive is contructed from are provided by
         <a href="https://www.ecmwf.int/en/forecasts/datasets/open-data">ECMWF Open Data</a>
-        and accessed from the <a href="https://registry.opendata.aws/ecmwf-forecasts//">AWS Open Data Registry</a>.
+        and accessed from the <a href="https://registry.opendata.aws/ecmwf-forecasts/">AWS Open Data Registry</a>.
         </p>
 
         <h3>Data availability</h3>
         <p>
         This dataset contains only forecasts initialized on or after 2024-04-01, 
-        which are available at the full 0.25 degree (~9km) resolution.
+        which are available at the open data 0.25 degree (~20km) resolution.
         All variables are available for the full period, save for 
         <code>precipitation_surface</code>, which is filled with NaNs 
-        until 2024-11-13 UTC, when it first becomes available (coinciding 
-        with a model update, IFS Cycle 49r1).
+        before 2024-11-13 UTC.
         </p>
 
         <h3>Ensemble members</h3>
@@ -455,11 +456,6 @@ ds["temperature_2m"].sel(init_time="2025-01-01T00", x=0, y=0, method="nearest").
         are each produced with slight perturbations of initial conditions 
         and of the models. Taken together, ensemble of 51 forecasts shows 
         the range of possible outcomes and the likelihood of their occurrence.
-
-        As of November 2024 (IFS Cycle 49r1), the control member for the 
-        ensemble is scientifically, structurally and computationally identical 
-        to ECMWF's HRES forecast. This control member may be referred to as 
-        "Ensemble Control", "IFS-CF", or "ex-HRES". 
         </p>
 
         <h3>Storage</h3>
@@ -479,23 +475,23 @@ ds["temperature_2m"].sel(init_time="2025-01-01T00", x=0, y=0, method="nearest").
         <a href="https://github.com/dynamical-org/reformatters/blob/main/src/reformatters/ecmwf/ifs_ens/forecast_15_day_0_25_degree/template_config.py">reformatting code</a>.
         </p>
       `,
-    // url: "https://data.dynamical.org/ecmwf/ifs-ens/forecast-15-day-0-25-degree/latest.zarr",
+    url: "https://data.dynamical.org/ecmwf/ifs-ens/forecast-15-day-0-25-degree/latest.zarr",
     status: "coming soon",
-//     examples: [
-//       {
-//         title: "Maximum temperature in ensemble forecast",
-//         code: `
-// import xarray as xr  # xarray>=2025.1.2 and zarr>=3.0.8 for zarr v3 support
+    examples: [
+      {
+        title: "Maximum temperature in ensemble forecast",
+        code: `
+import xarray as xr  # xarray>=2025.1.2 and zarr>=3.0.8 for zarr v3 support
 
-// ds = xr.open_zarr("https://data.dynamical.org/ecmwf/ifs-ens/forecast-15-day-0-25-degree/latest.zarr?email=optional@email.com")
-// ds["temperature_2m"].sel(init_time="2025-01-01T00", latitude=0, longitude=0).max().compute()
-//     `,
-//       },
-//     ],
-    // githubUrl:
-    //   "https://github.com/dynamical-org/notebooks/blob/main/ecmwf-ifs-ens-forecast-15-day-0-25-degree.ipynb",
-    // colabUrl:
-    //   "https://colab.research.google.com/github/dynamical-org/notebooks/blob/main/ecmwf-ifs-ens-forecast-15-day-0-25-degree.ipynb",
+ds = xr.open_zarr("https://data.dynamical.org/ecmwf/ifs-ens/forecast-15-day-0-25-degree/latest.zarr?email=optional@email.com")
+ds["temperature_2m"].sel(init_time="2025-01-01T00", latitude=0, longitude=0).max().compute()
+    `,
+      },
+    ],
+    githubUrl:
+      "https://github.com/dynamical-org/notebooks/blob/main/ecmwf-ifs-ens-forecast-15-day-0-25-degree.ipynb",
+    colabUrl:
+      "https://colab.research.google.com/github/dynamical-org/notebooks/blob/main/ecmwf-ifs-ens-forecast-15-day-0-25-degree.ipynb",
   },
 ].filter((entry) => !entry.hide);
 

--- a/docs/catalog/index.html
+++ b/docs/catalog/index.html
@@ -167,6 +167,32 @@
         </ul>
       </div>
     
+      <div class="model-group">
+        <div class="model-header">
+          <h2>
+            <a href="/catalog/models/ifs-ens">ECMWF IFS Ensemble (ENS)</a>
+          </h2>
+          <p>The Integrated Forecasting System (IFS) is a global forecast model developed by ECMWF. It consists of a numerical model of the Earth system, which...</p>
+        </div>
+        <ul class="catalog-list">
+          
+            <li>
+              <div style='display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap;'>
+                <strong>
+                  
+                    ECMWF IFS Ensemble (ENS) Forecast, 15 day, 0.25 degree
+                  
+                </strong>
+                <br/> 
+<span style="background-color: rgb(240, 240, 240);">coming soon</span>
+
+              </div>
+              <p>Ensemble weather forecasts from the ECMWF Integrated Forecasting System (IFS); 15 day forecasts, 0.25 degree resolution.</p>
+            </li>
+          
+        </ul>
+      </div>
+    
   </div>
   <hr style="margin: 6rem 0;" />
   <h2>Roadmap, Phase 1</h2>

--- a/docs/catalog/llms/index.html
+++ b/docs/catalog/llms/index.html
@@ -2250,3 +2250,297 @@ ds["temperature_2m"].sel(init_time="2025-01-01T00", x=0, y=0, method="nearest").
             </div>
         
     </div>
+
+    <div class="content catalog-item">
+        <div style="display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap;">
+            <h1>ECMWF IFS Ensemble (ENS) Forecast, 15 day, 0.25 degree</h1>
+        </div>
+        <table>
+            <tr>
+                <td>Dataset url</td>
+                <td>https://data.dynamical.org/ecmwf/ifs-ens/forecast-15-day-0-25-degree/latest.zarr</td>
+            </tr>
+            <tr>
+                <td>Spatial domain</td>
+                <td>Global</td>
+            </tr>
+            <tr>
+                <td>Spatial resolution</td>
+                <td>0.25 degrees (~20km)</td>
+            </tr>
+            <tr>
+                <td>Time domain</td>
+                <td>Forecasts initialized 2024-04-01 00:00:00 UTC to Present</td>
+            </tr>
+            <tr>
+                <td>Time resolution</td>
+                <td>Forecasts initialized every 24 hours</td>
+            </tr>
+            
+                <tr>
+                    <td>Forecast domain</td>
+                    <td>Forecast lead time 0-360 hours (0-15 days) ahead</td>
+                </tr>
+                <tr>
+                    <td>Forecast resolution</td>
+                    <td>Forecast step 0-144 hours: 3 hourly, 144-360 hours: 6 hourly</td>
+                </tr>
+            
+        </table>
+        <h2>Description</h2>
+        <p>
+            
+        <p>
+        This dataset is an archive of past and present ECMWF IFS Ensemble (ENS) forecasts.
+        Forecasts are identified by an initialization time (<code>init_time</code>) 
+        denoting the start time of the model run, as well as by the 
+        <code>ensemble_member</code>. Along the <code>lead_time</code> dimension, 
+        each forecast begins at a 3 hourly forecast step (0-144 hours) and switches 
+        to a 6 hourly step for days 6 through 15 of the forecast (hours 144-360).
+        This dataset contains the 00 UTC initialization times only.
+        </p>
+      
+        </p>
+        <!-- Structured metadata for LLMs -->
+        <div class="llm-metadata">
+            <pre class="llm-metadata">
+{
+    "dataset_name": "ECMWF IFS Ensemble (ENS) Forecast, 15 day, 0.25 degree",
+    "description_short": "Ensemble weather forecasts from the ECMWF Integrated Forecasting System (IFS); 15 day forecasts, 0.25 degree resolution.",
+    "url": "https://data.dynamical.org/ecmwf/ifs-ens/forecast-15-day-0-25-degree/latest.zarr",
+    "spatial_domain": "Global",
+    "spatial_resolution": "0.25 degrees (~20km)",
+    "time_domain": "Forecasts initialized 2024-04-01 00:00:00 UTC to Present",
+    "time_resolution": "Forecasts initialized every 24 hours",
+    "forecast_domain": "Forecast lead time 0-360 hours (0-15 days) ahead",
+    "forecast_resolution": "Forecast step 0-144 hours: 3 hourly, 144-360 hours: 6 hourly",
+    "dimensions": [
+        {
+            "name": "ensemble_member",
+            "min": "0",
+            "max": "50",
+            "units": "realization"
+        },
+        {
+            "name": "init_time",
+            "min": "2024-04-01T00:00:00",
+            "max": "Present",
+            "units": "seconds since 1970-01-01"
+        },
+        {
+            "name": "latitude",
+            "min": "-90",
+            "max": "90",
+            "units": "degrees_north"
+        },
+        {
+            "name": "lead_time",
+            "min": "0 days 00:00:00",
+            "max": "15 days 00:00:00",
+            "units": "seconds"
+        },
+        {
+            "name": "longitude",
+            "min": "-180",
+            "max": "179.75",
+            "units": "degrees_east"
+        }
+    ],
+    "variables": [
+        {
+            "name": "categorical_precipitation_type_surface",
+            "long_name": "Categorical precipitation type at surface",
+            "units": "[0=No precipitation; 1=Rain; 2=Thunderstorm; 3=Freezing rain; 4=Mixed/ice; 5=Snow; 6=Wet snow; 7=Mixture of rain and snow; 8=Ice pellets; 9=Graupel; 10=Hail; 11=Drizzle; 12=Freezing drizzle; 13-191=Reserved; 192-254=Reserved for local use; 255=Missing",
+            "dimensions": "init_time × lead_time × ensemble_member × latitude × longitude"
+        },
+        {
+            "name": "downward_long_wave_radiation_flux_surface",
+            "long_name": "Surface downward long-wave radiation flux",
+            "units": "W/(m^2)",
+            "dimensions": "init_time × lead_time × ensemble_member × latitude × longitude"
+        },
+        {
+            "name": "downward_short_wave_radiation_flux_surface",
+            "long_name": "Surface downward short-wave radiation flux",
+            "units": "W/(m^2)",
+            "dimensions": "init_time × lead_time × ensemble_member × latitude × longitude"
+        },
+        {
+            "name": "expected_forecast_length",
+            "long_name": "",
+            "units": "seconds",
+            "dimensions": "init_time"
+        },
+        {
+            "name": "ingested_forecast_length",
+            "long_name": "",
+            "units": "seconds",
+            "dimensions": "init_time"
+        },
+        {
+            "name": "precipitation_surface",
+            "long_name": "Total precipitation",
+            "units": "mm/s",
+            "comment": "Average precipitation rate since the previous forecast step.",
+            "dimensions": "init_time × lead_time × ensemble_member × latitude × longitude"
+        },
+        {
+            "name": "pressure_reduced_to_mean_sea_level",
+            "long_name": "Pressure reduced to MSL",
+            "units": "Pa",
+            "dimensions": "init_time × lead_time × ensemble_member × latitude × longitude"
+        },
+        {
+            "name": "pressure_surface",
+            "long_name": "Surface pressure",
+            "units": "Pa",
+            "dimensions": "init_time × lead_time × ensemble_member × latitude × longitude"
+        },
+        {
+            "name": "temperature_2m",
+            "long_name": "2 metre temperature",
+            "units": "C",
+            "dimensions": "init_time × lead_time × ensemble_member × latitude × longitude"
+        },
+        {
+            "name": "valid_time",
+            "long_name": "",
+            "units": "seconds since 1970-01-01",
+            "dimensions": "init_time × lead_time"
+        },
+        {
+            "name": "wind_u_100m",
+            "long_name": "100 metre U wind component",
+            "units": "m/s",
+            "dimensions": "init_time × lead_time × ensemble_member × latitude × longitude"
+        },
+        {
+            "name": "wind_u_10m",
+            "long_name": "10 metre U wind component",
+            "units": "m s**-1",
+            "dimensions": "init_time × lead_time × ensemble_member × latitude × longitude"
+        },
+        {
+            "name": "wind_v_100m",
+            "long_name": "100 metre V wind component",
+            "units": "m/s",
+            "dimensions": "init_time × lead_time × ensemble_member × latitude × longitude"
+        },
+        {
+            "name": "wind_v_10m",
+            "long_name": "10 metre V wind component",
+            "units": "m s**-1",
+            "dimensions": "init_time × lead_time × ensemble_member × latitude × longitude"
+        }
+    ]
+}
+            </pre>
+        </div>
+        <h2>For LLMs & AI Assistants</h2>
+        <div class="llm-context-info">
+            <p>
+                <strong>Dataset summary:</strong>
+                ECMWF IFS Ensemble (ENS) Forecast, 15 day, 0.25 degree is a dataset containing 14 variables across 5
+                dimensions, covering
+                Global at 0.25 degrees (~20km) resolution and
+                Forecasts initialized 2024-04-01 00:00:00 UTC to Present at Forecasts initialized every 24 hours resolution.
+            </p>
+            <p>
+                <strong>Key use cases:</strong>
+                This dataset is suitable for
+                forecasting and prediction models,
+                
+                data analysis, visualization, and scientific research related to this domain.
+            </p>
+            <p>
+                <strong>Access pattern:</strong>
+                Use this URL with optional email parameter to access this dataset programmatically: https://data.dynamical.org/ecmwf/ifs-ens/forecast-15-day-0-25-degree/latest.zarr
+            </p>
+        </div>
+        <h2>Details</h2>
+        <p>
+            
+        <h3>Source</h3>
+        <p>
+        The source grib files this archive is contructed from are provided by
+        <a href="https://www.ecmwf.int/en/forecasts/datasets/open-data">ECMWF Open Data</a>
+        and accessed from the <a href="https://registry.opendata.aws/ecmwf-forecasts/">AWS Open Data Registry</a>.
+        </p>
+
+        <h3>Data availability</h3>
+        <p>
+        This dataset contains only forecasts initialized on or after 2024-04-01, 
+        which are available at the open data 0.25 degree (~20km) resolution.
+        All variables are available for the full period, save for 
+        <code>precipitation_surface</code>, which is filled with NaNs 
+        before 2024-11-13 UTC.
+        </p>
+
+        <h3>Ensemble members</h3>
+        <p>
+        Each forecast contains 51 ensemble members, including a control member (0) 
+        and 50 perturbed members (1-50). The control forecast is produced with 
+        the best available data and unperturbed models. The other 50 members 
+        are each produced with slight perturbations of initial conditions 
+        and of the models. Taken together, ensemble of 51 forecasts shows 
+        the range of possible outcomes and the likelihood of their occurrence.
+        </p>
+
+        <h3>Storage</h3>
+        <p>
+        Storage for this dataset is generously provided by
+        <a href="https://source.coop/">Source Cooperative</a>,
+        a <a href="https://radiant.earth/">Radiant Earth</a> initiative.
+        </p>
+
+        <h3>Compression</h3>
+        <p>
+        The data values in this dataset have been rounded in their binary
+        floating point representation to improve compression. See
+        <a href="https://www.nature.com/articles/s43588-021-00156-2">Klöwer et al. 2021</a>
+        for more information on this approach. The exact number of rounded bits
+        can be found in our
+        <a href="https://github.com/dynamical-org/reformatters/blob/main/src/reformatters/ecmwf/ifs_ens/forecast_15_day_0_25_degree/template_config.py">reformatting code</a>.
+        </p>
+      
+        </p>
+        <h2>Examples</h2>
+        <h3>Brief example usage:</h3>
+        
+            <div class="frame">
+                <div class="frameHeader">
+                    <div class="frameHeaderTitle">dynamical.org - ECMWF IFS Ensemble (ENS) Forecast, 15 day, 0.25 degree</div>
+                    <div class="frameHeaderSubtitle">Maximum temperature in ensemble forecast</div>
+                </div>
+                <pre class="frameContent frameContentDesktop"><code class="language-python">
+# Example: Maximum temperature in ensemble forecast
+# Dataset: ECMWF IFS Ensemble (ENS) Forecast, 15 day, 0.25 degree
+# This code demonstrates how to access and process the ECMWF IFS Ensemble (ENS) Forecast, 15 day, 0.25 degree dataset
+
+
+import xarray as xr  # xarray>=2025.1.2 and zarr>=3.0.8 for zarr v3 support
+
+ds = xr.open_zarr("https://data.dynamical.org/ecmwf/ifs-ens/forecast-15-day-0-25-degree/latest.zarr?email=optional@email.com")
+ds["temperature_2m"].sel(init_time="2025-01-01T00", latitude=0, longitude=0).max().compute()
+    </code></pre>
+                <div class="example-notes">
+                    <p>
+                        <strong>What this example does:</strong>
+                        This code demonstrates accessing the ECMWF IFS Ensemble (ENS) Forecast, 15 day, 0.25 degree dataset and processing its data.</p>
+                    <p>
+                        <strong>Key components:</strong>
+                        Data loading, processing, and potentially visualization of the dataset variables.</p>
+                </div>
+            </div>
+        
+        
+            <div class="notebook-content">
+                <h3>Python notebook example usage:</h3>
+                
+                <div class="example-source">Source:
+                    <a href="https://github.com/dynamical-org/notebooks/blob/main/ecmwf-ifs-ens-forecast-15-day-0-25-degree.ipynb">https://github.com/dynamical-org/notebooks/blob/main/ecmwf-ifs-ens-forecast-15-day-0-25-degree.ipynb</a>
+                </div>
+                <p>Error loading notebook content: Bad response for https://raw.githubusercontent.com/dynamical-org/notebooks/refs/heads/main/ecmwf-ifs-ens-forecast-15-day-0-25-degree.ipynb (404): Not Found</p>
+            </div>
+        
+    </div>


### PR DESCRIPTION
Adds ECMWF IFS ENS to the catalog, hopefully in "coming soon" mode without any live links. 

ECMWF Documentation I pulled from for the copy:
* [Main IFS page describing the model](https://www.ecmwf.int/en/forecasts/documentation-and-support/changes-ecmwf-model)
* [IFS Forecast User Guide, describing ENS as one of the several configurations of IFS](https://confluence.ecmwf.int/display/FUG/Forecast+User+Guide)
* [On what they do to perturb the ensemble members](https://www.ecmwf.int/en/about/media-centre/focus/2017/fact-sheet-ensemble-weather-forecasting) 
* [On the control member and HRES being the same](https://confluence.ecmwf.int/display/FUG/Section+2.1.2.4++Ensemble+Control+ex-HRES)

-------
I think there are two things (almost definitely two symptoms of the same issue) I need help with however:
* running `npm start` locally to try to view the built page fails on some unrelated json and csv errors for the gfs dataset? unclear what's happening there. I haven't been able to verify that this looks sane on a localhost version of the page however, which should definitely be done before merging to catch mistakes.
* similarly, the cloudflare build is failing, but I don't have access to see those logs to investigate why! Presumably the same issue?