### PR TITLE
Support multiple notebooks per catalog entry (forward-compat)

### DIFF
--- a/_data/catalog.js
+++ b/_data/catalog.js
@@ -8,7 +8,10 @@ module.exports = async function () {
 
   const entries = await Promise.all(
     childLinks.map(async (link) => {
-      const collection = await fetch(link.href, { type: "json" });
+      // Child links are absolute (stac.dynamical.org). Rewrite to STAC_BASE_URL
+      // so local builds can point at a locally-served stac/ tree.
+      const href = link.href.replace("https://stac.dynamical.org", STAC_BASE_URL);
+      const collection = await fetch(href, { type: "json" });
       return { status: "live", ...reshapeStacCollection(collection) };
     }),
   );
@@ -72,9 +75,7 @@ function reshapeStacCollection(collection) {
     return Array.isArray(value) ? value[0] : value;
   };
 
-  const exampleLinks = (collection.links || []).filter((l) => l.rel === "example");
-  const githubUrl = exampleLinks.find((l) => l.type === "application/x-ipynb+json")?.href;
-  const colabUrl = exampleLinks.find((l) => l.type === "text/html")?.href;
+  const notebooks = parseNotebooks(collection.links);
 
   const licenseLinks = (collection.links || []).filter((l) => l.rel === "license");
 
@@ -98,7 +99,36 @@ function reshapeStacCollection(collection) {
     forecast_resolution: summaryValue("forecast_resolution"),
     dimensions,
     variables,
-    githubUrl,
-    colabUrl,
+    notebooks,
   };
+}
+
+// Pair `rel:example` links into notebooks by the `{slug}.ipynb` filename
+// they share. Each notebook ends up with a github (ipynb json) URL and a
+// colab (html) URL. Backward-compatible with STAC output that emits a single
+// pair per dataset.
+function parseNotebooks(links) {
+  const examples = (links || []).filter((l) => l.rel === "example");
+  const order = [];
+  const bySlug = {};
+  for (const link of examples) {
+    const match = link.href.match(/([^/]+)\.ipynb(?:$|\?|#)/);
+    if (!match) continue;
+    const slug = match[1];
+    if (!bySlug[slug]) {
+      order.push(slug);
+      const title = (link.title || "")
+        .replace(/\s*\((?:GitHub|Colab)\)\s*$/i, "")
+        .trim();
+      bySlug[slug] = { slug, title: title || slug };
+    }
+    if (link.type === "application/x-ipynb+json") {
+      bySlug[slug].githubUrl = link.href;
+    } else if (link.type === "text/html") {
+      bySlug[slug].colabUrl = link.href;
+    }
+  }
+  return order
+    .map((slug) => bySlug[slug])
+    .filter((nb) => nb.githubUrl && nb.colabUrl);
 }

--- a/_data/catalog.js
+++ b/_data/catalog.js
@@ -8,9 +8,12 @@ module.exports = async function () {
 
   const entries = await Promise.all(
     childLinks.map(async (link) => {
-      // Child links are absolute (stac.dynamical.org). Rewrite to STAC_BASE_URL
-      // so local builds can point at a locally-served stac/ tree.
-      const href = link.href.replace("https://stac.dynamical.org", STAC_BASE_URL);
+      // Child links are absolute (stac.dynamical.org). When STAC_BASE_URL is
+      // set explicitly, rewrite them to it so local builds can point at a
+      // locally-served stac/ tree. Otherwise pass the href through untouched.
+      const href = process.env.STAC_BASE_URL
+        ? link.href.replace("https://stac.dynamical.org", process.env.STAC_BASE_URL)
+        : link.href;
       const collection = await fetch(href, { type: "json" });
       return { status: "live", ...reshapeStacCollection(collection) };
     }),

--- a/content/aws-open-data-registry.njk
+++ b/content/aws-open-data-registry.njk
@@ -5,7 +5,12 @@ pagination:
   size: 1
 permalink: 'aws/dynamical-{{model.id}}.yaml'
 ---
-{%- set entries = model.datasets | selectattr('githubUrl') | list -%}
+{%- set entries = [] -%}
+{%- for dataset in model.datasets -%}
+  {%- if dataset.notebooks.length -%}
+    {%- set _ = entries.push(dataset) -%}
+  {%- endif -%}
+{%- endfor -%}
 {%- set bucket = "dynamical-" ~ model.id -%}
 Name: {{model.name}} - dynamical.org Icechunk Zarr
 Description: |
@@ -43,11 +48,13 @@ Resources:
 DataAtWork:
   Tutorials:
     {%- for entry in entries %}
-    - Title: {{entry.name}} python quickstart notebook
-      URL: {{entry.githubUrl}}
-      NotebookURL: {{entry.githubUrl}}
+      {%- for notebook in entry.notebooks %}
+    - Title: "{{ entry.name }} — {{ notebook.title }}"
+      URL: {{ notebook.githubUrl }}
+      NotebookURL: {{ notebook.githubUrl }}
       AuthorName: dynamical.org
       AuthorURL: https://dynamical.org
+      {%- endfor %}
     {%- endfor %}
 ADXCategories:
   - Environmental Data

--- a/content/catalog-pages.njk
+++ b/content/catalog-pages.njk
@@ -88,24 +88,22 @@ eleventyComputed:
   {% endif %}
   <h2>Examples</h2>
   <table>
-    {% if entry.githubUrl %}
+    {% for notebook in entry.notebooks %}
       <tr>
         <td style="text-align: center"><img src="/assets/github-mark.svg" height="18"/>
         </td>
         <td>
-          <a href="{{ entry.githubUrl }}">Open notebook in github</a>
+          <a href="{{ notebook.githubUrl }}">{{ notebook.title }} (Github)</a>
         </td>
       </tr>
-    {% endif %}
-    {% if entry.colabUrl %}
       <tr>
         <td style="text-align: center;"><img src="/assets/colab.svg" height="18"/>
         </td>
         <td>
-          <a href="{{ entry.colabUrl }}">Open notebook in colab</a>
+          <a href="{{ notebook.colabUrl }}">{{ notebook.title }} (Colab)</a>
         </td>
       </tr>
-    {% endif %}
+    {% endfor %}
   </table>
   {% for example in entry.examples %}
     <div class="frame">

--- a/content/earthmover-readmes.njk
+++ b/content/earthmover-readmes.njk
@@ -3,8 +3,6 @@ pagination:
   data: catalog.entries
   alias: entry
   size: 1
-  filter:
-    entry.githubUrl
 permalink: 'earthmover/{{entry.dataset_id}}.md'
 ---
 {%- set model = catalog.models | find('id', entry.model_id) -%}
@@ -28,11 +26,13 @@ permalink: 'earthmover/{{entry.dataset_id}}.md'
 
 _Don't see what you're looking for or have a question? Contact feedback@dynamical.org._
 
-{% if entry.githubUrl %}
+{% if entry.notebooks.length %}
 ## Examples
 
-* [Open notebook in github]({{ entry.githubUrl }})
-* [Open notebook in colab]({{ entry.colabUrl }})
+{% for notebook in entry.notebooks -%}
+* [{{ notebook.title }} (Github)]({{ notebook.githubUrl }})
+* [{{ notebook.title }} (Colab)]({{ notebook.colabUrl }})
+{% endfor %}
 {% endif %}
 
 ## Dimensions


### PR DESCRIPTION
## Summary

- `_data/catalog.js` now exposes an `entry.notebooks` list (paired by `.ipynb` filename in `rel:example` links) instead of singular `githubUrl`/`colabUrl`.
- Catalog page, AWS Open Data Registry yaml, and Earthmover readme iterate the list; labels become `{Title} (Github)` / `{Title} (Colab)`.
- AWS tutorial `Title:` values are quoted so colons in notebook titles (e.g. `Heating degree days: GFS vs AIFS`) don't break yaml parsing.
- `STAC_BASE_URL` is substituted for absolute `https://stac.dynamical.org` hrefs in child links so local builds can point at a locally-served `stac/` tree.

This is the forward-compat half of dynamical-org/meta#84. Merging has no visible change against the current single-notebook STAC — the notebooks list has one element per dataset. Once the matching dynamical-stac update ships, additional notebooks (e.g. the cross-model GFS + AIFS HDD notebook) will render in all three places automatically.

## Test plan

- [x] Merge and watch Cloudflare Pages auto-deploy succeed
- [x] Spot-check `https://dynamical.org/catalog/noaa-gfs-forecast/` — Examples section should show `Quickstart (Github)` / `Quickstart (Colab)` (a relabeling, no link-count change)
- [x] Spot-check `https://dynamical.org/aws/dynamical-noaa-gfs.yaml` parses as yaml
- [ ] After the dynamical-stac release, re-check the same pages for the second notebook entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)