### PR TITLE
add icechunk 2.0 upgrade notice blog post

### DIFF
--- a/content/updates/2026-04-17.md
+++ b/content/updates/2026-04-17.md
@@ -1,0 +1,30 @@
+---
+title: "dynamical.org - icechunk 2.0 upgrade cometh"
+date: 2026-04-17
+---
+
+Short one today — a quick housekeeping note for anyone pulling from our icechunk data products.
+
+Icechunk 2 is [out](https://www.earthmover.io/blog/announcing-icechunk-2-better-consistency-performance-and-reliability-for-tensor-storage)! If you're using our datasets via Icechunk, please **update your Python library before Thursday April 24**:
+
+```
+pip install icechunk --upgrade
+```
+
+or 
+
+
+```
+uv add icechunk --upgrade
+```
+
+
+Note that **icechunk 2 requires Python 3.12 or higher.** If you're on an older runtime, now's the time to bump it. 
+
+We'll be targeting the v2 format going forward.
+
+---
+
+Enjoy the [weather](https://www.youtube.com/watch?v=McjFepEpcBE&list=RDMcjFepEpcBE),
+
+MM


### PR DESCRIPTION
Closes https://github.com/dynamical-org/meta/issues/72

Short update post asking users to upgrade to icechunk 2.0 before April 24. Notes the Python 3.12+ requirement.