### PR TITLE
Fix globe data URL to fetch from scorecard R2 bucket

### DIFF
--- a/public/globe.js
+++ b/public/globe.js
@@ -702,7 +702,7 @@
 
   // --- Load data and start ---
   // Try R2 first (production), fall back to local static file (dev)
-  var DATA_URL = "https://data.dynamical.org/site/globe-data.json";
+  var DATA_URL = "https://sa.dynamical.org/site/globe-data.json";
   fetch(DATA_URL)
     .then(function (res) {
       if (!res.ok) throw new Error(res.status);


### PR DESCRIPTION
The globe visualization was fetching globe-data.json from
data.dynamical.org which had stale data, causing missing wind on
production. Switch to sa.dynamical.org where the data is actively
generated. Also remove the stale local copy to avoid confusion.

https://claude.ai/code/session_01TXBXr354htYMfAfLBVhSQ5