### PR TITLE
wxopticon: consume on_timedness from backend

### DIFF
--- a/plans/69_wxopticon_on_timedness.md
+++ b/plans/69_wxopticon_on_timedness.md
@@ -1,0 +1,53 @@
+# Plan: consume wxopticon `on_timedness` from the backend
+
+## Context
+
+Companion to [dynamical-org/wxopticon#14](https://github.com/dynamical-org/wxopticon/pull/14), which moves the "on track / delayed / unobserved" decision out of this frontend and into `summary.py`. See that PR's `plans/14_centralize_status_timedness.md` for the full design and data-model rationale. This plan covers the dynamical.org side only.
+
+Closes dynamical-org/dynamical.org#66.
+
+## Approach
+
+Drive presentation purely off the new `status` + `on_timedness` pair. Delete all client-side re-derivation in `public/wxopticon.js`. CSS keys off a single composite value (`on_timedness ?? status`) instead of the old `data-on-track="true|false"` attribute.
+
+### JS — `public/wxopticon.js`
+
+1. `etaTarget` / `buildRowDetails`: `i.status === "in_progress"` → `"processing"`.
+2. `groupSlices` / `renderGroupSegments`: segment class is `g-${timednessKey(g)}` where `timednessKey = on_timedness ?? status`.
+3. `applyOnTrack` renamed → `applyOnTimedness`; sets `data-on-timedness` on the bar (or removes it). No more "only in_progress" guard — the backend field is already scoped.
+4. ETA state-slot text: drive suffix directly off `inProgress.on_timedness` (`on_track` / `delayed` get qualifiers; `insufficient_data` / `unobserved` show plain "processing" — the #66 fix).
+5. `buildRowDetails`: delete the `if (gStatus === "in_progress")` re-derivation block. Use `g.on_timedness ?? g.status`.
+6. `statusLabel` rewritten for the new vocabulary: `on_time`/`late` → "complete", `on_track`/`insufficient_data` → "processing", `unobserved`/`not_started` → "pending".
+7. `barTooltip` / `g.status === "in_progress"` → `"processing"`; tooltip includes `on_timedness` when present.
+
+### CSS — `public/main.css`
+
+- `[data-status="on_time"|"in_progress"|"late"]` single-fill rules rewritten for the new `status` + `on_timedness` pair.
+- `[data-on-track="true|false"]` replaced with `[data-on-timedness=...]` analogs covering all five processing/complete values.
+- `g-on_track` / `g-delayed` / `g-insufficient_data` added; `g-in_progress` removed.
+- `eta-g-on_track` / `eta-g-insufficient_data` / `eta-g-unobserved` added; `eta-g-in_progress` removed.
+
+## Critical files
+
+- `/Users/marsh/workspace/dynamical-org/dynamical.org/public/wxopticon.js`
+- `/Users/marsh/workspace/dynamical-org/dynamical.org/public/main.css`
+- Reference only: `/Users/marsh/workspace/dynamical-org/dynamical.org/_data/wxopticon.js` (build-time skeleton — doesn't touch `status` or `on_track`; no changes needed).
+
+## Sequencing
+
+**Must merge after** the wxopticon PR has deployed AND `scripts/reprocess_history.py` has backfilled historical snapshots in R2. The plan's principle: "the simplified frontend never has to handle mixed schemas." Between the two deploys, there's a short window where the old frontend reads new JSON — that's fine (brief stale render, plan accepts this). Merging PR 69 before wxopticon PR 14 is the opposite direction and would break production.
+
+## Verification
+
+1. `npm run build` — succeeds, no template errors.
+2. `npm start` → open `/status/`:
+   - In-progress rows with `on_timedness: on_track` show "· on track" in green.
+   - In-progress rows with `on_timedness: delayed` show "· delayed" in yellow.
+   - In-progress rows with `on_timedness: insufficient_data` or `unobserved` show plain muted "processing" (#66).
+   - Complete rows with `on_timedness: late` show red; `on_time` shows green.
+3. Scrub through historical snapshots — every reprocessed epoch renders consistently.
+4. Close `gh:dynamical-org/dynamical.org#66` after deploy confirms #66's visual fix.
+
+## Out of scope
+
+- Removing the legacy `on_track: bool` field — that's a follow-up PR in wxopticon (PR 3 in the sequence) after this has baked.

--- a/public/main.css
+++ b/public/main.css
@@ -831,11 +831,12 @@ article img {
   }
 }
 
-/* Status fills — solid color per status. Single-fill rules apply to
-   pre-lead-groups snapshots (graceful fallback). Stacked rules below
-   key off each segment's own g-{status} class. */
+/* Status fills — solid color per (status, on_timedness) pair. Single-fill
+   rules below only fire on pre-lead-groups snapshots (every current product
+   emits lead_groups); the stacked-segment rules further down handle the
+   normal path. Unobserved / failed / not_started use the track-level rules
+   (dotted border, no fill). */
 
-/* Single-fill fallback for pre-lead-groups snapshots. */
 .status-bar[data-status="complete"][data-on-timedness="on_time"] .status-bar-fill {
   background-color: var(--status-on-time);
 }

--- a/public/main.css
+++ b/public/main.css
@@ -980,10 +980,10 @@ article img {
 }
 
 .eta-g-on_time { color: var(--status-on-time); }
-.eta-g-on_track { color: var(--muted-text); }
+.eta-g-on_track { color: var(--status-on-time); }
 .eta-g-insufficient_data { color: var(--muted-text); }
 .eta-g-unobserved { color: var(--muted-text); }
-.eta-g-delayed { color: var(--status-late); }
+.eta-g-delayed { color: var(--status-in-progress); }
 .eta-g-not_started { color: var(--muted-text); }
 .eta-g-late { color: var(--status-late); }
 .eta-g-failed { color: var(--status-failed); }

--- a/public/main.css
+++ b/public/main.css
@@ -835,16 +835,21 @@ article img {
    pre-lead-groups snapshots (graceful fallback). Stacked rules below
    key off each segment's own g-{status} class. */
 
-.status-bar[data-status="on_time"] .status-bar-fill {
+/* Single-fill fallback for pre-lead-groups snapshots. */
+.status-bar[data-status="complete"][data-on-timedness="on_time"] .status-bar-fill {
   background-color: var(--status-on-time);
 }
 
-.status-bar[data-status="in_progress"] .status-bar-fill {
+.status-bar[data-status="complete"][data-on-timedness="late"] .status-bar-fill {
+  background-color: var(--status-late);
+}
+
+.status-bar[data-status="processing"] .status-bar-fill {
   background-color: var(--status-in-progress);
 }
 
-.status-bar[data-status="late"] .status-bar-fill {
-  background-color: var(--status-late);
+.status-bar[data-status="processing"][data-on-timedness="on_track"] .status-bar-fill {
+  background-color: var(--status-on-track);
 }
 
 .status-bar[data-status="failed"] .status-bar-fill {
@@ -855,17 +860,19 @@ article img {
   height: 100%;
 }
 
-/* Stacked group segments: color comes from each segment's g-{status}. */
+/* Stacked group segments: the class suffix `g-{key}` is `on_timedness ??
+   status`, so complete/processing collapse into their timedness values. */
 .status-bar-fill-group.g-on_time .status-bar-fill-inner {
   background-color: var(--status-on-time);
 }
 
-.status-bar-fill-group.g-in_progress .status-bar-fill-inner {
-  background-color: var(--status-in-progress);
+.status-bar-fill-group.g-on_track .status-bar-fill-inner {
+  background-color: var(--status-on-track);
 }
 
-.status-bar[data-on-track="true"] .status-bar-fill-group.g-in_progress .status-bar-fill-inner {
-  background-color: var(--status-on-track);
+.status-bar-fill-group.g-delayed .status-bar-fill-inner,
+.status-bar-fill-group.g-insufficient_data .status-bar-fill-inner {
+  background-color: var(--status-in-progress);
 }
 
 .status-bar-fill-group.g-late .status-bar-fill-inner {
@@ -932,12 +939,23 @@ article img {
   white-space: nowrap;
 }
 
-.status-eta [data-on-track="true"] {
+.status-eta [data-on-timedness="on_track"],
+.status-eta [data-on-timedness="on_time"] {
   color: var(--status-on-time);
 }
 
-.status-eta [data-on-track="false"] {
+.status-eta [data-on-timedness="delayed"] {
   color: var(--status-in-progress);
+}
+
+.status-eta [data-on-timedness="late"] {
+  color: var(--status-late);
+}
+
+/* insufficient_data / unobserved — no trustworthy signal yet, stay muted. */
+.status-eta [data-on-timedness="insufficient_data"],
+.status-eta [data-on-timedness="unobserved"] {
+  color: var(--muted-text);
 }
 
 .eta-details-btn {
@@ -961,7 +979,9 @@ article img {
 }
 
 .eta-g-on_time { color: var(--status-on-time); }
-.eta-g-in_progress { color: var(--muted-text); }
+.eta-g-on_track { color: var(--muted-text); }
+.eta-g-insufficient_data { color: var(--muted-text); }
+.eta-g-unobserved { color: var(--muted-text); }
 .eta-g-delayed { color: var(--status-late); }
 .eta-g-not_started { color: var(--muted-text); }
 .eta-g-late { color: var(--status-late); }

--- a/public/wxopticon.js
+++ b/public/wxopticon.js
@@ -170,7 +170,7 @@
     // (init_time + p95), falling back to the next scheduled run's
     // p95-based completion when nothing's in progress.
     const p95 = product.latency_stats.p95_s;
-    const inProgress = product.recent_inits.find((i) => i.status === "in_progress");
+    const inProgress = product.recent_inits.find((i) => i.status === "processing");
     if (inProgress && p95 != null) {
       const targetMs = new Date(inProgress.init_time).getTime() + p95 * 1000;
       return {
@@ -220,8 +220,17 @@
       prevExp = g.leads_expected;
       const heightPct = total > 0 ? (sliceExp / total) * 100 : 0;
       const fillPct = sliceExp > 0 ? Math.max(0, Math.min(100, (sliceAvail / sliceExp) * 100)) : 0;
-      return { name: g.name, status: g.status, heightPct, fillPct };
+      return { name: g.name, key: timednessKey(g), heightPct, fillPct };
     });
+  }
+
+  // Collapses the (status, on_timedness) pair into a single string used as
+  // both the segment CSS class suffix (`g-${key}`) and the details-table
+  // class suffix (`eta-g-${key}`). One of:
+  //   on_time, late, on_track, delayed, insufficient_data, unobserved,
+  //   not_started, failed.
+  function timednessKey(node) {
+    return node.on_timedness ?? node.status;
   }
 
   function renderGroupSegments(init) {
@@ -229,7 +238,7 @@
     let bottom = 0;
     return slices.map((s) => {
       const seg = el("div", {
-        class: `status-bar-fill-group g-${s.status}`,
+        class: `status-bar-fill-group g-${s.key}`,
         "data-group": s.name,
         style: `--band-height: ${s.heightPct}%; --band-bottom: ${bottom}%; --fill: ${s.fillPct}%;`,
       }, [
@@ -254,26 +263,28 @@
     if (init.status === "unobserved") {
       return `${initText} · no data observed — wxopticon had no probe visibility for this init during its monitoring window (not a publication failure)`;
     }
+    const stateText = init.on_timedness ? `${init.status} · ${init.on_timedness}` : init.status;
     const base = [
       initText,
-      init.status,
+      stateText,
       fmtPercent(init.completion_pct),
       init.latency_s != null ? `latency ${fmtLatency(init.latency_s)}` : null,
     ].filter(Boolean).join(" · ");
     if (!init.lead_groups || init.lead_groups.length === 0) return base;
-    const groupParts = init.lead_groups.map((g) =>
-      g.status === "in_progress"
-        ? `${g.name} ${g.status} ${fmtPercent(g.completion_pct)}`
-        : `${g.name} ${g.status}`
-    );
+    const groupParts = init.lead_groups.map((g) => {
+      const gState = g.on_timedness ?? g.status;
+      return g.status === "processing"
+        ? `${g.name} ${gState} ${fmtPercent(g.completion_pct)}`
+        : `${g.name} ${gState}`;
+    });
     return `${base}\n${groupParts.join(" · ")}`;
   }
 
-  function applyOnTrack(bar, init) {
-    if (init.status === "in_progress" && typeof init.on_track === "boolean") {
-      bar.setAttribute("data-on-track", init.on_track ? "true" : "false");
+  function applyOnTimedness(bar, init) {
+    if (init.on_timedness) {
+      bar.setAttribute("data-on-timedness", init.on_timedness);
     } else {
-      bar.removeAttribute("data-on-track");
+      bar.removeAttribute("data-on-timedness");
     }
   }
 
@@ -291,7 +302,7 @@
         el("div", { class: "status-bar-label" }, initLabel(init.init_time)),
       ]
     );
-    applyOnTrack(bar, init);
+    applyOnTimedness(bar, init);
     return bar;
   }
 
@@ -300,7 +311,7 @@
   function updateBar(bar, init) {
     bar.setAttribute("data-status", init.status);
     bar.setAttribute("title", barTooltip(init));
-    applyOnTrack(bar, init);
+    applyOnTimedness(bar, init);
 
     const segments = bar.querySelectorAll(".status-bar-fill-group");
     const hasGroups = init.lead_groups && init.lead_groups.length > 0;
@@ -309,7 +320,7 @@
       segments.forEach((seg, i) => {
         const s = slices[i];
         seg.style.setProperty("--fill", `${s.fillPct}%`);
-        seg.className = `status-bar-fill-group g-${s.status}`;
+        seg.className = `status-bar-fill-group g-${s.key}`;
       });
       return;
     }
@@ -380,22 +391,26 @@
     if (target) {
       initSlot.textContent = initShort(target.initTime);
       stateSlot.hidden = false;
-      const inProgress = product.recent_inits.find((i) => i.status === "in_progress");
+      const inProgress = product.recent_inits.find((i) => i.status === "processing");
       if (target.inProgress) {
-        const onTrack = inProgress && typeof inProgress.on_track === "boolean"
-          ? (inProgress.on_track ? " · on track" : " · delayed")
-          : "";
-        stateSlot.textContent = `processing${onTrack}`;
+        // Qualifier is only shown for the two decisive cases (on_track /
+        // delayed); insufficient_data and unobserved read as plain
+        // "processing" so a grey/muted row matches #66's guidance.
+        const suffix = {
+          on_track: " · on track",
+          delayed: " · delayed",
+        }[inProgress?.on_timedness] ?? "";
+        stateSlot.textContent = `processing${suffix}`;
         stateSlot.removeAttribute("data-init-start");
-        if (inProgress && typeof inProgress.on_track === "boolean") {
-          stateSlot.setAttribute("data-on-track", String(inProgress.on_track));
+        if (inProgress?.on_timedness) {
+          stateSlot.setAttribute("data-on-timedness", inProgress.on_timedness);
         } else {
-          stateSlot.removeAttribute("data-on-track");
+          stateSlot.removeAttribute("data-on-timedness");
         }
       } else {
         stateSlot.textContent = "init in —";
         stateSlot.setAttribute("data-init-start", target.initTime);
-        stateSlot.removeAttribute("data-on-track");
+        stateSlot.removeAttribute("data-on-timedness");
       }
       lineSlot.hidden = false;
       lineSlot.textContent = "ETA —";
@@ -421,17 +436,22 @@
     }
   }
 
-  function statusLabel(status) {
-    if (status === "on_time" || status === "late") return "complete";
-    if (status === "in_progress") return "processing";
-    if (status === "not_started") return "pending";
-    if (status === "delayed") return "delayed";
-    return status.replace(/_/g, " ");
+  // Maps the composite `on_timedness ?? status` key to a short human label.
+  // Processing sub-states (on_track / insufficient_data) collapse to
+  // "processing"; unobserved/not_started → "pending"; complete sub-states
+  // (on_time / late) collapse to "complete". Delayed and failed pass
+  // through unchanged.
+  function statusLabel(key) {
+    if (key === "on_time" || key === "late") return "complete";
+    if (key === "on_track" || key === "insufficient_data") return "processing";
+    if (key === "unobserved" || key === "not_started") return "pending";
+    if (key === "delayed") return "delayed";
+    return key.replace(/_/g, " ");
   }
 
   function buildRowDetails(container, product) {
     const stats = product.lead_group_stats;
-    const inProgress = product.recent_inits.find((i) => i.status === "in_progress");
+    const inProgress = product.recent_inits.find((i) => i.status === "processing");
     const groups = inProgress?.lead_groups;
     const initMs = inProgress ? new Date(inProgress.init_time).getTime() : 0;
     const hasLive = !!(groups?.length);
@@ -457,26 +477,17 @@
       el("tr", null, subHeadCols),
     ]);
 
-    // Per-group rows
+    // Per-group rows. The backend already collapses (status, on_timedness)
+    // into the right presentation state, so no client-side re-derivation.
     const groupRows = stats.map((s, i) => {
       const g = hasLive ? groups[i] : null;
-      // A group may be marked in_progress by the backend as soon as init time
-      // passes, even if no files have arrived yet. Display those as "pending"
-      // until we observe direct progress. Once progress is observed, flip to
-      // "delayed" if we've already run past the p95 processing duration.
-      const observed = g && g.completion_pct != null && g.completion_pct > 0;
-      const elapsedS = (lastCountdownNow - initMs) / 1000;
-      let gStatus = g?.status ?? "not_started";
-      if (gStatus === "in_progress") {
-        if (!observed) gStatus = "not_started";
-        else if (s.p95_s != null && elapsedS > s.p95_s) gStatus = "delayed";
-      }
+      const gKey = g ? (g.on_timedness ?? g.status) : "not_started";
 
       const cols = [el("td", null, s.label)];
-      cols.push(el("td", { class: `right eta-g-${gStatus}` }, statusLabel(gStatus)));
+      cols.push(el("td", { class: `right eta-g-${gKey}` }, statusLabel(gKey)));
       const etaCell = el("td", { class: "right" });
       const durCell = el("td", { class: "right" });
-      const completed = g?.status === "on_time" || g?.status === "late";
+      const completed = g?.status === "complete";
       if (completed && g.latency_s != null) {
         const completedIso = new Date(initMs + g.latency_s * 1000).toISOString();
         etaCell.setAttribute("data-completed-at", completedIso);
@@ -528,10 +539,9 @@
 
   // Pure render: paint products + generated_at from a fully-loaded summary.
   // Banners, ribbon, and the countdown ticker are owned by the outer shell
-  // and differ between live and scrub modes. nowMs is set first so builders
-  // that read lastCountdownNow (e.g. buildRowDetails for the delayed/pending
-  // threshold) see the snapshot's reference clock rather than the previous
-  // one.
+  // and differ between live and scrub modes. nowMs is set first so the
+  // countdown ticker picks up the snapshot's reference clock on the next
+  // tick (rather than lagging behind the previous one).
   function renderSnapshot(summary, nowMs) {
     lastCountdownNow = nowMs;
     generatedAtSlot.replaceChildren(timeNode(summary.generated_at));


### PR DESCRIPTION
## Summary

- Stops re-deriving `delayed / pending / on track` client-side. The wxopticon backend (https://github.com/dynamical-org/wxopticon/pull/14) now emits the full `(status, on_timedness)` pair per init + per lead group, so the frontend just maps `on_timedness ?? status` → CSS class + label.
- Resolves dynamical-org/dynamical.org#66: processing rows with no observed progress now read as plain muted `processing`, not a false `· on track`.
- Also tightens the "delayed" color gradient: `on_track` green → `delayed` yellow (p95 exceeded) → `late` orange (p99 exceeded) → `failed` red.

## Sequencing

This PR **must merge after** https://github.com/dynamical-org/wxopticon/pull/14 has deployed **and** `scripts/reprocess_history.py` has backfilled historical snapshots in R2. Otherwise:
- Live `summary.json` still has `status: in_progress` / `on_track: bool` → the ETA line loses its "processing" qualifier.
- Historical snapshots in the scrub panel have the old schema → bars render with inherited default colors (invisible segments).

A follow-up PR in `wxopticon` will drop the legacy `on_track: bool` field once this has baked.

## Test plan

- [ ] Wait for wxopticon PR 14 to deploy + `scripts/reprocess_history.py` to complete
- [ ] Load `/status/` against live summary — confirm:
  - [ ] In-progress rows with `on_timedness: on_track` show "· on track" in green
  - [ ] In-progress rows with `on_timedness: delayed` show "· delayed" in yellow
  - [ ] In-progress rows with `on_timedness: insufficient_data` or `unobserved` show plain muted "processing" (#66)
  - [ ] Complete rows with `on_timedness: late` show red; `on_time` shows green
- [ ] Scrub through historical snapshots — all epochs render consistently with the new schema
- [ ] Details table: "status" column labels collapse correctly (complete / processing / pending / delayed / failed)