### PR TITLE
fix mobile overflow for catalog detail tables and status bars

### DIFF
--- a/public/main.css
+++ b/public/main.css
@@ -978,6 +978,9 @@ article img {
 .status-row-details {
   grid-column: 1 / -1;
   padding: 1rem 0 0.4rem;
+  min-width: 0;
+  max-width: 100%;
+  overflow-x: auto;
 }
 
 .status-row-details table.data {


### PR DESCRIPTION
Wrap the spatial/temporal details and Examples tables in .table-container
so they scroll horizontally instead of pushing the page wider on mobile,
matching the pattern used by the catalog listing table.

Apply the same overflow-x behavior to the status bar chart: give bars a
minimum width via grid-auto-columns and enable horizontal scroll on
status-row-body, with sticky lead-group labels so the y-axis stays
pinned while the bars scroll.

Closes #64

https://claude.ai/code/session_017oyWx7T4f8BGGrvyFJjCjh