### PR TITLE
Add STAC catalog validation script and integrate into build

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,9 +4,10 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "build": "npx @11ty/eleventy",
+    "build": "npx @11ty/eleventy && npm run validate:stac",
     "start": "npx @11ty/eleventy --serve --port=8081",
-    "clean": "rm -r docs .cache"
+    "clean": "rm -r docs .cache",
+    "validate:stac": "bash scripts/validate-stac.sh"
   },
   "repository": {
     "type": "git",

--- a/scripts/validate-stac.sh
+++ b/scripts/validate-stac.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+STAC_DIR="$PROJECT_DIR/docs/stac"
+VALIDATOR_DIR="$PROJECT_DIR/.cache/gostac-validator"
+VALIDATOR_BIN="$VALIDATOR_DIR/stac-cli"
+VALIDATOR_REPO="https://github.com/StacLabs/gostac-validator.git"
+
+# Build the validator if not already present
+if [ ! -x "$VALIDATOR_BIN" ]; then
+  echo "Building gostac-validator..."
+  rm -rf "$VALIDATOR_DIR"
+  git clone --depth 1 "$VALIDATOR_REPO" "$VALIDATOR_DIR"
+  cd "$VALIDATOR_DIR"
+  go build -o stac-cli ./cmd/cli
+  cd "$PROJECT_DIR"
+  echo "gostac-validator built successfully."
+fi
+
+# Check that the STAC output directory exists
+if [ ! -d "$STAC_DIR" ]; then
+  echo "Error: STAC output directory not found at $STAC_DIR"
+  echo "Run 'npm run build' first to generate the STAC catalog."
+  exit 1
+fi
+
+# Find all STAC JSON files and validate them
+STAC_FILES=$(find "$STAC_DIR" -name '*.json' -type f)
+FILE_COUNT=$(echo "$STAC_FILES" | wc -l)
+echo "Validating $FILE_COUNT STAC file(s) in $STAC_DIR..."
+
+FAILED=0
+for file in $STAC_FILES; do
+  RELATIVE=$(echo "$file" | sed "s|$PROJECT_DIR/||")
+  OUTPUT=$("$VALIDATOR_BIN" "$file" 2>&1) || true
+
+  if echo "$OUTPUT" | grep -q '"valid": true'; then
+    echo "  ✓ $RELATIVE"
+  else
+    echo "  ✗ $RELATIVE"
+    echo "$OUTPUT" | sed 's/^/    /'
+    FAILED=$((FAILED + 1))
+  fi
+done
+
+echo ""
+if [ "$FAILED" -gt 0 ]; then
+  echo "STAC validation failed: $FAILED file(s) invalid."
+  exit 1
+else
+  echo "All $FILE_COUNT STAC file(s) are valid."
+fi


### PR DESCRIPTION
## Summary
This PR adds automated validation of STAC (SpatioTemporal Asset Catalog) JSON files to the build pipeline. A new bash script validates all generated STAC files using the gostac-validator tool, ensuring catalog integrity before deployment.

## Key Changes
- **New validation script** (`scripts/validate-stac.sh`):
  - Automatically builds gostac-validator from source if not already present
  - Discovers and validates all STAC JSON files in the `docs/stac` directory
  - Provides clear pass/fail output for each file with detailed error messages
  - Exits with failure status if any files are invalid
  
- **Updated build pipeline** (`package.json`):
  - Integrated STAC validation into the `build` script to run after Eleventy compilation
  - Added new `validate:stac` npm script for standalone validation runs
  - Ensures STAC catalogs are valid before the build completes

## Implementation Details
- The validator is cached in `.cache/gostac-validator` to avoid rebuilding on every run
- Uses shallow clone (`--depth 1`) for faster validator setup
- Provides user-friendly output with checkmarks (✓) for valid files and crosses (✗) for invalid ones
- Includes helpful error message if STAC output directory doesn't exist, guiding users to run build first
- Gracefully handles validator output parsing to detect validation results

https://claude.ai/code/session_01HqPu7U8YpWHFqhJJRAMUtq