### PR TITLE
stac: validate catalog at build time, fix best-practice warnings

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -197,7 +197,7 @@ module.exports = function (eleventyConfig) {
     return {
       type: "Catalog",
       id: "dynamical-org",
-      stac_version: "1.0.0",
+      stac_version: "1.1.0",
       description:
         "Cloud-optimized weather and climate datasets from dynamical.org",
       links: [
@@ -205,11 +205,13 @@ module.exports = function (eleventyConfig) {
           rel: "self",
           href: `${STAC_BASE_URL}/catalog.json`,
           type: "application/json",
+          title: "Dynamical.org STAC Catalog",
         },
         {
           rel: "root",
           href: `${STAC_BASE_URL}/catalog.json`,
           type: "application/json",
+          title: "Dynamical.org STAC Catalog",
         },
         ...liveEntries.map((e) => ({
           rel: "child",
@@ -338,7 +340,7 @@ module.exports = function (eleventyConfig) {
     return {
       type: "Collection",
       id: entry.dataset_id,
-      stac_version: "1.0.0",
+      stac_version: "1.1.0",
       stac_extensions: [
         "https://stac-extensions.github.io/xarray-assets/v1.0.0/schema.json",
         "https://stac-extensions.github.io/datacube/v2.2.0/schema.json",
@@ -352,22 +354,28 @@ module.exports = function (eleventyConfig) {
         spatial: { bbox: [bbox] },
         temporal: { interval: [[temporalStart, null]] },
       },
+      summaries: {
+        "cube:variables": Object.keys(cubeVariables),
+      },
       assets,
       links: [
         {
           rel: "self",
           href: `${STAC_BASE_URL}/${entry.dataset_id}/collection.json`,
           type: "application/json",
+          title: entry.name,
         },
         {
           rel: "root",
           href: `${STAC_BASE_URL}/catalog.json`,
           type: "application/json",
+          title: "Dynamical.org STAC Catalog",
         },
         {
           rel: "parent",
           href: `${STAC_BASE_URL}/catalog.json`,
           type: "application/json",
+          title: "Dynamical.org STAC Catalog",
         },
         {
           rel: "about",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "build": "npx @11ty/eleventy",
+    "build": "npx @11ty/eleventy && bash scripts/validate-stac.sh",
     "start": "npx @11ty/eleventy --serve --port=8081",
     "clean": "rm -r docs .cache"
   },

--- a/scripts/validate-stac.sh
+++ b/scripts/validate-stac.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Use uvx (uv) locally, fall back to pipx in environments like Cloudflare Pages
+run_tool() {
+  if command -v uvx &>/dev/null; then
+    uvx "$@"
+  else
+    pipx run "$@"
+  fi
+}
+
+echo "==> stac-validator: schema validation"
+run_tool stac-validator validate docs/stac/catalog.json --recursive
+
+echo ""
+echo "==> stac-check: best practices"
+FAILED=0
+for f in docs/stac/catalog.json docs/stac/*/collection.json; do
+  output=$(run_tool stac-check "$f" 2>&1)
+  warnings=$(echo "$output" | awk '/STAC Best Practices:/{found=1; next} /Additional Information:/{found=0} found && /[^ \t]/')
+  if [ -n "$warnings" ]; then
+    echo "FAIL: $f"
+    echo "$warnings"
+    FAILED=1
+  fi
+done
+
+if [ "$FAILED" -eq 1 ]; then
+  exit 1
+fi
+echo "All STAC files passed."


### PR DESCRIPTION
## Summary

- Bumps `stac_version` from 1.0.0 → 1.1.0 across catalog and all collections
- Adds `title` to `self`/`root`/`parent` links (stac-check best practice)
- Adds `summaries.cube:variables` (flat variable name list) to each collection for STAC API discoverability
- Adds `scripts/validate-stac.sh` which runs `stac-validator` (schema) and `stac-check` (best practices) against the generated `docs/stac/` output
- Wires validation into `npm run build` so it runs on every deploy — build fails if any file is invalid or has best-practice warnings

## Test plan

- [x] `npm run build` completes without errors
- [x] `scripts/validate-stac.sh` reports `All STAC files passed.` (10/10 catalog + collections)
- [x] No stac-check best-practice warnings on any file

🤖 Generated with [Claude Code](https://claude.com/claude-code)