### PR TITLE
Refactor scorecard chart styling to use CSS class

### DIFF
--- a/content/scorecard-state.njk
+++ b/content/scorecard-state.njk
@@ -31,8 +31,8 @@ permalink: /scorecard/us-state/{{ state.abbr | slug }}/
           <a href="/scorecard/observation-data/">observation data details</a>.
         </p>
       </div>
-      <div id="temperature-chart" style="max-width: 600px;"></div>
-      <div id="precipitation-chart" style="max-width: 600px;"></div>
+      <div id="temperature-chart" class="scorecard-chart"></div>
+      <div id="precipitation-chart" class="scorecard-chart"></div>
       <div id="station-list">
         <h2>Stations in {{ state.name }}</h2>
         <ul>

--- a/content/scorecard-station.njk
+++ b/content/scorecard-station.njk
@@ -97,8 +97,8 @@ permalink: /scorecard/station/{{ station.id }}/
       <label for="temp_90">90 days</label>
     </div>
   </div>
-  <div id="temperature_2m-obs" style="max-width: 600px;"></div>
-  <div id="temperature_2m-score" style="max-width: 600px;"></div>
+  <div id="temperature_2m-obs" class="scorecard-chart"></div>
+  <div id="temperature_2m-score" class="scorecard-chart"></div>
   <div class='responsive-flex'>
     <h2>Precipitation</h2>
     <div>
@@ -108,8 +108,8 @@ permalink: /scorecard/station/{{ station.id }}/
       <label for="precip_90">90 days</label>
     </div>
   </div>
-  <div id="precipitation_surface-obs" style="max-width: 600px;"></div>
-  <div id="precipitation_surface-score" style="max-width: 600px;"></div>
+  <div id="precipitation_surface-obs" class="scorecard-chart"></div>
+  <div id="precipitation_surface-score" class="scorecard-chart"></div>
 </div>
 <script src="https://d3js.org/d3.v7.min.js"></script>
 <script src="https://unpkg.com/topojson-client@3"></script>

--- a/content/scorecard.njk
+++ b/content/scorecard.njk
@@ -42,8 +42,8 @@ title: Scorecard
           <a href="/scorecard/observation-data/">observation data details</a>.
         </p>
       </div>
-      <div id="temperature-chart" style="max-width: 600px;"></div>
-      <div id="precipitation-chart" style="max-width: 600px;"></div>
+      <div id="temperature-chart" class="scorecard-chart"></div>
+      <div id="precipitation-chart" class="scorecard-chart"></div>
       <div id="station-list">
         {% for state, stations_in_state in scorecard.index.stations | sort(attribute="state_name") | groupby("state_name") %}
           <h3>

--- a/public/main.css
+++ b/public/main.css
@@ -402,6 +402,16 @@ article img {
   margin-top: 0.25rem;
 }
 
+.scorecard-chart {
+  max-width: 600px;
+}
+
+@media screen and (max-width: 768px) {
+  .scorecard-chart {
+    max-width: none;
+  }
+}
+
 .responsive-flex {
   display: flex;
   flex-wrap: wrap;


### PR DESCRIPTION
## Summary
Refactored inline styles for scorecard chart containers into a reusable CSS class to improve maintainability and enable responsive design.

## Key Changes
- Added `.scorecard-chart` CSS class in `public/main.css` with `max-width: 600px` and responsive behavior for screens ≤768px
- Replaced inline `style="max-width: 600px;"` attributes with `class="scorecard-chart"` across four template files:
  - `content/scorecard-station.njk` (2 chart divs)
  - `content/scorecard-state.njk` (2 chart divs)
  - `content/scorecard.njk` (2 chart divs)

## Implementation Details
- The new CSS class includes a media query that removes the max-width constraint on mobile devices (≤768px), allowing charts to be full-width on smaller screens
- This change centralizes styling logic and makes future adjustments to chart dimensions easier to maintain

https://claude.ai/code/session_01QgmZVRu9R1NnPVMznyxb9w