### PR TITLE
wxopticon: stacked lead-group bars + on-track coloring

### DIFF
--- a/_data/wxopticon.js
+++ b/_data/wxopticon.js
@@ -16,12 +16,26 @@ module.exports = async function () {
     cadence_hours: p.cadence_hours,
     recent_init_count: Math.min(p.recent_inits.length, RECENT_INIT_COUNT),
     // Pass lead-group shape through so the build-time skeleton can allocate
-    // one sub-bar per group before hydration. Absent for pre-lead-groups
-    // summaries — wxopticon.js falls back to a single fill in that case.
-    lead_groups: (p.lead_group_stats ?? []).map((g) => ({
-      name: g.name,
-      leads_in_group: g.leads_in_group,
-    })),
+    // one sub-bar per group before hydration (and a sibling label column).
+    // Absent for pre-lead-groups summaries — wxopticon.js falls back to a
+    // single fill in that case.
+    lead_groups: (() => {
+      const groups = p.lead_group_stats ?? [];
+      if (groups.length === 0) return [];
+      const total = groups[groups.length - 1].leads_in_group;
+      let prev = 0;
+      return groups.map((g) => {
+        const slice = g.leads_in_group - prev;
+        const center_pct = total > 0 ? ((prev + slice / 2) / total) * 100 : 0;
+        prev = g.leads_in_group;
+        return {
+          name: g.name,
+          label: g.label,
+          leads_in_group: g.leads_in_group,
+          center_pct,
+        };
+      });
+    })(),
   }));
 
   return {

--- a/_data/wxopticon.js
+++ b/_data/wxopticon.js
@@ -15,6 +15,13 @@ module.exports = async function () {
     source: p.source,
     cadence_hours: p.cadence_hours,
     recent_init_count: Math.min(p.recent_inits.length, RECENT_INIT_COUNT),
+    // Pass lead-group shape through so the build-time skeleton can allocate
+    // one sub-bar per group before hydration. Absent for pre-lead-groups
+    // summaries — wxopticon.js falls back to a single fill in that case.
+    lead_groups: (p.lead_group_stats ?? []).map((g) => ({
+      name: g.name,
+      leads_in_group: g.leads_in_group,
+    })),
   }));
 
   return {

--- a/_data/wxopticon.js
+++ b/_data/wxopticon.js
@@ -3,6 +3,20 @@ const fetch = require("@11ty/eleventy-fetch");
 // Keep in sync with RECENT_INIT_COUNT in public/wxopticon.js
 const RECENT_INIT_COUNT = 10;
 
+const DISPLAY_NAMES = {
+  "noaa-gfs-aws": "NOAA GFS (AWS)",
+  "noaa-gfs-ftp": "NOAA GFS (NOMADS)",
+  "noaa-gefs-short-aws": "NOAA GEFS 16-day (AWS)",
+  "noaa-gefs-short-ftp": "NOAA GEFS 16-day (NOMADS)",
+  "noaa-gefs-long-aws": "NOAA GEFS 35-day (AWS)",
+  "noaa-gefs-long-ftp": "NOAA GEFS 35-day (NOMADS)",
+  "noaa-hrrr-aws": "NOAA HRRR 48h (AWS)",
+  "noaa-hrrr-ftp": "NOAA HRRR 48h (NOMADS)",
+  "ecmwf-aifs-aws": "ECMWF AIFS Single (AWS)",
+  "ecmwf-ifs-ens-long-aws": "ECMWF IFS ENS 15-day (AWS)",
+  "ecmwf-ifs-ens-short-aws": "ECMWF IFS ENS 6-day (AWS)",
+};
+
 module.exports = async function () {
   const summary = await fetch(
     "https://assets.dynamical.org/wxopticon/summary.json",
@@ -11,9 +25,10 @@ module.exports = async function () {
 
   const products = summary.products.map((p) => ({
     id: p.id,
-    label: p.label,
+    label: DISPLAY_NAMES[p.id] ?? p.id,
     source: p.source,
     cadence_hours: p.cadence_hours,
+    init_hours: [...new Set(p.recent_inits.map((i) => i.init_time.slice(11, 13)))].sort(),
     recent_init_count: Math.min(p.recent_inits.length, RECENT_INIT_COUNT),
     // Pass lead-group shape through so the build-time skeleton can allocate
     // one sub-bar per group before hydration (and a sibling label column).

--- a/_data/wxopticon.js
+++ b/_data/wxopticon.js
@@ -25,7 +25,7 @@ module.exports = async function () {
 
   const products = summary.products.map((p) => ({
     id: p.id,
-    label: DISPLAY_NAMES[p.id] ?? p.id,
+    label: DISPLAY_NAMES[p.id] ?? p.label ?? p.id,
     source: p.source,
     cadence_hours: p.cadence_hours,
     init_hours: [...new Set(p.recent_inits.map((i) => i.init_time.slice(11, 13)))].sort(),

--- a/_includes/base.njk
+++ b/_includes/base.njk
@@ -18,13 +18,16 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
     <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;700&display=swap" rel="stylesheet"/>
     <link href="/prism-atom-dark.css" rel="stylesheet"/>
+    <link rel="icon" href="/assets/favicon.svg" type="image/svg+xml"/>
+    <link rel="alternate icon" href="/favicon.ico"/>
+    <link rel="apple-touch-icon" href="/apple-touch-icon.png"/>
     <link rel="alternate" href="/feed/feed.xml" type="application/atom+xml" title="{{ metadata.title }}"/>
     <link rel="alternate" href="/feed/feed.json" type="application/json" title="{{ metadata.title }}"/>
   </head>
   <body>
     <nav aria-label="Primary">
       <ul>
-        <li><a href="/">dynamical.org</a></li>
+        <li><a href="/" class="nav-lockup"><picture><source srcset="/assets/lockup-white.svg" media="(prefers-color-scheme: dark)"><img src="/assets/lockup.svg" alt="dynamical.org" height="32"></picture></a></li>
         <li><a href="/catalog">catalog</a></li>
         <li><a href="/about">about</a></li>
         <li><a href="/updates">updates</a></li>

--- a/content/wxopticon.njk
+++ b/content/wxopticon.njk
@@ -79,16 +79,12 @@ permalink: /status/
           <strong data-slot="eta-init">—</strong>
           <span data-slot="eta-state" hidden></span>
           <span data-slot="eta-line" hidden></span>
-          <div data-slot="eta-details-wrap" hidden style="margin-top:0.8rem;">
-            <button type="button" data-slot="eta-details-btn" class="eta-details-btn">more details</button>
-            <div data-slot="eta-details" class="eta-details" hidden></div>
-          </div>
         </div>
-        {#
-        <div>---</div>
-        <div data-slot="latency">p50 -h -m<br>p95 -h -m<br>p99 -h -m</div>
-        #}
+        <div style="margin-top:0.8rem;">
+          <button type="button" data-slot="row-details-btn" class="eta-details-btn" hidden>more details</button>
+        </div>
       </div>
+      <div class="status-row-details" data-slot="row-details" hidden></div>
     </section>
     {% endfor %}
 

--- a/content/wxopticon.njk
+++ b/content/wxopticon.njk
@@ -52,7 +52,8 @@ permalink: /status/
         <strong>{{ product.label }}</strong>
         <div style="font-size:1.2rem;">
           <div>{{ product.source }}</div>
-          <div>{{ product.cadence_hours }}h cadence</div>
+          <div>{{ product.cadence_hours }}h init cadence</div>
+          <div>{{ product.init_hours | join('/') }}z</div>
         </div>
       </div>
       <div class="status-row-body">

--- a/content/wxopticon.njk
+++ b/content/wxopticon.njk
@@ -78,8 +78,11 @@ permalink: /status/
         <div class="status-eta" data-slot="eta">
           <strong data-slot="eta-init">—</strong>
           <span data-slot="eta-state" hidden></span>
-          <span data-slot="eta-time" hidden></span>
-          <span data-slot="eta-duration" hidden></span>
+          <span data-slot="eta-line" hidden></span>
+          <div data-slot="eta-details-wrap" hidden style="margin-top:0.8rem;">
+            <button type="button" data-slot="eta-details-btn" class="eta-details-btn">more details</button>
+            <div data-slot="eta-details" class="eta-details" hidden></div>
+          </div>
         </div>
         {#
         <div>---</div>

--- a/content/wxopticon.njk
+++ b/content/wxopticon.njk
@@ -82,10 +82,10 @@ permalink: /status/
           <span data-slot="eta-line" hidden></span>
         </div>
         <div style="margin-top:0.8rem;">
-          <button type="button" data-slot="row-details-btn" class="eta-details-btn" hidden>more details</button>
+          <button type="button" data-slot="row-details-btn" class="eta-details-btn" aria-expanded="false" aria-controls="row-details-{{ product.id }}" hidden>more details</button>
         </div>
       </div>
-      <div class="status-row-details" data-slot="row-details" hidden></div>
+      <div id="row-details-{{ product.id }}" class="status-row-details" data-slot="row-details" hidden></div>
     </section>
     {% endfor %}
 

--- a/content/wxopticon.njk
+++ b/content/wxopticon.njk
@@ -55,13 +55,24 @@ permalink: /status/
           <div>{{ product.cadence_hours }}h cadence</div>
         </div>
       </div>
-      <div class="status-grid" data-slot="grid">
-        {% for _ in range(0, product.recent_init_count) %}
-        <div class="status-bar" data-skeleton>
-          <div class="status-bar-track"></div>
-          <div class="status-bar-label"></div>
+      <div class="status-row-body">
+        {% if product.lead_groups.length %}
+        <div class="status-group-labels" aria-hidden="true">
+          {# Skip the bottom-most group (always the f000 "0h" start signal) —
+             its band is a sliver and the label collides with the track border. #}
+          {% for g in product.lead_groups %}{% if not loop.first %}
+          <span style="bottom: {{ g.center_pct }}%">{{ g.label }}</span>
+          {% endif %}{% endfor %}
         </div>
-        {% endfor %}
+        {% endif %}
+        <div class="status-grid" data-slot="grid">
+          {% for _ in range(0, product.recent_init_count) %}
+          <div class="status-bar" data-skeleton>
+            <div class="status-bar-track"></div>
+            <div class="status-bar-label"></div>
+          </div>
+          {% endfor %}
+        </div>
       </div>
       <div class="status-stats">
         <div class="status-eta" data-slot="eta">

--- a/plans/63_wxopticon_lead_groups.md
+++ b/plans/63_wxopticon_lead_groups.md
@@ -1,0 +1,51 @@
+# wxopticon: stacked lead-group bars + on-track coloring
+
+Frontend counterpart to [wxopticon PR #9](https://github.com/dynamical-org/wxopticon/pull/9)
+(Phase 2 of the backend plan in that repo at `plans/9_lead_groups.md`).
+
+## Motivation
+
+The backend now emits per-lead-group latency stats and per-init lead-group
+completion. This PR teaches `/status/` to draw each init bar as a vertical
+stack of group segments, so you can see which part of the run is dragging
+(e.g. short range landed, long range still processing) instead of one
+monolithic fill.
+
+While a run is processing, the fill color is now driven by `init.on_track`:
+green if every group is still within its historical envelope, amber (the
+existing "in progress" shade) when at least one group has blown past p99.
+
+## Success criteria
+
+- [ ] `_data/wxopticon.js` passes through `lead_groups: [{name,
+      leads_in_group}]` per product so the build-time skeleton can allocate
+      sub-bar nodes before hydration.
+- [ ] `renderBar` renders one `.status-bar-fill-group` per `init.lead_groups`
+      entry, stacked bottom-up with slice height = share of total leads and
+      inner fill = share of leads found in that slice.
+- [ ] `.status-bar` carries `data-on-track="true"|"false"` only when the
+      init is `in_progress`. CSS picks green vs amber off this attribute.
+- [ ] Tooltip keeps the existing run summary and appends per-group status
+      lines.
+- [ ] Bars without `init.lead_groups` (old snapshots, or during the window
+      where prod summary.json hasn't been regenerated yet) still render
+      identically to today's single-fill bar.
+- [ ] Existing `on_time` / `late` / `failed` / `unobserved` visuals are
+      unchanged.
+- [ ] Playwright screenshot confirms both live and scrub modes render with
+      the new stacked visual.
+
+## Implementation notes
+
+- Backend values are cumulative: group `i` covers leads 0..max_lead[i], so
+  the slice for group `i` is diffed from `i-1`.
+- Slice height (% of track): `(leads_expected[i] - leads_expected[i-1]) / total_leads`
+- Slice fill fraction: `(leads_available[i] - leads_available[i-1]) / (leads_expected[i] - leads_expected[i-1])`
+- First group is the undiffed case (use `completion_pct` directly).
+- Segment carries a status class (`g-on_time`, `g-in_progress`, …). For the
+  in-progress group color we gate on `.status-bar[data-on-track="true"]` so
+  on-track runs go green without needing a second class per segment.
+
+## Log
+
+### 2026-04-15 — plan created

--- a/public/main.css
+++ b/public/main.css
@@ -975,7 +975,7 @@ article img {
 
 .details-table th,
 .details-table td {
-  padding: 0.2rem 1.2rem 0.2rem 0;
+  padding: 0.3rem 1.2rem 0.3rem 0;
   white-space: nowrap;
   text-align: left;
 }
@@ -983,6 +983,7 @@ article img {
 .details-table th {
   color: var(--muted-text);
   font-weight: normal;
+  padding-bottom: 0.6rem;
 }
 
 .details-table td:first-child {
@@ -990,12 +991,12 @@ article img {
 }
 
 .details-table .details-overall td {
-  border-bottom: 1px solid var(--border-muted-color);
-  padding-bottom: 0.4rem;
+  border-bottom: 1px dotted var(--border-muted-color);
+  padding-bottom: 0.8rem;
 }
 
 .details-table .details-overall + tr td {
-  padding-top: 0.4rem;
+  padding-top: 0.8rem;
 }
 
 

--- a/public/main.css
+++ b/public/main.css
@@ -436,6 +436,12 @@ nav ul li:first-child {
   margin-right: auto;
 }
 
+.nav-lockup img {
+  display: block;
+  height: 24px;
+  width: auto;
+}
+
 footer {
   max-width: 78rem;
   margin: 6rem auto 2rem;
@@ -956,32 +962,46 @@ article img {
   text-decoration: underline;
 }
 
-.eta-details table {
-  margin-top: 0.6rem;
-  font-size: 1.1rem;
+.status-row-details {
+  grid-column: 1 / -1;
+  padding: 1rem 0 0.4rem;
+}
+
+.details-table {
+  font-size: 1.2rem;
   border-collapse: collapse;
-  width: 100%;
 }
 
-.eta-details td {
-  padding: 0.2rem 0;
+.details-table th,
+.details-table td {
+  padding: 0.2rem 1.2rem 0.2rem 0;
   white-space: nowrap;
+  text-align: left;
 }
 
-.eta-details td:first-child {
-  padding-right: 0.8rem;
+.details-table th {
+  color: var(--muted-text);
+  font-weight: normal;
+}
+
+.details-table td:first-child {
   color: var(--text-color);
 }
 
-.eta-details td:nth-child(2) {
-  padding-right: 0.8rem;
+.details-table .details-overall td {
+  border-bottom: 1px solid var(--border-muted-color);
+  padding-bottom: 0.4rem;
 }
 
-.eta-details .eta-g-on_time { color: var(--status-on-time); }
-.eta-details .eta-g-in_progress { color: var(--status-in-progress); }
-.eta-details .eta-g-not_started { color: var(--muted-text); }
-.eta-details .eta-g-late { color: var(--status-late); }
-.eta-details .eta-g-failed { color: var(--status-failed); }
+.details-table .details-overall + tr td {
+  padding-top: 0.4rem;
+}
+
+.eta-g-on_time { color: var(--status-on-time); }
+.eta-g-in_progress { color: var(--status-in-progress); }
+.eta-g-not_started { color: var(--muted-text); }
+.eta-g-late { color: var(--status-late); }
+.eta-g-failed { color: var(--status-failed); }
 
 .status-footer {
   margin-top: 2rem;

--- a/public/main.css
+++ b/public/main.css
@@ -792,6 +792,10 @@ article img {
   height: var(--band-height, 0%);
 }
 
+.status-bar-fill-group + .status-bar-fill-group {
+  border-top: 1px solid var(--text-color);
+}
+
 .status-bar-fill-inner {
   position: absolute;
   left: 0;

--- a/public/main.css
+++ b/public/main.css
@@ -43,6 +43,11 @@
   --status-failed-fg: #ffffff;
   --status-unobserved: #a8a8ad;
   --status-track-bg: #e9e9ee;
+
+  /* Green pulse for "processing but still inside historical envelope".
+     Same hue as on_time — the pulse (animation) is what distinguishes
+     an in-flight run from a completed one. */
+  --status-on-track: var(--status-on-time);
 }
 
 @media (prefers-color-scheme: dark) {
@@ -745,6 +750,33 @@ article img {
   transition: height 0.3s ease;
 }
 
+/* Stacked lead-group segments (when summary.json carries lead_groups).
+   Each band is positioned absolutely within the track — --band-bottom
+   is the cumulative share of leads below this band, --band-height is
+   this group's share. --fill is the share of that band that's arrived.
+   The inner div is what carries the status-keyed background color so
+   the band outline (hairline separator) stays visible even at 0% fill. */
+.status-bar-fill-group {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: var(--band-bottom, 0%);
+  height: var(--band-height, 0%);
+}
+
+.status-bar-fill-group.has-separator {
+  border-top: 1px solid var(--text-color);
+}
+
+.status-bar-fill-inner {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: var(--fill, 0%);
+  transition: height 0.3s ease;
+}
+
 .status-bar[data-skeleton] {
   animation: status-skeleton-pulse 1.6s ease-in-out infinite;
 }
@@ -761,7 +793,9 @@ article img {
   }
 }
 
-/* Status fills — solid color per status. */
+/* Status fills — solid color per status. Single-fill rules apply to
+   pre-lead-groups snapshots (graceful fallback). Stacked rules below
+   key off each segment's own g-{status} class. */
 
 .status-bar[data-status="on_time"] .status-bar-fill {
   background-color: var(--status-on-time);
@@ -788,6 +822,39 @@ article img {
   height: 100%;
 }
 
+/* Stacked group segments: color comes from each segment's g-{status}. */
+.status-bar-fill-group.g-on_time .status-bar-fill-inner {
+  background-color: var(--status-on-time);
+}
+
+.status-bar-fill-group.g-in_progress .status-bar-fill-inner {
+  background-color: var(--status-in-progress);
+  animation: status-bar-pulse 1.8s ease-in-out infinite;
+  /* Keep a sliver visible at 0% fill so the pulsing target is always
+     discoverable — same rationale as the single-fill in_progress rule. */
+  min-height: 3px;
+}
+
+/* On-track runs: swap the in-progress amber for the on-track green, but
+   keep pulsing so you can still tell at-a-glance this group is live. */
+.status-bar[data-on-track="true"] .status-bar-fill-group.g-in_progress .status-bar-fill-inner {
+  background-color: var(--status-on-track);
+}
+
+.status-bar-fill-group.g-late .status-bar-fill-inner {
+  background-color: var(--status-late);
+}
+
+.status-bar-fill-group.g-failed .status-bar-fill-inner {
+  background-color: var(--status-failed);
+  height: 100%;
+}
+
+.status-bar-fill-group.g-not_started .status-bar-fill-inner,
+.status-bar-fill-group.g-unobserved .status-bar-fill-inner {
+  display: none;
+}
+
 /* Unobserved = monitoring-coverage gap, not a publication failure.
    Empty bar with a dotted outline reads as "no information" without
    implying something broke. */
@@ -796,7 +863,8 @@ article img {
   border-color: var(--status-unobserved);
 }
 
-.status-bar[data-status="unobserved"] .status-bar-fill {
+.status-bar[data-status="unobserved"] .status-bar-fill,
+.status-bar[data-status="unobserved"] .status-bar-fill-group {
   display: none;
 }
 
@@ -806,7 +874,8 @@ article img {
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .status-bar[data-status="in_progress"] .status-bar-fill {
+  .status-bar[data-status="in_progress"] .status-bar-fill,
+  .status-bar-fill-group.g-in_progress .status-bar-fill-inner {
     animation: none;
   }
 }

--- a/public/main.css
+++ b/public/main.css
@@ -718,11 +718,39 @@ article img {
   border-top: none;
 }
 
+.status-row-body {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.6rem;
+  min-width: 0;
+}
+
+/* Left-aligned y-axis column: one label per lead group, centered on its
+   band. Height matches .status-bar-track so percentages line up. */
+.status-group-labels {
+  position: relative;
+  flex-shrink: 0;
+  width: 2.6rem;
+  height: 11rem;
+  font-size: 1rem;
+  color: var(--muted-text);
+  line-height: 1;
+}
+
+.status-group-labels span {
+  position: absolute;
+  right: 0;
+  transform: translateY(50%);
+  white-space: nowrap;
+}
+
 .status-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(0, 1fr));
   gap: 0.6rem;
   min-height: 10rem;
+  flex: 1;
+  min-width: 0;
 }
 
 .status-bar {

--- a/public/main.css
+++ b/public/main.css
@@ -970,6 +970,7 @@ article img {
 .details-table {
   font-size: 1.2rem;
   border-collapse: collapse;
+  width: 100%;
 }
 
 .details-table th,

--- a/public/main.css
+++ b/public/main.css
@@ -938,6 +938,51 @@ article img {
   white-space: nowrap;
 }
 
+.status-eta [data-on-track="true"] {
+  color: var(--status-on-time);
+}
+
+.status-eta [data-on-track="false"] {
+  color: var(--status-in-progress);
+}
+
+.eta-details-btn {
+  background: none;
+  border: none;
+  padding: 0;
+  font: inherit;
+  color: var(--link-color);
+  cursor: pointer;
+  text-decoration: underline;
+}
+
+.eta-details table {
+  margin-top: 0.6rem;
+  font-size: 1.1rem;
+  border-collapse: collapse;
+  width: 100%;
+}
+
+.eta-details td {
+  padding: 0.2rem 0;
+  white-space: nowrap;
+}
+
+.eta-details td:first-child {
+  padding-right: 0.8rem;
+  color: var(--text-color);
+}
+
+.eta-details td:nth-child(2) {
+  padding-right: 0.8rem;
+}
+
+.eta-details .eta-g-on_time { color: var(--status-on-time); }
+.eta-details .eta-g-in_progress { color: var(--status-in-progress); }
+.eta-details .eta-g-not_started { color: var(--muted-text); }
+.eta-details .eta-g-late { color: var(--status-late); }
+.eta-details .eta-g-failed { color: var(--status-failed); }
+
 .status-footer {
   margin-top: 2rem;
   padding-top: 1rem;

--- a/public/main.css
+++ b/public/main.css
@@ -1017,8 +1017,9 @@ article img {
   position: absolute;
   top: 2px;
   height: 10px;
-  background: var(--muted-text);
-  opacity: 0.2;
+  min-width: 2px;
+  background: var(--text-color);
+  opacity: 0.25;
 }
 
 .boxplot-marker {

--- a/public/main.css
+++ b/public/main.css
@@ -832,10 +832,6 @@ article img {
 .status-bar[data-status="in_progress"] .status-bar-fill {
   background-color: var(--status-in-progress);
   animation: status-bar-pulse 1.8s ease-in-out infinite;
-  /* At 0% completion the fill height is 0 and the bar is invisible;
-     hold a minimum sliver so the pulsing amber is always visible once
-     a run starts. */
-  min-height: 3px;
 }
 
 .status-bar[data-status="late"] .status-bar-fill {
@@ -858,9 +854,6 @@ article img {
 .status-bar-fill-group.g-in_progress .status-bar-fill-inner {
   background-color: var(--status-in-progress);
   animation: status-bar-pulse 1.8s ease-in-out infinite;
-  /* Keep a sliver visible at 0% fill so the pulsing target is always
-     discoverable — same rationale as the single-fill in_progress rule. */
-  min-height: 3px;
 }
 
 /* On-track runs: swap the in-progress amber for the on-track green, but
@@ -876,6 +869,13 @@ article img {
 .status-bar-fill-group.g-failed .status-bar-fill-inner {
   background-color: var(--status-failed);
   height: 100%;
+}
+
+/* Not-started = leads in this group haven't arrived yet during an
+   in-progress run. Dotted border echoes the unobserved track treatment
+   so it reads as "expected but not yet seen". */
+.status-bar-fill-group.g-not_started {
+  border: 1px dotted var(--status-unobserved);
 }
 
 .status-bar-fill-group.g-not_started .status-bar-fill-inner,

--- a/public/main.css
+++ b/public/main.css
@@ -26,14 +26,14 @@
   --muted-text-2: #999999;
   --shadow-color: rgba(0, 0, 0, 0.15);
 
-  --pill-available-bg: #78fa64;
+  --pill-available-bg: #5bc54a;
   --pill-available-fg: #081a08;
   --pill-muted-bg: #f0f0f0;
   --pill-muted-fg: #111111;
   --pill-muted-border: #d0d0d0;
 
   /* wxopticon arrival-status colors (light) */
-  --status-on-time: #78fa64;
+  --status-on-time: #5bc54a;
   --status-on-time-fg: #081a08;
   --status-in-progress: #f4b942;
   --status-in-progress-fg: #1a1204;
@@ -44,9 +44,6 @@
   --status-unobserved: #a8a8ad;
   --status-track-bg: #e9e9ee;
 
-  /* Green pulse for "processing but still inside historical envelope".
-     Same hue as on_time — the pulse (animation) is what distinguishes
-     an in-flight run from a completed one. */
   --status-on-track: var(--status-on-time);
 }
 
@@ -219,6 +216,16 @@ table.data th {
 table.data tr td.right,
 table.data tr th.right {
   text-align: right;
+}
+
+table.data.small {
+  font-size: 1.2rem;
+}
+
+table.data.small td,
+table.data.small th {
+  padding: 4px 12px;
+  white-space: nowrap;
 }
 
 /* Catalog grouped table */
@@ -737,7 +744,7 @@ article img {
   position: relative;
   flex-shrink: 0;
   width: 2.6rem;
-  height: 11rem;
+  height: 13rem;
   font-size: 1rem;
   color: var(--muted-text);
   line-height: 1;
@@ -770,7 +777,7 @@ article img {
 .status-bar-track {
   position: relative;
   width: 100%;
-  height: 11rem;
+  height: 13rem;
   border: 1px solid var(--text-color);
   overflow: hidden;
 }
@@ -781,7 +788,6 @@ article img {
   right: 0;
   bottom: 0;
   height: var(--fill, 0%);
-  transition: height 0.3s ease;
 }
 
 /* Stacked lead-group segments (when summary.json carries lead_groups).
@@ -808,7 +814,6 @@ article img {
   right: 0;
   bottom: 0;
   height: var(--fill, 0%);
-  transition: height 0.3s ease;
 }
 
 .status-bar[data-skeleton] {
@@ -837,7 +842,6 @@ article img {
 
 .status-bar[data-status="in_progress"] .status-bar-fill {
   background-color: var(--status-in-progress);
-  animation: status-bar-pulse 1.8s ease-in-out infinite;
 }
 
 .status-bar[data-status="late"] .status-bar-fill {
@@ -859,11 +863,8 @@ article img {
 
 .status-bar-fill-group.g-in_progress .status-bar-fill-inner {
   background-color: var(--status-in-progress);
-  animation: status-bar-pulse 1.8s ease-in-out infinite;
 }
 
-/* On-track runs: swap the in-progress amber for the on-track green, but
-   keep pulsing so you can still tell at-a-glance this group is live. */
 .status-bar[data-on-track="true"] .status-bar-fill-group.g-in_progress .status-bar-fill-inner {
   background-color: var(--status-on-track);
 }
@@ -900,18 +901,6 @@ article img {
 .status-bar[data-status="unobserved"] .status-bar-fill,
 .status-bar[data-status="unobserved"] .status-bar-fill-group {
   display: none;
-}
-
-@keyframes status-bar-pulse {
-  0%, 100% { opacity: 0.7; }
-  50%      { opacity: 1; }
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .status-bar[data-status="in_progress"] .status-bar-fill,
-  .status-bar-fill-group.g-in_progress .status-bar-fill-inner {
-    animation: none;
-  }
 }
 
 .status-bar-label {
@@ -967,41 +956,14 @@ article img {
   padding: 1rem 0 0.4rem;
 }
 
-.details-table {
-  font-size: 1.2rem;
-  border-collapse: collapse;
-  width: 100%;
+.status-row-details table.data {
+  margin-left: auto;
+  margin-right: auto;
 }
-
-.details-table th,
-.details-table td {
-  padding: 0.3rem 1.2rem 0.3rem 0;
-  white-space: nowrap;
-  text-align: left;
-}
-
-.details-table th {
-  color: var(--muted-text);
-  font-weight: normal;
-  padding-bottom: 0.6rem;
-}
-
-.details-table td:first-child {
-  color: var(--text-color);
-}
-
-.details-table .details-overall td {
-  border-bottom: 1px dotted var(--border-muted-color);
-  padding-bottom: 0.8rem;
-}
-
-.details-table .details-overall + tr td {
-  padding-top: 0.8rem;
-}
-
 
 .eta-g-on_time { color: var(--status-on-time); }
-.eta-g-in_progress { color: var(--status-in-progress); }
+.eta-g-in_progress { color: var(--muted-text); }
+.eta-g-delayed { color: var(--status-late); }
 .eta-g-not_started { color: var(--muted-text); }
 .eta-g-late { color: var(--status-late); }
 .eta-g-failed { color: var(--status-failed); }

--- a/public/main.css
+++ b/public/main.css
@@ -792,10 +792,6 @@ article img {
   height: var(--band-height, 0%);
 }
 
-.status-bar-fill-group.has-separator {
-  border-top: 1px solid var(--text-color);
-}
-
 .status-bar-fill-inner {
   position: absolute;
   left: 0;

--- a/public/main.css
+++ b/public/main.css
@@ -428,7 +428,6 @@ nav {
 nav ul {
   display: flex;
   flex-wrap: wrap;
-  align-items: baseline;
   gap: 0.25rem 1.25rem;
   padding-inline-start: 0;
   margin: 0;

--- a/public/main.css
+++ b/public/main.css
@@ -997,46 +997,6 @@ article img {
   padding-top: 0.4rem;
 }
 
-/* Inline horizontal box plot: 100px wide, shows p50/p95/p99 distribution
-   with a triangle marker at the actual or expected value. */
-.boxplot {
-  position: relative;
-  width: 100px;
-  height: 14px;
-}
-
-.boxplot-whisker {
-  position: absolute;
-  top: 50%;
-  left: 0;
-  height: 1px;
-  background: var(--muted-text);
-}
-
-.boxplot-box {
-  position: absolute;
-  top: 2px;
-  height: 10px;
-  min-width: 2px;
-  background: var(--text-color);
-  opacity: 0.25;
-}
-
-.boxplot-marker {
-  position: absolute;
-  top: 0;
-  width: 0;
-  height: 0;
-  border-left: 4px solid transparent;
-  border-right: 4px solid transparent;
-  border-top: 6px solid currentColor;
-  transform: translateX(-4px);
-}
-
-.bpm-on-time  { color: var(--status-on-time); }
-.bpm-late     { color: var(--status-late); }
-.bpm-in-progress { color: var(--status-in-progress); }
-.bpm-muted    { color: var(--muted-text); }
 
 .eta-g-on_time { color: var(--status-on-time); }
 .eta-g-in_progress { color: var(--status-in-progress); }

--- a/public/main.css
+++ b/public/main.css
@@ -997,6 +997,46 @@ article img {
   padding-top: 0.4rem;
 }
 
+/* Inline horizontal box plot: 100px wide, shows p50/p95/p99 distribution
+   with a triangle marker at the actual or expected value. */
+.boxplot {
+  position: relative;
+  width: 100px;
+  height: 14px;
+}
+
+.boxplot-whisker {
+  position: absolute;
+  top: 50%;
+  left: 0;
+  height: 1px;
+  background: var(--muted-text);
+}
+
+.boxplot-box {
+  position: absolute;
+  top: 2px;
+  height: 10px;
+  background: var(--muted-text);
+  opacity: 0.2;
+}
+
+.boxplot-marker {
+  position: absolute;
+  top: 0;
+  width: 0;
+  height: 0;
+  border-left: 4px solid transparent;
+  border-right: 4px solid transparent;
+  border-top: 6px solid currentColor;
+  transform: translateX(-4px);
+}
+
+.bpm-on-time  { color: var(--status-on-time); }
+.bpm-late     { color: var(--status-late); }
+.bpm-in-progress { color: var(--status-in-progress); }
+.bpm-muted    { color: var(--muted-text); }
+
 .eta-g-on_time { color: var(--status-on-time); }
 .eta-g-in_progress { color: var(--status-in-progress); }
 .eta-g-not_started { color: var(--muted-text); }

--- a/public/main.css
+++ b/public/main.css
@@ -792,7 +792,7 @@ article img {
   height: var(--band-height, 0%);
 }
 
-.status-bar-fill-group + .status-bar-fill-group {
+.status-bar-fill-group + .status-bar-fill-group:not(:last-child) {
   border-top: 1px solid var(--text-color);
 }
 

--- a/public/wxopticon.js
+++ b/public/wxopticon.js
@@ -453,11 +453,9 @@
     const initMs = inProgress ? new Date(inProgress.init_time).getTime() : 0;
     const hasLive = !!(groups?.length);
 
-    // Scale: zoom x-axis to [first_group.p50 .. overall_p99] so the
-    // interesting spread between groups fills the plot width instead
-    // of being compressed into the far right.
-    const scaleMin = stats[0]?.p50_s ?? 0;
-    const scaleMax = ls?.p99_s ?? 0;
+    // Each row's box plot is scaled to its own [p50, p99] range so the
+    // p50–p95 box fills most of the width. Cross-group time comparison
+    // comes from the ETA column; the plot shows distribution shape.
 
     // Header
     const headCols = [el("th"), el("th", null, "status"), el("th", null, "ETA"), el("th")];
@@ -478,7 +476,7 @@
       el("td", null, "overall"),
       el("td", { class: `eta-g-${overallStatus}` }, hasLive ? statusLabel(overallStatus) : "—"),
       overallEtaCell,
-      el("td", null, [renderBoxplot(ls?.p50_s, ls?.p95_s, ls?.p99_s, overallMarker, markerClassForStatus(overallStatus), scaleMin, scaleMax)]),
+      el("td", null, [renderBoxplot(ls?.p50_s, ls?.p95_s, ls?.p99_s, overallMarker, markerClassForStatus(overallStatus), ls?.p50_s ?? 0, ls?.p99_s ?? 0)]),
     ]);
 
     // Per-group rows
@@ -519,7 +517,7 @@
         el("td", null, s.label),
         el("td", { class: g ? `eta-g-${gStatus}` : "" }, g ? statusLabel(gStatus) : "—"),
         etaCell,
-        el("td", null, [renderBoxplot(s.p50_s, s.p95_s, s.p99_s, marker, mClass, scaleMin, scaleMax)]),
+        el("td", null, [renderBoxplot(s.p50_s, s.p95_s, s.p99_s, marker, mClass, s.p50_s ?? 0, s.p99_s ?? 0)]),
       ]);
     });
 

--- a/public/wxopticon.js
+++ b/public/wxopticon.js
@@ -387,8 +387,11 @@
           : "";
         stateSlot.textContent = `processing${onTrack}`;
         stateSlot.removeAttribute("data-init-start");
-        if (inProgress) stateSlot.setAttribute("data-on-track", String(inProgress.on_track));
-        else stateSlot.removeAttribute("data-on-track");
+        if (inProgress && typeof inProgress.on_track === "boolean") {
+          stateSlot.setAttribute("data-on-track", String(inProgress.on_track));
+        } else {
+          stateSlot.removeAttribute("data-on-track");
+        }
       } else {
         stateSlot.textContent = "init in —";
         stateSlot.setAttribute("data-init-start", target.initTime);
@@ -402,6 +405,13 @@
     // "more details" is always available when the product has lead_group_stats.
     const groupStats = product.lead_group_stats;
     if (groupStats?.length) {
+      if (detailsBtn.hidden) {
+        // Transitioning from disabled → enabled (e.g. scrubbing from a pre-lead-groups
+        // snapshot); reset the reveal to its default closed state.
+        detailsBtn.textContent = "more details";
+        detailsBtn.setAttribute("aria-expanded", "false");
+        detailsSlot.hidden = true;
+      }
       detailsBtn.hidden = false;
       buildRowDetails(detailsSlot, product);
     } else {
@@ -518,8 +528,12 @@
 
   // Pure render: paint products + generated_at from a fully-loaded summary.
   // Banners, ribbon, and the countdown ticker are owned by the outer shell
-  // and differ between live and scrub modes.
-  function renderSnapshot(summary) {
+  // and differ between live and scrub modes. nowMs is set first so builders
+  // that read lastCountdownNow (e.g. buildRowDetails for the delayed/pending
+  // threshold) see the snapshot's reference clock rather than the previous
+  // one.
+  function renderSnapshot(summary, nowMs) {
+    lastCountdownNow = nowMs;
     generatedAtSlot.replaceChildren(timeNode(summary.generated_at));
     for (const product of summary.products) {
       hydrateRow(product);
@@ -528,8 +542,9 @@
 
   function applyLive() {
     updateBanners(latest);
-    renderSnapshot(latest);
-    updateCountdowns(Date.now());
+    const nowMs = Date.now();
+    renderSnapshot(latest, nowMs);
+    updateCountdowns(nowMs);
   }
 
   function showLoadError(error) {
@@ -681,8 +696,9 @@
       if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
       const json = await resp.json();
       if (seq !== scrubSeq || mode !== "scrub") return;
-      renderSnapshot(json);
-      updateCountdowns(new Date(json.generated_at).getTime());
+      const snapMs = new Date(json.generated_at).getTime();
+      renderSnapshot(json, snapMs);
+      updateCountdowns(snapMs);
       clearScrubError();
     } catch (e) {
       if (seq !== scrubSeq || mode !== "scrub") return;
@@ -838,6 +854,7 @@
     const show = details.hidden;
     details.hidden = !show;
     btn.textContent = show ? "less" : "more details";
+    btn.setAttribute("aria-expanded", String(show));
     // Kick a countdown update so ETA cells in the table are filled immediately.
     if (show) updateCountdowns(lastCountdownNow);
   });

--- a/public/wxopticon.js
+++ b/public/wxopticon.js
@@ -361,36 +361,92 @@
     // }
 
     // "init in" ticks down to init_time and flips to "processing" once
-    // elapsed (optimistic — next poll confirms). The eta-time and
-    // eta-duration slots are filled by updateCountdowns on the next tick.
+    // elapsed (optimistic — next poll confirms). The eta-line slot is
+    // updated by updateCountdowns on the next tick.
     const initSlot = row.querySelector('[data-slot="eta-init"]');
     const stateSlot = row.querySelector('[data-slot="eta-state"]');
-    const timeSlot = row.querySelector('[data-slot="eta-time"]');
-    const durationSlot = row.querySelector('[data-slot="eta-duration"]');
+    const lineSlot = row.querySelector('[data-slot="eta-line"]');
+    const detailsWrap = row.querySelector('[data-slot="eta-details-wrap"]');
+    const detailsSlot = row.querySelector('[data-slot="eta-details"]');
     const target = etaTarget(product);
     if (!target) {
       initSlot.textContent = "—";
       stateSlot.hidden = true;
       stateSlot.removeAttribute("data-init-start");
-      timeSlot.hidden = true;
-      timeSlot.removeAttribute("data-next-complete");
-      durationSlot.hidden = true;
+      lineSlot.hidden = true;
+      lineSlot.removeAttribute("data-next-complete");
+      detailsWrap.hidden = true;
       return;
     }
     initSlot.textContent = initShort(target.initTime);
     stateSlot.hidden = false;
+    const inProgress = product.recent_inits.find((i) => i.status === "in_progress");
     if (target.inProgress) {
-      stateSlot.textContent = "processing";
+      const onTrack = inProgress && typeof inProgress.on_track === "boolean"
+        ? (inProgress.on_track ? " · on track" : " · delayed")
+        : "";
+      stateSlot.textContent = `processing${onTrack}`;
       stateSlot.removeAttribute("data-init-start");
+      if (inProgress) stateSlot.setAttribute("data-on-track", String(inProgress.on_track));
+      else stateSlot.removeAttribute("data-on-track");
     } else {
       stateSlot.textContent = "init in —";
       stateSlot.setAttribute("data-init-start", target.initTime);
+      stateSlot.removeAttribute("data-on-track");
     }
-    timeSlot.hidden = false;
-    timeSlot.textContent = "ETA —";
-    timeSlot.setAttribute("data-next-complete", target.targetIso);
-    durationSlot.hidden = false;
-    durationSlot.textContent = "in —";
+    lineSlot.hidden = false;
+    lineSlot.textContent = "ETA —";
+    lineSlot.setAttribute("data-next-complete", target.targetIso);
+
+    // Per-group details: show "more details" button only for in-progress
+    // runs that carry lead_groups and product-level lead_group_stats.
+    const groupStats = product.lead_group_stats;
+    if (inProgress?.lead_groups?.length && groupStats?.length) {
+      detailsWrap.hidden = false;
+      buildGroupDetails(detailsSlot, product, inProgress);
+    } else {
+      detailsWrap.hidden = true;
+      detailsSlot.hidden = true;
+      detailsSlot.replaceChildren();
+    }
+  }
+
+  function statusLabel(status) {
+    if (status === "on_time") return "on time";
+    if (status === "in_progress") return "processing";
+    if (status === "not_started") return "pending";
+    return status.replace(/_/g, " ");
+  }
+
+  function buildGroupDetails(container, product, init) {
+    const groups = init.lead_groups;
+    const stats = product.lead_group_stats;
+    const initMs = new Date(init.init_time).getTime();
+
+    const rows = groups.map((g, i) => {
+      const s = stats[i];
+      const etaCell = el("td");
+
+      if (g.status === "on_time" && g.latency_s != null) {
+        etaCell.textContent = fmtLatency(g.latency_s);
+      } else if (g.status === "on_time") {
+        etaCell.textContent = "done";
+      } else if (s?.p95_s != null) {
+        const targetIso = new Date(initMs + s.p95_s * 1000).toISOString();
+        etaCell.setAttribute("data-next-complete", targetIso);
+        etaCell.setAttribute("data-eta-compact", "");
+      } else {
+        etaCell.textContent = "—";
+      }
+
+      return el("tr", null, [
+        el("td", null, s?.label ?? g.name),
+        el("td", { class: `eta-g-${g.status}` }, statusLabel(g.status)),
+        etaCell,
+      ]);
+    });
+
+    container.replaceChildren(el("table", null, rows));
   }
 
   function updateBanners(summary) {
@@ -463,14 +519,15 @@
     for (const node of app.querySelectorAll("[data-next-complete]")) {
       const iso = node.getAttribute("data-next-complete");
       const delta = Math.floor((new Date(iso).getTime() - nowMs) / 1000);
-      const duration = node.closest(".status-eta").querySelector('[data-slot="eta-duration"]');
+      const compact = node.hasAttribute("data-eta-compact");
       if (delta <= 0) {
-        node.textContent = "ETA any moment";
-        duration.hidden = true;
+        node.textContent = compact ? "any moment" : "ETA any moment";
       } else {
-        node.textContent = `ETA ${fmtClock(iso)}`;
-        duration.hidden = false;
-        duration.textContent = `in ${fmtDuration(delta)}`;
+        const clock = fmtClock(iso);
+        const dur = fmtDuration(delta);
+        node.textContent = compact
+          ? `${clock} (in ${dur})`
+          : `ETA ${clock} (in ${dur})`;
       }
     }
   }
@@ -713,6 +770,17 @@
       e.preventDefault();
       returnToLive();
     }
+  });
+
+  // Details toggle: event delegation so hydrateRow doesn't re-wire per poll.
+  app.addEventListener("click", (e) => {
+    const btn = e.target.closest('[data-slot="eta-details-btn"]');
+    if (!btn) return;
+    const wrap = btn.closest('[data-slot="eta-details-wrap"]');
+    const details = wrap.querySelector('[data-slot="eta-details"]');
+    const show = details.hidden;
+    details.hidden = !show;
+    btn.textContent = show ? "less" : "more details";
   });
 
   // Kick off.

--- a/public/wxopticon.js
+++ b/public/wxopticon.js
@@ -412,89 +412,92 @@
   }
 
   function statusLabel(status) {
-    if (status === "on_time") return "on time";
+    if (status === "on_time" || status === "late") return "complete";
     if (status === "in_progress") return "processing";
     if (status === "not_started") return "pending";
+    if (status === "delayed") return "delayed";
     return status.replace(/_/g, " ");
   }
 
   function buildRowDetails(container, product) {
     const stats = product.lead_group_stats;
-    const ls = product.latency_stats;
     const inProgress = product.recent_inits.find((i) => i.status === "in_progress");
     const groups = inProgress?.lead_groups;
     const initMs = inProgress ? new Date(inProgress.init_time).getTime() : 0;
     const hasLive = !!(groups?.length);
 
-    // Header
-    const headCols = [el("th"), el("th", null, "p50"), el("th", null, "p95"), el("th", null, "p99")];
-    if (hasLive) {
-      headCols.push(el("th", null, "status"));
-      headCols.push(el("th", null, "ETA"));
-    }
-    const thead = el("thead", null, [el("tr", null, headCols)]);
-
-    // Overall row
-    const overallCols = [
-      el("td", null, "overall"),
-      el("td", null, fmtLatency(ls?.p50_s)),
-      el("td", null, fmtLatency(ls?.p95_s)),
-      el("td", null, fmtLatency(ls?.p99_s)),
+    // Header: two-row group header over the p-columns.
+    const initHeaderLabel = hasLive ? initShort(inProgress.init_time) : "waiting for next init";
+    const groupHeadCols = [
+      el("th"),
+      el("th", { colspan: "3", style: "text-align: center;" }, initHeaderLabel),
+      el("th", { colspan: "3", style: "text-align: center;" }, "time after init"),
     ];
-    if (hasLive) {
-      const status = inProgress.status;
-      overallCols.push(el("td", { class: `eta-g-${status}` }, statusLabel(status)));
-      const etaCell = el("td");
-      if (ls?.p95_s != null) {
-        const targetIso = new Date(initMs + ls.p95_s * 1000).toISOString();
-        etaCell.setAttribute("data-next-complete", targetIso);
-        etaCell.setAttribute("data-eta-compact", "");
-      } else {
-        etaCell.textContent = "—";
-      }
-      overallCols.push(etaCell);
-    }
-    const overallRow = el("tr", { class: "details-overall" }, overallCols);
+    const subHeadCols = [
+      el("th"),
+      el("th", { class: "right" }, "status"),
+      el("th", { class: "right" }, "time"),
+      el("th", { class: "right" }, "duration"),
+      el("th", { class: "right" }, "p50"),
+      el("th", { class: "right" }, "p95"),
+      el("th", { class: "right" }, "p99"),
+    ];
+    const thead = el("thead", null, [
+      el("tr", null, groupHeadCols),
+      el("tr", null, subHeadCols),
+    ]);
 
     // Per-group rows
     const groupRows = stats.map((s, i) => {
       const g = hasLive ? groups[i] : null;
-      const gStatus = g?.status;
-
-      const cols = [
-        el("td", null, s.label),
-        el("td", null, fmtLatency(s.p50_s)),
-        el("td", null, fmtLatency(s.p95_s)),
-        el("td", null, fmtLatency(s.p99_s)),
-      ];
-      if (hasLive) {
-        if (g) {
-          cols.push(el("td", { class: `eta-g-${gStatus}` }, statusLabel(gStatus)));
-          const etaCell = el("td");
-          if (gStatus === "on_time" && g.latency_s != null) {
-            etaCell.textContent = fmtLatency(g.latency_s);
-          } else if (gStatus === "on_time") {
-            etaCell.textContent = "done";
-          } else if (s.p95_s != null) {
-            const targetIso = new Date(initMs + s.p95_s * 1000).toISOString();
-            etaCell.setAttribute("data-next-complete", targetIso);
-            etaCell.setAttribute("data-eta-compact", "");
-          } else {
-            etaCell.textContent = "—";
-          }
-          cols.push(etaCell);
-        } else {
-          cols.push(el("td", null, "—"), el("td", null, "—"));
-        }
+      // A group may be marked in_progress by the backend as soon as init time
+      // passes, even if no files have arrived yet. Display those as "pending"
+      // until we observe direct progress. Once progress is observed, flip to
+      // "delayed" if we've already run past the p95 processing duration.
+      const observed = g && g.completion_pct != null && g.completion_pct > 0;
+      const elapsedS = (lastCountdownNow - initMs) / 1000;
+      let gStatus = g?.status ?? "not_started";
+      if (gStatus === "in_progress") {
+        if (!observed) gStatus = "not_started";
+        else if (s.p95_s != null && elapsedS > s.p95_s) gStatus = "delayed";
       }
+
+      const cols = [el("td", null, s.label)];
+      cols.push(el("td", { class: `right eta-g-${gStatus}` }, statusLabel(gStatus)));
+      const etaCell = el("td", { class: "right" });
+      const durCell = el("td", { class: "right" });
+      const completed = g?.status === "on_time" || g?.status === "late";
+      if (completed && g.latency_s != null) {
+        const completedIso = new Date(initMs + g.latency_s * 1000).toISOString();
+        etaCell.setAttribute("data-completed-at", completedIso);
+        durCell.textContent = fmtLatency(g.latency_s);
+      } else if (completed) {
+        etaCell.textContent = "done";
+        durCell.textContent = "—";
+      } else if (hasLive && s.p95_s != null) {
+        const targetIso = new Date(initMs + s.p95_s * 1000).toISOString();
+        etaCell.setAttribute("data-next-complete", targetIso);
+        etaCell.setAttribute("data-clock-only", "");
+        durCell.setAttribute("data-duration-since", inProgress.init_time);
+      } else {
+        etaCell.textContent = "—";
+        durCell.textContent = "—";
+      }
+      cols.push(etaCell, durCell);
+      cols.push(
+        el("td", { class: "right" }, fmtLatency(s.p50_s)),
+        el("td", { class: "right" }, fmtLatency(s.p95_s)),
+        el("td", { class: "right" }, fmtLatency(s.p99_s)),
+      );
       return el("tr", null, cols);
     });
 
-    const table = el("table", { class: "details-table" }, [
+    const table = el("table", { class: "data small" }, [
       thead,
-      el("tbody", null, [overallRow, ...groupRows]),
+      el("tbody", null, groupRows),
     ]);
-    container.replaceChildren(table);
+    const wrapper = el("div", { class: "table-container" }, [table]);
+    container.replaceChildren(wrapper);
   }
 
   function updateBanners(summary) {
@@ -567,16 +570,22 @@
     for (const node of app.querySelectorAll("[data-next-complete]")) {
       const iso = node.getAttribute("data-next-complete");
       const delta = Math.floor((new Date(iso).getTime() - nowMs) / 1000);
-      const compact = node.hasAttribute("data-eta-compact");
-      if (delta <= 0) {
-        node.textContent = compact ? "any moment" : "ETA any moment";
+      const clockOnly = node.hasAttribute("data-clock-only");
+      if (clockOnly) {
+        node.textContent = delta <= 0 ? "—" : `ETA ${fmtClock(iso)}`;
+      } else if (delta <= 0) {
+        node.textContent = "ETA any moment";
       } else {
-        const clock = fmtClock(iso);
-        const dur = fmtDuration(delta);
-        node.textContent = compact
-          ? `${clock} (in ${dur})`
-          : `ETA ${clock} (in ${dur})`;
+        node.textContent = `ETA ${fmtClock(iso)} (in ${fmtDuration(delta)})`;
       }
+    }
+    for (const node of app.querySelectorAll("[data-duration-since]")) {
+      const iso = node.getAttribute("data-duration-since");
+      const delta = Math.floor((nowMs - new Date(iso).getTime()) / 1000);
+      node.textContent = delta <= 0 ? "—" : fmtDuration(delta);
+    }
+    for (const node of app.querySelectorAll("[data-completed-at]")) {
+      node.textContent = fmtClock(node.getAttribute("data-completed-at"));
     }
   }
 

--- a/public/wxopticon.js
+++ b/public/wxopticon.js
@@ -227,7 +227,7 @@
   function renderGroupSegments(init) {
     const slices = groupSlices(init.lead_groups);
     let bottom = 0;
-    const segs = slices.map((s, i) => {
+    return slices.map((s) => {
       const seg = el("div", {
         class: `status-bar-fill-group g-${s.status}`,
         "data-group": s.name,
@@ -235,11 +235,9 @@
       }, [
         el("div", { class: "status-bar-fill-inner" }),
       ]);
-      if (i > 0) seg.classList.add("has-separator");
       bottom += s.heightPct;
       return seg;
     });
-    return segs;
   }
 
   function renderTrackContents(init) {
@@ -311,7 +309,7 @@
       segments.forEach((seg, i) => {
         const s = slices[i];
         seg.style.setProperty("--fill", `${s.fillPct}%`);
-        seg.className = `status-bar-fill-group g-${s.status}${i > 0 ? " has-separator" : ""}`;
+        seg.className = `status-bar-fill-group g-${s.status}`;
       });
       return;
     }

--- a/public/wxopticon.js
+++ b/public/wxopticon.js
@@ -366,8 +366,8 @@
     const initSlot = row.querySelector('[data-slot="eta-init"]');
     const stateSlot = row.querySelector('[data-slot="eta-state"]');
     const lineSlot = row.querySelector('[data-slot="eta-line"]');
-    const detailsWrap = row.querySelector('[data-slot="eta-details-wrap"]');
-    const detailsSlot = row.querySelector('[data-slot="eta-details"]');
+    const detailsBtn = row.querySelector('[data-slot="row-details-btn"]');
+    const detailsSlot = row.querySelector('[data-slot="row-details"]');
     const target = etaTarget(product);
     if (!target) {
       initSlot.textContent = "—";
@@ -375,37 +375,37 @@
       stateSlot.removeAttribute("data-init-start");
       lineSlot.hidden = true;
       lineSlot.removeAttribute("data-next-complete");
-      detailsWrap.hidden = true;
-      return;
+      // Keep details button visible for latency stats even without an ETA target.
     }
-    initSlot.textContent = initShort(target.initTime);
-    stateSlot.hidden = false;
-    const inProgress = product.recent_inits.find((i) => i.status === "in_progress");
-    if (target.inProgress) {
-      const onTrack = inProgress && typeof inProgress.on_track === "boolean"
-        ? (inProgress.on_track ? " · on track" : " · delayed")
-        : "";
-      stateSlot.textContent = `processing${onTrack}`;
-      stateSlot.removeAttribute("data-init-start");
-      if (inProgress) stateSlot.setAttribute("data-on-track", String(inProgress.on_track));
-      else stateSlot.removeAttribute("data-on-track");
-    } else {
-      stateSlot.textContent = "init in —";
-      stateSlot.setAttribute("data-init-start", target.initTime);
-      stateSlot.removeAttribute("data-on-track");
+    if (target) {
+      initSlot.textContent = initShort(target.initTime);
+      stateSlot.hidden = false;
+      const inProgress = product.recent_inits.find((i) => i.status === "in_progress");
+      if (target.inProgress) {
+        const onTrack = inProgress && typeof inProgress.on_track === "boolean"
+          ? (inProgress.on_track ? " · on track" : " · delayed")
+          : "";
+        stateSlot.textContent = `processing${onTrack}`;
+        stateSlot.removeAttribute("data-init-start");
+        if (inProgress) stateSlot.setAttribute("data-on-track", String(inProgress.on_track));
+        else stateSlot.removeAttribute("data-on-track");
+      } else {
+        stateSlot.textContent = "init in —";
+        stateSlot.setAttribute("data-init-start", target.initTime);
+        stateSlot.removeAttribute("data-on-track");
+      }
+      lineSlot.hidden = false;
+      lineSlot.textContent = "ETA —";
+      lineSlot.setAttribute("data-next-complete", target.targetIso);
     }
-    lineSlot.hidden = false;
-    lineSlot.textContent = "ETA —";
-    lineSlot.setAttribute("data-next-complete", target.targetIso);
 
-    // Per-group details: show "more details" button only for in-progress
-    // runs that carry lead_groups and product-level lead_group_stats.
+    // "more details" is always available when the product has lead_group_stats.
     const groupStats = product.lead_group_stats;
-    if (inProgress?.lead_groups?.length && groupStats?.length) {
-      detailsWrap.hidden = false;
-      buildGroupDetails(detailsSlot, product, inProgress);
+    if (groupStats?.length) {
+      detailsBtn.hidden = false;
+      buildRowDetails(detailsSlot, product);
     } else {
-      detailsWrap.hidden = true;
+      detailsBtn.hidden = true;
       detailsSlot.hidden = true;
       detailsSlot.replaceChildren();
     }
@@ -418,35 +418,86 @@
     return status.replace(/_/g, " ");
   }
 
-  function buildGroupDetails(container, product, init) {
-    const groups = init.lead_groups;
+  function buildRowDetails(container, product) {
     const stats = product.lead_group_stats;
-    const initMs = new Date(init.init_time).getTime();
+    const ls = product.latency_stats;
+    const inProgress = product.recent_inits.find((i) => i.status === "in_progress");
+    const groups = inProgress?.lead_groups;
+    const initMs = inProgress ? new Date(inProgress.init_time).getTime() : 0;
+    const hasLive = !!(groups?.length);
 
-    const rows = groups.map((g, i) => {
-      const s = stats[i];
+    // Header
+    const headCols = [
+      el("th"),                     // label
+      el("th", null, "p50"),
+      el("th", null, "p95"),
+      el("th", null, "p99"),
+    ];
+    if (hasLive) {
+      headCols.push(el("th", null, "status"));
+      headCols.push(el("th", null, "ETA"));
+    }
+    const thead = el("thead", null, [el("tr", null, headCols)]);
+
+    // Overall row
+    const overallCols = [
+      el("td", null, "overall"),
+      el("td", null, fmtLatency(ls?.p50_s)),
+      el("td", null, fmtLatency(ls?.p95_s)),
+      el("td", null, fmtLatency(ls?.p99_s)),
+    ];
+    if (hasLive) {
+      const status = inProgress.status;
+      overallCols.push(el("td", { class: `eta-g-${status}` }, statusLabel(status)));
       const etaCell = el("td");
-
-      if (g.status === "on_time" && g.latency_s != null) {
-        etaCell.textContent = fmtLatency(g.latency_s);
-      } else if (g.status === "on_time") {
-        etaCell.textContent = "done";
-      } else if (s?.p95_s != null) {
-        const targetIso = new Date(initMs + s.p95_s * 1000).toISOString();
+      if (ls?.p95_s != null) {
+        const targetIso = new Date(initMs + ls.p95_s * 1000).toISOString();
         etaCell.setAttribute("data-next-complete", targetIso);
         etaCell.setAttribute("data-eta-compact", "");
       } else {
         etaCell.textContent = "—";
       }
+      overallCols.push(etaCell);
+    }
+    const overallRow = el("tr", { class: "details-overall" }, overallCols);
 
-      return el("tr", null, [
-        el("td", null, s?.label ?? g.name),
-        el("td", { class: `eta-g-${g.status}` }, statusLabel(g.status)),
-        etaCell,
-      ]);
+    // Per-group rows
+    const groupRows = stats.map((s, i) => {
+      const cols = [
+        el("td", null, s.label),
+        el("td", null, fmtLatency(s.p50_s)),
+        el("td", null, fmtLatency(s.p95_s)),
+        el("td", null, fmtLatency(s.p99_s)),
+      ];
+      if (hasLive) {
+        const g = groups[i];
+        if (g) {
+          cols.push(el("td", { class: `eta-g-${g.status}` }, statusLabel(g.status)));
+          const etaCell = el("td");
+          if (g.status === "on_time" && g.latency_s != null) {
+            etaCell.textContent = fmtLatency(g.latency_s);
+          } else if (g.status === "on_time") {
+            etaCell.textContent = "done";
+          } else if (s.p95_s != null) {
+            const targetIso = new Date(initMs + s.p95_s * 1000).toISOString();
+            etaCell.setAttribute("data-next-complete", targetIso);
+            etaCell.setAttribute("data-eta-compact", "");
+          } else {
+            etaCell.textContent = "—";
+          }
+          cols.push(etaCell);
+        } else {
+          cols.push(el("td", null, "—"), el("td", null, "—"));
+        }
+      }
+      return el("tr", null, cols);
     });
 
-    container.replaceChildren(el("table", null, rows));
+    const table = el("table", { class: "details-table" }, [
+      thead,
+      el("tbody", null, [overallRow, ...groupRows]),
+    ]);
+    container.replaceChildren(table);
   }
 
   function updateBanners(summary) {
@@ -774,13 +825,15 @@
 
   // Details toggle: event delegation so hydrateRow doesn't re-wire per poll.
   app.addEventListener("click", (e) => {
-    const btn = e.target.closest('[data-slot="eta-details-btn"]');
+    const btn = e.target.closest('[data-slot="row-details-btn"]');
     if (!btn) return;
-    const wrap = btn.closest('[data-slot="eta-details-wrap"]');
-    const details = wrap.querySelector('[data-slot="eta-details"]');
+    const row = btn.closest(".status-row");
+    const details = row.querySelector('[data-slot="row-details"]');
     const show = details.hidden;
     details.hidden = !show;
     btn.textContent = show ? "less" : "more details";
+    // Kick a countdown update so ETA cells in the table are filled immediately.
+    if (show) updateCountdowns(lastCountdownNow);
   });
 
   // Kick off.

--- a/public/wxopticon.js
+++ b/public/wxopticon.js
@@ -206,6 +206,49 @@
     return Math.max(0, Math.min(100, (init.completion_pct ?? 0) * 100));
   }
 
+  // Backend values in lead_groups are cumulative (group i covers leads
+  // 0..max_lead[i]). Diff consecutive groups to get the per-slice heights
+  // (share of total leads) and fills (share of leads arrived in that slice).
+  function groupSlices(leadGroups) {
+    const total = leadGroups[leadGroups.length - 1].leads_expected;
+    let prevAvail = 0;
+    let prevExp = 0;
+    return leadGroups.map((g) => {
+      const sliceExp = g.leads_expected - prevExp;
+      const sliceAvail = g.leads_available - prevAvail;
+      prevAvail = g.leads_available;
+      prevExp = g.leads_expected;
+      const heightPct = total > 0 ? (sliceExp / total) * 100 : 0;
+      const fillPct = sliceExp > 0 ? Math.max(0, Math.min(100, (sliceAvail / sliceExp) * 100)) : 0;
+      return { name: g.name, status: g.status, heightPct, fillPct };
+    });
+  }
+
+  function renderGroupSegments(init) {
+    const slices = groupSlices(init.lead_groups);
+    let bottom = 0;
+    const segs = slices.map((s, i) => {
+      const seg = el("div", {
+        class: `status-bar-fill-group g-${s.status}`,
+        "data-group": s.name,
+        style: `--band-height: ${s.heightPct}%; --band-bottom: ${bottom}%; --fill: ${s.fillPct}%;`,
+      }, [
+        el("div", { class: "status-bar-fill-inner" }),
+      ]);
+      if (i > 0) seg.classList.add("has-separator");
+      bottom += s.heightPct;
+      return seg;
+    });
+    return segs;
+  }
+
+  function renderTrackContents(init) {
+    if (init.lead_groups && init.lead_groups.length > 0) {
+      return renderGroupSegments(init);
+    }
+    return [el("div", { class: "status-bar-fill", style: `--fill: ${barFill(init)}%` })];
+  }
+
   // Unobserved = monitoring-coverage gap, not a publication failure.
   // Give it a plain-English tooltip so it isn't mistaken for "failed".
   function barTooltip(init) {
@@ -213,16 +256,31 @@
     if (init.status === "unobserved") {
       return `${initText} · no data observed — wxopticon had no probe visibility for this init during its monitoring window (not a publication failure)`;
     }
-    return [
+    const base = [
       initText,
       init.status,
       fmtPercent(init.completion_pct),
       init.latency_s != null ? `latency ${fmtLatency(init.latency_s)}` : null,
     ].filter(Boolean).join(" · ");
+    if (!init.lead_groups || init.lead_groups.length === 0) return base;
+    const groupParts = init.lead_groups.map((g) =>
+      g.status === "in_progress"
+        ? `${g.name} ${g.status} ${fmtPercent(g.completion_pct)}`
+        : `${g.name} ${g.status}`
+    );
+    return `${base}\n${groupParts.join(" · ")}`;
+  }
+
+  function applyOnTrack(bar, init) {
+    if (init.status === "in_progress" && typeof init.on_track === "boolean") {
+      bar.setAttribute("data-on-track", init.on_track ? "true" : "false");
+    } else {
+      bar.removeAttribute("data-on-track");
+    }
   }
 
   function renderBar(init) {
-    return el(
+    const bar = el(
       "div",
       {
         class: "status-bar",
@@ -231,12 +289,12 @@
         title: barTooltip(init),
       },
       [
-        el("div", { class: "status-bar-track" }, [
-          el("div", { class: "status-bar-fill", style: `--fill: ${barFill(init)}%` }),
-        ]),
+        el("div", { class: "status-bar-track" }, renderTrackContents(init)),
         el("div", { class: "status-bar-label" }, initLabel(init.init_time)),
       ]
     );
+    applyOnTrack(bar, init);
+    return bar;
   }
 
   // Mutate an existing bar in place so CSS transitions animate the fill
@@ -244,7 +302,29 @@
   function updateBar(bar, init) {
     bar.setAttribute("data-status", init.status);
     bar.setAttribute("title", barTooltip(init));
-    bar.querySelector(".status-bar-fill").style.setProperty("--fill", `${barFill(init)}%`);
+    applyOnTrack(bar, init);
+
+    const segments = bar.querySelectorAll(".status-bar-fill-group");
+    const hasGroups = init.lead_groups && init.lead_groups.length > 0;
+    if (hasGroups && segments.length === init.lead_groups.length) {
+      const slices = groupSlices(init.lead_groups);
+      segments.forEach((seg, i) => {
+        const s = slices[i];
+        seg.style.setProperty("--fill", `${s.fillPct}%`);
+        seg.className = `status-bar-fill-group g-${s.status}${i > 0 ? " has-separator" : ""}`;
+      });
+      return;
+    }
+
+    const singleFill = bar.querySelector(".status-bar-fill");
+    if (!hasGroups && singleFill) {
+      singleFill.style.setProperty("--fill", `${barFill(init)}%`);
+      return;
+    }
+
+    // Structure changed (old→new snapshot shape) — rebuild the track contents.
+    const track = bar.querySelector(".status-bar-track");
+    if (track) track.replaceChildren(...renderTrackContents(init));
   }
 
   function hydrateRow(product) {

--- a/public/wxopticon.js
+++ b/public/wxopticon.js
@@ -418,6 +418,31 @@
     return status.replace(/_/g, " ");
   }
 
+  // Inline box plot: thin whisker from 0 to p99, filled box from p50 to
+  // p95, and a down-pointing triangle marker at the actual/expected value.
+  function renderBoxplot(p50, p95, p99, marker, markerClass, scaleMax) {
+    const pct = (v) => v != null && scaleMax > 0
+      ? Math.min(100, (v / scaleMax) * 100) : 0;
+    const children = [
+      el("div", { class: "boxplot-whisker", style: `width: ${pct(p99)}%` }),
+      el("div", { class: "boxplot-box", style: `left: ${pct(p50)}%; width: ${pct(p95) - pct(p50)}%` }),
+    ];
+    if (marker != null) {
+      children.push(el("div", {
+        class: `boxplot-marker ${markerClass}`,
+        style: `left: ${pct(marker)}%`,
+      }));
+    }
+    return el("div", { class: "boxplot" }, children);
+  }
+
+  function markerClassForStatus(status) {
+    if (status === "on_time") return "bpm-on-time";
+    if (status === "late") return "bpm-late";
+    if (status === "in_progress") return "bpm-in-progress";
+    return "bpm-muted";
+  }
+
   function buildRowDetails(container, product) {
     const stats = product.lead_group_stats;
     const ls = product.latency_stats;
@@ -426,71 +451,71 @@
     const initMs = inProgress ? new Date(inProgress.init_time).getTime() : 0;
     const hasLive = !!(groups?.length);
 
+    // Scale: overall p99 so all groups share a common x-axis.
+    const scaleMax = ls?.p99_s ?? 0;
+
     // Header
-    const headCols = [
-      el("th"),                     // label
-      el("th", null, "p50"),
-      el("th", null, "p95"),
-      el("th", null, "p99"),
-    ];
-    if (hasLive) {
-      headCols.push(el("th", null, "status"));
-      headCols.push(el("th", null, "ETA"));
-    }
+    const headCols = [el("th"), el("th", null, "status"), el("th", null, "ETA"), el("th")];
     const thead = el("thead", null, [el("tr", null, headCols)]);
 
     // Overall row
-    const overallCols = [
-      el("td", null, "overall"),
-      el("td", null, fmtLatency(ls?.p50_s)),
-      el("td", null, fmtLatency(ls?.p95_s)),
-      el("td", null, fmtLatency(ls?.p99_s)),
-    ];
-    if (hasLive) {
-      const status = inProgress.status;
-      overallCols.push(el("td", { class: `eta-g-${status}` }, statusLabel(status)));
-      const etaCell = el("td");
-      if (ls?.p95_s != null) {
-        const targetIso = new Date(initMs + ls.p95_s * 1000).toISOString();
-        etaCell.setAttribute("data-next-complete", targetIso);
-        etaCell.setAttribute("data-eta-compact", "");
-      } else {
-        etaCell.textContent = "—";
-      }
-      overallCols.push(etaCell);
+    const overallStatus = hasLive ? inProgress.status : "on_time";
+    const overallMarker = hasLive ? ls?.p95_s : null;
+    const overallEtaCell = el("td");
+    if (hasLive && ls?.p95_s != null) {
+      const targetIso = new Date(initMs + ls.p95_s * 1000).toISOString();
+      overallEtaCell.setAttribute("data-next-complete", targetIso);
+      overallEtaCell.setAttribute("data-eta-compact", "");
+    } else {
+      overallEtaCell.textContent = "—";
     }
-    const overallRow = el("tr", { class: "details-overall" }, overallCols);
+    const overallRow = el("tr", { class: "details-overall" }, [
+      el("td", null, "overall"),
+      el("td", { class: `eta-g-${overallStatus}` }, hasLive ? statusLabel(overallStatus) : "—"),
+      overallEtaCell,
+      el("td", null, [renderBoxplot(ls?.p50_s, ls?.p95_s, ls?.p99_s, overallMarker, markerClassForStatus(overallStatus), scaleMax)]),
+    ]);
 
     // Per-group rows
     const groupRows = stats.map((s, i) => {
-      const cols = [
-        el("td", null, s.label),
-        el("td", null, fmtLatency(s.p50_s)),
-        el("td", null, fmtLatency(s.p95_s)),
-        el("td", null, fmtLatency(s.p99_s)),
-      ];
-      if (hasLive) {
-        const g = groups[i];
-        if (g) {
-          cols.push(el("td", { class: `eta-g-${g.status}` }, statusLabel(g.status)));
-          const etaCell = el("td");
-          if (g.status === "on_time" && g.latency_s != null) {
-            etaCell.textContent = fmtLatency(g.latency_s);
-          } else if (g.status === "on_time") {
-            etaCell.textContent = "done";
-          } else if (s.p95_s != null) {
-            const targetIso = new Date(initMs + s.p95_s * 1000).toISOString();
-            etaCell.setAttribute("data-next-complete", targetIso);
-            etaCell.setAttribute("data-eta-compact", "");
-          } else {
-            etaCell.textContent = "—";
-          }
-          cols.push(etaCell);
-        } else {
-          cols.push(el("td", null, "—"), el("td", null, "—"));
+      const g = hasLive ? groups[i] : null;
+      const gStatus = g?.status;
+
+      // Marker: actual latency for completed groups, p95 for pending/in-progress.
+      let marker = null;
+      let mClass = "bpm-muted";
+      if (g) {
+        if ((gStatus === "on_time" || gStatus === "late") && g.latency_s != null) {
+          marker = g.latency_s;
+        } else if (gStatus !== "not_started") {
+          marker = s.p95_s;
         }
+        mClass = markerClassForStatus(gStatus);
       }
-      return el("tr", null, cols);
+
+      const etaCell = el("td");
+      if (g) {
+        if (gStatus === "on_time" && g.latency_s != null) {
+          etaCell.textContent = fmtLatency(g.latency_s);
+        } else if (gStatus === "on_time") {
+          etaCell.textContent = "done";
+        } else if (s.p95_s != null) {
+          const targetIso = new Date(initMs + s.p95_s * 1000).toISOString();
+          etaCell.setAttribute("data-next-complete", targetIso);
+          etaCell.setAttribute("data-eta-compact", "");
+        } else {
+          etaCell.textContent = "—";
+        }
+      } else {
+        etaCell.textContent = "—";
+      }
+
+      return el("tr", null, [
+        el("td", null, s.label),
+        el("td", { class: g ? `eta-g-${gStatus}` : "" }, g ? statusLabel(gStatus) : "—"),
+        etaCell,
+        el("td", null, [renderBoxplot(s.p50_s, s.p95_s, s.p99_s, marker, mClass, scaleMax)]),
+      ]);
     });
 
     const table = el("table", { class: "details-table" }, [

--- a/public/wxopticon.js
+++ b/public/wxopticon.js
@@ -418,11 +418,13 @@
     return status.replace(/_/g, " ");
   }
 
-  // Inline box plot: thin whisker from 0 to p99, filled box from p50 to
+  // Inline box plot: thin whisker from p50 to p99, filled box from p50 to
   // p95, and a down-pointing triangle marker at the actual/expected value.
-  function renderBoxplot(p50, p95, p99, marker, markerClass, scaleMax) {
-    const pct = (v) => v != null && scaleMax > 0
-      ? Math.min(100, (v / scaleMax) * 100) : 0;
+  // scaleMin/scaleMax define the visible x-axis window.
+  function renderBoxplot(p50, p95, p99, marker, markerClass, scaleMin, scaleMax) {
+    const range = scaleMax - scaleMin;
+    const pct = (v) => v != null && range > 0
+      ? Math.max(0, Math.min(100, ((v - scaleMin) / range) * 100)) : 0;
     const children = [
       el("div", { class: "boxplot-whisker", style: `width: ${pct(p99)}%` }),
       el("div", { class: "boxplot-box", style: `left: ${pct(p50)}%; width: ${pct(p95) - pct(p50)}%` }),
@@ -451,7 +453,10 @@
     const initMs = inProgress ? new Date(inProgress.init_time).getTime() : 0;
     const hasLive = !!(groups?.length);
 
-    // Scale: overall p99 so all groups share a common x-axis.
+    // Scale: zoom x-axis to [first_group.p50 .. overall_p99] so the
+    // interesting spread between groups fills the plot width instead
+    // of being compressed into the far right.
+    const scaleMin = stats[0]?.p50_s ?? 0;
     const scaleMax = ls?.p99_s ?? 0;
 
     // Header
@@ -473,7 +478,7 @@
       el("td", null, "overall"),
       el("td", { class: `eta-g-${overallStatus}` }, hasLive ? statusLabel(overallStatus) : "—"),
       overallEtaCell,
-      el("td", null, [renderBoxplot(ls?.p50_s, ls?.p95_s, ls?.p99_s, overallMarker, markerClassForStatus(overallStatus), scaleMax)]),
+      el("td", null, [renderBoxplot(ls?.p50_s, ls?.p95_s, ls?.p99_s, overallMarker, markerClassForStatus(overallStatus), scaleMin, scaleMax)]),
     ]);
 
     // Per-group rows
@@ -514,7 +519,7 @@
         el("td", null, s.label),
         el("td", { class: g ? `eta-g-${gStatus}` : "" }, g ? statusLabel(gStatus) : "—"),
         etaCell,
-        el("td", null, [renderBoxplot(s.p50_s, s.p95_s, s.p99_s, marker, mClass, scaleMax)]),
+        el("td", null, [renderBoxplot(s.p50_s, s.p95_s, s.p99_s, marker, mClass, scaleMin, scaleMax)]),
       ]);
     });
 

--- a/public/wxopticon.js
+++ b/public/wxopticon.js
@@ -418,33 +418,6 @@
     return status.replace(/_/g, " ");
   }
 
-  // Inline box plot: thin whisker from p50 to p99, filled box from p50 to
-  // p95, and a down-pointing triangle marker at the actual/expected value.
-  // scaleMin/scaleMax define the visible x-axis window.
-  function renderBoxplot(p50, p95, p99, marker, markerClass, scaleMin, scaleMax) {
-    const range = scaleMax - scaleMin;
-    const pct = (v) => v != null && range > 0
-      ? Math.max(0, Math.min(100, ((v - scaleMin) / range) * 100)) : 0;
-    const children = [
-      el("div", { class: "boxplot-whisker", style: `width: ${pct(p99)}%` }),
-      el("div", { class: "boxplot-box", style: `left: ${pct(p50)}%; width: ${pct(p95) - pct(p50)}%` }),
-    ];
-    if (marker != null) {
-      children.push(el("div", {
-        class: `boxplot-marker ${markerClass}`,
-        style: `left: ${pct(marker)}%`,
-      }));
-    }
-    return el("div", { class: "boxplot" }, children);
-  }
-
-  function markerClassForStatus(status) {
-    if (status === "on_time") return "bpm-on-time";
-    if (status === "late") return "bpm-late";
-    if (status === "in_progress") return "bpm-in-progress";
-    return "bpm-muted";
-  }
-
   function buildRowDetails(container, product) {
     const stats = product.lead_group_stats;
     const ls = product.latency_stats;
@@ -453,72 +426,68 @@
     const initMs = inProgress ? new Date(inProgress.init_time).getTime() : 0;
     const hasLive = !!(groups?.length);
 
-    // Each row's box plot is scaled to its own [p50, p99] range so the
-    // p50–p95 box fills most of the width. Cross-group time comparison
-    // comes from the ETA column; the plot shows distribution shape.
-
     // Header
-    const headCols = [el("th"), el("th", null, "status"), el("th", null, "ETA"), el("th")];
+    const headCols = [el("th"), el("th", null, "p50"), el("th", null, "p95"), el("th", null, "p99")];
+    if (hasLive) {
+      headCols.push(el("th", null, "status"));
+      headCols.push(el("th", null, "ETA"));
+    }
     const thead = el("thead", null, [el("tr", null, headCols)]);
 
     // Overall row
-    const overallStatus = hasLive ? inProgress.status : "on_time";
-    const overallMarker = hasLive ? ls?.p95_s : null;
-    const overallEtaCell = el("td");
-    if (hasLive && ls?.p95_s != null) {
-      const targetIso = new Date(initMs + ls.p95_s * 1000).toISOString();
-      overallEtaCell.setAttribute("data-next-complete", targetIso);
-      overallEtaCell.setAttribute("data-eta-compact", "");
-    } else {
-      overallEtaCell.textContent = "—";
-    }
-    const overallRow = el("tr", { class: "details-overall" }, [
+    const overallCols = [
       el("td", null, "overall"),
-      el("td", { class: `eta-g-${overallStatus}` }, hasLive ? statusLabel(overallStatus) : "—"),
-      overallEtaCell,
-      el("td", null, [renderBoxplot(ls?.p50_s, ls?.p95_s, ls?.p99_s, overallMarker, markerClassForStatus(overallStatus), ls?.p50_s ?? 0, ls?.p99_s ?? 0)]),
-    ]);
+      el("td", null, fmtLatency(ls?.p50_s)),
+      el("td", null, fmtLatency(ls?.p95_s)),
+      el("td", null, fmtLatency(ls?.p99_s)),
+    ];
+    if (hasLive) {
+      const status = inProgress.status;
+      overallCols.push(el("td", { class: `eta-g-${status}` }, statusLabel(status)));
+      const etaCell = el("td");
+      if (ls?.p95_s != null) {
+        const targetIso = new Date(initMs + ls.p95_s * 1000).toISOString();
+        etaCell.setAttribute("data-next-complete", targetIso);
+        etaCell.setAttribute("data-eta-compact", "");
+      } else {
+        etaCell.textContent = "—";
+      }
+      overallCols.push(etaCell);
+    }
+    const overallRow = el("tr", { class: "details-overall" }, overallCols);
 
     // Per-group rows
     const groupRows = stats.map((s, i) => {
       const g = hasLive ? groups[i] : null;
       const gStatus = g?.status;
 
-      // Marker: actual latency for completed groups, p95 for pending/in-progress.
-      let marker = null;
-      let mClass = "bpm-muted";
-      if (g) {
-        if ((gStatus === "on_time" || gStatus === "late") && g.latency_s != null) {
-          marker = g.latency_s;
-        } else if (gStatus !== "not_started") {
-          marker = s.p95_s;
-        }
-        mClass = markerClassForStatus(gStatus);
-      }
-
-      const etaCell = el("td");
-      if (g) {
-        if (gStatus === "on_time" && g.latency_s != null) {
-          etaCell.textContent = fmtLatency(g.latency_s);
-        } else if (gStatus === "on_time") {
-          etaCell.textContent = "done";
-        } else if (s.p95_s != null) {
-          const targetIso = new Date(initMs + s.p95_s * 1000).toISOString();
-          etaCell.setAttribute("data-next-complete", targetIso);
-          etaCell.setAttribute("data-eta-compact", "");
-        } else {
-          etaCell.textContent = "—";
-        }
-      } else {
-        etaCell.textContent = "—";
-      }
-
-      return el("tr", null, [
+      const cols = [
         el("td", null, s.label),
-        el("td", { class: g ? `eta-g-${gStatus}` : "" }, g ? statusLabel(gStatus) : "—"),
-        etaCell,
-        el("td", null, [renderBoxplot(s.p50_s, s.p95_s, s.p99_s, marker, mClass, s.p50_s ?? 0, s.p99_s ?? 0)]),
-      ]);
+        el("td", null, fmtLatency(s.p50_s)),
+        el("td", null, fmtLatency(s.p95_s)),
+        el("td", null, fmtLatency(s.p99_s)),
+      ];
+      if (hasLive) {
+        if (g) {
+          cols.push(el("td", { class: `eta-g-${gStatus}` }, statusLabel(gStatus)));
+          const etaCell = el("td");
+          if (gStatus === "on_time" && g.latency_s != null) {
+            etaCell.textContent = fmtLatency(g.latency_s);
+          } else if (gStatus === "on_time") {
+            etaCell.textContent = "done";
+          } else if (s.p95_s != null) {
+            const targetIso = new Date(initMs + s.p95_s * 1000).toISOString();
+            etaCell.setAttribute("data-next-complete", targetIso);
+            etaCell.setAttribute("data-eta-compact", "");
+          } else {
+            etaCell.textContent = "—";
+          }
+          cols.push(etaCell);
+        } else {
+          cols.push(el("td", null, "—"), el("td", null, "—"));
+        }
+      }
+      return el("tr", null, cols);
     });
 
     const table = el("table", { class: "details-table" }, [


### PR DESCRIPTION
## Summary

Frontend counterpart to [wxopticon#9](https://github.com/dynamical-org/wxopticon/pull/9).
The backend now ships per-lead-group completion and latency stats; this
teaches `/status/` to draw each init bar as a vertical stack of group
segments, with in-progress runs colored green vs amber based on the new
`on_track` flag.

Plan: [plans/63_wxopticon_lead_groups.md](plans/63_wxopticon_lead_groups.md).

## Test plan

- [ ] Playwright screenshot of live mode showing stacked group segments
- [ ] Playwright screenshot of scrub mode still renders historical snapshots
- [ ] Fallback: a snapshot without `lead_groups` renders as a single fill
- [ ] `on_time` / `late` / `failed` / `unobserved` visuals unchanged