### PR TITLE
catalog: derive entries from STAC root catalog

### DIFF
--- a/_data/catalog.js
+++ b/_data/catalog.js
@@ -1,98 +1,18 @@
 const fetch = require("@11ty/eleventy-fetch");
 
-const CC_BY_4 = `
-        <p>
-        Dataset licensed under <a href="https://creativecommons.org/licenses/by/4.0/">CC BY 4.0</a>.
-        </p>
-`;
-
-const ECMWF_LICENSE = `
-        <p>
-        This data is based on data and products of the European Centre for
-        Medium-Range Weather Forecasts (ECMWF). Use is governed by the
-        <a href="https://creativecommons.org/licenses/by/4.0/">CC BY 4.0</a> license
-        and the ECMWF <a href="https://apps.ecmwf.int/datasets/licences/general/">Terms of Use</a>.
-        </p>
-`;
-
-// Entries are minimal here — url (for slug derivation and the copyable input),
-// status (live / coming soon / deprecated), and license blurb. All prose
-// (descriptions, examples, per-model metadata) is fetched from STAC at build
-// time and merged in via reshapeStacCollection.
-let entries = [
-  {
-    url: "https://data.dynamical.org/noaa/gfs/analysis/latest.zarr",
-    status: "live",
-    license: CC_BY_4,
-  },
-  {
-    url: "https://data.dynamical.org/noaa/gfs/forecast/latest.zarr",
-    status: "live",
-    license: CC_BY_4,
-  },
-  {
-    url: "https://data.dynamical.org/noaa/gefs/forecast-35-day/latest.zarr",
-    status: "live",
-    license: CC_BY_4,
-  },
-  {
-    url: "https://data.dynamical.org/noaa/gefs/analysis/latest.zarr",
-    status: "live",
-    license: CC_BY_4,
-  },
-  {
-    url: "https://data.dynamical.org/noaa/hrrr/forecast-48-hour/latest.zarr",
-    status: "live",
-    license: CC_BY_4,
-  },
-  {
-    url: "https://data.dynamical.org/noaa/hrrr/analysis/latest.zarr",
-    status: "live",
-    license: CC_BY_4,
-  },
-  {
-    url: "https://data.dynamical.org/noaa/mrms/conus-analysis-hourly/latest.zarr",
-    status: "live",
-    license: CC_BY_4,
-  },
-  {
-    url: "https://data.dynamical.org/ecmwf/aifs-single/forecast/latest.zarr",
-    status: "live",
-    license: ECMWF_LICENSE,
-  },
-  {
-    url: "https://data.dynamical.org/ecmwf/ifs-ens/forecast-15-day-0-25-degree/latest.zarr",
-    status: "live",
-    license: ECMWF_LICENSE,
-  },
-].filter((entry) => !entry.hide);
-
 const STAC_BASE_URL = process.env.STAC_BASE_URL || "https://stac.dynamical.org";
 
 module.exports = async function () {
-  for (const entry of entries) {
-    if (!entry.url) continue;
+  const rootCatalog = await fetch(`${STAC_BASE_URL}/catalog.json`, { type: "json" });
+  const childLinks = (rootCatalog.links || []).filter((l) => l.rel === "child");
 
-    const slug = stacSlugFromUrl(entry.url);
-    try {
-      const collection = await fetchStacCollection(slug);
-      Object.assign(entry, reshapeStacCollection(collection));
-    } catch (e) {
-      // Tolerate only 404 (dataset not yet ingested into STAC). Any other
-      // failure — network, 5xx, malformed JSON — should fail the build
-      // rather than silently publish a page missing its metadata tables.
-      if (e.cause?.status !== 404) throw e;
-      console.log(`No STAC collection for ${slug}: ${e.message}`);
-      entry.dataset_id = entry.dataset_id || slug;
-      entry.name = entry.name || slug;
-    }
-  }
+  const entries = await Promise.all(
+    childLinks.map(async (link) => {
+      const collection = await fetch(link.href, { type: "json" });
+      return { status: "live", ...reshapeStacCollection(collection) };
+    }),
+  );
 
-  // Group datasets by model using STAC-provided model_id / model_name /
-  // description_model. For non-STAC entries (e.g. dwd-icon-eu), model_id
-  // comes from the inline hand-authored field and model_name / description_model
-  // are undefined — matching prior behavior where the dwd-icon-eu row in the
-  // catalog table renders with an empty model cell.
   const modelGroups = {};
   entries.forEach((entry) => {
     if (!entry.model_id) return;
@@ -112,16 +32,6 @@ module.exports = async function () {
     models: Object.values(modelGroups),
   };
 };
-
-// e.g. https://data.dynamical.org/noaa/gfs/analysis/latest.zarr → noaa-gfs-analysis
-function stacSlugFromUrl(url) {
-  const path = new URL(url).pathname.replace(/^\/+|\/+$/g, "");
-  return path.replace(/\/[^/]+\.zarr$/, "").split("/").join("-");
-}
-
-function fetchStacCollection(slug) {
-  return fetch(`${STAC_BASE_URL}/${slug}/collection.json`, { type: "json" });
-}
 
 function licenseMd(licenseLinks) {
   if (!licenseLinks || licenseLinks.length === 0) return "";

--- a/content/catalog-pages.njk
+++ b/content/catalog-pages.njk
@@ -176,7 +176,7 @@ eleventyComputed:
   </p>
   <h2>Details</h2>
     <h3>License</h3>
-    {{- entry.license | safe }}
+    {{ entry.license_md | markdown | safe }}
 
     <h3>Attribution and citation</h3>
     <p><i>{{ entry.attribution }}</i></p>


### PR DESCRIPTION
## Summary

- Drop the hand-maintained `entries[]` array in `_data/catalog.js` — iterate `links[rel=child]` on the STAC root catalog instead. Adding a dataset to the website is now a pure STAC operation.
- Drop inline `CC_BY_4` / `ECMWF_LICENSE` HTML blurbs; render `license_md` (built from STAC `links[rel=license]`) through the markdown filter on the catalog page.
- Status is hardcoded `"live"` for every entry; ordering follows the STAC root catalog's child-link order.

Side effect: `dwd-icon-eu-forecast-5-day` shows up on the site (it was removed in #76 when its STAC collection didn't yet exist; the inline re-add was what motivated this cleanup).

### Output diff vs. main

- NOAA / DWD pages: identical except whitespace (`<p>...</p>` no longer wrapped across three hand-authored lines).
- ECMWF pages: license sentence shortens from the prior _"This data is based on data and products of ECMWF. Use is governed by the CC BY 4.0 license and the ECMWF Terms of Use."_ to _"Dataset licensed under CC BY 4.0 and ECMWF Terms of Use."_ — the STAC license links carry URLs/titles but not framing. If the longer text matters, push it upstream into the STAC collection.
- Catalog index ordering: DWD ICON-EU now appears last (newest STAC child link) rather than between MRMS and AIFS. Reorder upstream in `dynamical-stac` if needed.

## Test plan

- [ ] `npm run build` succeeds
- [ ] `/catalog/` lists all 10 datasets including DWD ICON-EU
- [ ] `/catalog/dwd-icon-eu-forecast-5-day/` renders with prose, dimensions, variables, license
- [ ] ECMWF pages show the dual-license sentence with both links