### PR TITLE
Add FSS (Fractions Skill Score) metric for precipitation forecasts

### DIFF
--- a/public/scorecard.js
+++ b/public/scorecard.js
@@ -26,12 +26,13 @@ const METRIC_CONFIG = {
   ETS:           { label: "ETS",            unitType: "unitless", refValue: 0 },
   FrequencyBias: { label: "Frequency Bias", unitType: "unitless", refValue: 1 },
   HSS:           { label: "HSS",            unitType: "unitless", refValue: 0 },
+  FSS:           { label: "FSS",            unitType: "unitless", refValue: 0 },
 };
 
 // Which metrics are available for each variable, and which is the default.
 export const VARIABLE_METRICS = {
   temperature_2m:       ["RMSE", "MAE", "Bias", "CRPS"],
-  precipitation_surface: ["MAE", "Bias", "CRPS", "ETS", "FrequencyBias", "HSS"],
+  precipitation_surface: ["MAE", "Bias", "CRPS", "ETS", "FrequencyBias", "HSS", "FSS"],
 };
 
 export const DEFAULT_METRIC = {


### PR DESCRIPTION
## Summary
This PR adds support for the FSS (Fractions Skill Score) metric to the scorecard, a spatial verification metric for precipitation forecasts that measures skill by comparing fractional coverage of precipitation events within neighborhoods rather than requiring exact grid-point matches.

## Key Changes
- **Documentation**: Added comprehensive FSS metric documentation in `scorecard-metrics.md` including:
  - Description of FSS as a spatial metric that gives credit for forecasts close in space
  - Explanation of the 0-1 scale and comparison to point-based metrics
  - Implementation details with Python code example
  - Note that FSS is applied to precipitation only
  
- **Configuration**: Updated `public/scorecard.js` to:
  - Add FSS to `METRIC_CONFIG` with unitless type and reference value of 0
  - Include FSS in the available metrics for `precipitation_surface` variable
  - Updated the deterministic metrics list in documentation to include FSS

## Implementation Details
- FSS uses the same 0.1 mm/h precipitation threshold as other categorical precipitation metrics (ETS, Frequency Bias, HSS)
- The metric compares observed and forecast fractions of precipitation events within a spatial neighborhood using uniform filtering
- FSS ranges from 0 to 1, where 1 indicates a perfect forecast and 0 indicates no skill
- Unlike point-based categorical metrics, FSS is more forgiving of small spatial displacement errors

https://claude.ai/code/session_016HWjbo95JEcis9Q9Mk6My4