### PR TITLE
Rename ECMWF AIFS deterministic to AIFS Single and update status

### DIFF
--- a/_data/catalog.js
+++ b/_data/catalog.js
@@ -904,7 +904,7 @@ ds["precipitation_surface"].sel(time="2026-01-01T00", latitude=40, longitude=-90
         </p>
       `,
     url: "https://data.dynamical.org/ecmwf/aifs-single/forecast/latest.zarr",
-    status: "coming soon",
+    status: "live",
     license: `
         <p>
         This data is based on data and products of the European Centre for
@@ -972,6 +972,12 @@ ds["temperature_2m"].sel(init_time="2025-01-01T00", latitude=0, longitude=0).max
         are each produced with slight perturbations of initial conditions 
         and of the models. Taken together, ensemble of 51 forecasts shows 
         the range of possible outcomes and the likelihood of their occurrence.
+        </p>
+
+        <h3>Model updates</h3>
+        <p>
+        IFS is updated regularly. Find details of recent and upcoming
+        <a href="https://confluence.ecmwf.int/display/FCST/Changes+to+the+forecasting+system">changes to the forecasting system</a> on the ECMWF website.
         </p>
 
         <h3>Storage</h3>

--- a/public/main.css
+++ b/public/main.css
@@ -196,8 +196,7 @@ table.data tr th.right {
 .catalog-table .catalog-model-cell {
   font-weight: 700;
   vertical-align: top;
-  word-break: break-word;
-  min-width: 20rem;
+  white-space: nowrap;
 }
 
 .catalog-glyph {


### PR DESCRIPTION
## Summary
This PR updates the ECMWF AIFS model naming convention from "deterministic" to "Single" throughout the catalog and related documentation, and marks the dataset as live.

## Key Changes
- **Model ID and naming**: Renamed `ecmwf-aifs-deterministic` to `ecmwf-aifs-single` with updated display names ("AIFS Single" instead of "AIFS deterministic")
- **Description updates**: Clarified the model description to state it "produces a single forecast trace" instead of referencing "deterministic 'single' (non-ensemble) configuration"
- **Data URLs**: Updated all references from `aifs-deterministic` to `aifs-single` in data URLs and GitHub notebook links
- **Status change**: Updated dataset status from "coming soon" to "live"
- **IFS documentation**: Added a new "Model updates" section to the IFS ensemble forecast dataset with a link to ECMWF's forecasting system changes
- **CSS refinement**: Changed catalog model cell styling from `word-break: break-word` with `min-width: 20rem` to `white-space: nowrap` for better table layout

## Implementation Details
- All references to the old naming convention have been systematically updated across model definitions, URLs, code examples, and documentation links
- The change maintains consistency across the catalog data structure and external resource references

https://claude.ai/code/session_01926EJnecFqCg5TWpLXtv7c