### PR TITLE
identity: reference hosted brand assets

### DIFF
--- a/_includes/base.njk
+++ b/_includes/base.njk
@@ -27,7 +27,7 @@
   <body>
     <nav aria-label="Primary">
       <ul>
-        <li><a href="/" class="nav-lockup"><picture><source srcset="https://assets.dynamical.org/identity/logo/lockup/lockup-white.svg" media="(prefers-color-scheme: dark)"><img src="https://assets.dynamical.org/identity/logo/lockup/lockup-black.svg" alt="dynamical.org" height="32"></picture></a></li>
+        <li><a href="/" class="nav-lockup"><picture><source srcset="https://assets.dynamical.org/identity/logo/lockup/lockup-white.svg" media="(prefers-color-scheme: dark)"><img src="https://assets.dynamical.org/identity/logo/lockup/lockup-black.svg" alt="dynamical.org" height="30"></picture></a></li>
         <li><a href="/catalog">catalog</a></li>
         <li><a href="/about">about</a></li>
         <li><a href="/updates">updates</a></li>

--- a/_includes/base.njk
+++ b/_includes/base.njk
@@ -18,16 +18,16 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
     <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;700&display=swap" rel="stylesheet"/>
     <link href="/prism-atom-dark.css" rel="stylesheet"/>
-    <link rel="icon" href="/assets/favicon.svg" type="image/svg+xml"/>
-    <link rel="alternate icon" href="/favicon.ico"/>
-    <link rel="apple-touch-icon" href="/apple-touch-icon.png"/>
+    <link rel="icon" href="https://assets.dynamical.org/identity/logo/favicon/favicon.svg" type="image/svg+xml"/>
+    <link rel="alternate icon" href="https://assets.dynamical.org/identity/logo/favicon/favicon.ico"/>
+    <link rel="apple-touch-icon" href="https://assets.dynamical.org/identity/logo/favicon/apple-touch-icon.png"/>
     <link rel="alternate" href="/feed/feed.xml" type="application/atom+xml" title="{{ metadata.title }}"/>
     <link rel="alternate" href="/feed/feed.json" type="application/json" title="{{ metadata.title }}"/>
   </head>
   <body>
     <nav aria-label="Primary">
       <ul>
-        <li><a href="/" class="nav-lockup"><picture><source srcset="/assets/lockup-white.svg" media="(prefers-color-scheme: dark)"><img src="/assets/lockup.svg" alt="dynamical.org" height="32"></picture></a></li>
+        <li><a href="/" class="nav-lockup"><picture><source srcset="https://assets.dynamical.org/identity/logo/lockup/lockup-white.svg" media="(prefers-color-scheme: dark)"><img src="https://assets.dynamical.org/identity/logo/lockup/lockup-black.svg" alt="dynamical.org" height="32"></picture></a></li>
         <li><a href="/catalog">catalog</a></li>
         <li><a href="/about">about</a></li>
         <li><a href="/updates">updates</a></li>

--- a/public/main.css
+++ b/public/main.css
@@ -444,7 +444,7 @@ nav ul li:first-child {
 
 .nav-lockup img {
   display: block;
-  height: 24px;
+  height: 30px;
   width: auto;
 }
 


### PR DESCRIPTION
## Summary

- Swap vendored favicon / apple-touch-icon / lockup paths for the R2-hosted equivalents at `https://assets.dynamical.org/identity/logo/...`
- Canonical source is [dynamical-org/brand](https://github.com/dynamical-org/brand); every push to its `main` re-syncs the assets to R2, so brand updates land here automatically — no vendor sync dance.

## What changed

`_includes/base.njk`:

| Element | Before | After |
|---|---|---|
| favicon SVG | \`/assets/favicon.svg\` | \`https://assets.dynamical.org/identity/logo/favicon/favicon.svg\` |
| favicon.ico | \`/favicon.ico\` | \`https://assets.dynamical.org/identity/logo/favicon/favicon.ico\` |
| apple-touch-icon | \`/apple-touch-icon.png\` | \`https://assets.dynamical.org/identity/logo/favicon/apple-touch-icon.png\` |
| nav lockup | \`/assets/lockup{,-white}.svg\` | \`https://assets.dynamical.org/identity/logo/lockup/lockup-{black,white}.svg\` |

The lockup also picks up a small spacing refinement from the brand repo (icon→wordmark gap widened from 4 → 5 grid blocks) which makes it read better at the nav's 32px height.

## Follow-up (not in this PR)

Once prod confirms the hosted URLs render correctly, delete the now-unused vendored files:

- \`public/assets/favicon.svg\`
- \`public/favicon.ico\`
- \`public/apple-touch-icon.png\`
- \`public/assets/lockup.svg\`
- \`public/assets/lockup-white.svg\`

## Test plan

- [ ] Preview deploy: favicon renders in browser tabs (light + dark OS theme)
- [ ] Preview deploy: nav lockup renders at 32px, no layout shift
- [ ] Preview deploy: apple-touch-icon serves (curl or iOS "Add to Home Screen")
- [ ] No CSP or CORS errors in the console