### PR TITLE
updates: add 2026-04-24

### DIFF
--- a/content/updates/2026-04-24.md
+++ b/content/updates/2026-04-24.md
@@ -7,7 +7,7 @@ Listen, my second child is arriving any minute now. This transmission will be br
 
 ## Zarr v2 deprecation
 
-We're all-in on Icechunk. Our existing Zarr v2 datasets will continue updating for 90 days, at which point we will sunset them. Consider them deprecated and update to the new access pattern.
+We're all-in on Icechunk. Our existing Zarr v2 datasets will continue updating for 90 days, at which point we will sunset them. Consider them deprecated and **update to the new access pattern by July 23, 2026**.
 
 
 ## Speaking of which

--- a/content/updates/2026-04-24.md
+++ b/content/updates/2026-04-24.md
@@ -38,7 +38,7 @@ ds = xr.open_zarr(store)
 
 ### Via STAC
 
-We are STAC-maxxers now. https://stac.dynamical.org/catalog.json hosts ALL of the data used to create our documentation and catalogs. Point your robots at it for all the documentation they need to get going. STAC-as-skill.
+We are STAC-maxxers now. https://stac.dynamical.org/catalog.json contains ALL of the data used to create our documentation and drive the dynamical-catalog library. Point your robots at it for all the documentation they need to get going. STAC-as-skill.
 
 
 ## ICON-EU

--- a/content/updates/2026-04-24.md
+++ b/content/updates/2026-04-24.md
@@ -49,7 +49,7 @@ What makes this one extra fun: as far as we can tell, **no other public archive 
 
 Huge thanks to:
 
-- [Jack Kelly](https://www.linkedin.com/in/jackkelly0/) and [Open Climate Fix](https://openclimatefix.org/) for getting this off the ground and hoarding forecasts to kickstart the archive
+- [Jack Kelly](https://www.linkedin.com/in/jackkelly0/) from [Open Climate Fix](https://openclimatefix.org/) for getting this off the ground and hoarding forecasts to kickstart the archive and to the [Patrick J McGovern Foundation](https://www.mcgovern.org/) for supporting their work.
 - The [DWD Open Data](https://www.dwd.de/EN/ourservices/opendata/opendata.html) program
 - [Source Cooperative](https://source.coop/) for hosting the upstream grib archive
 - AWS Open Data for the Icechunk storage

--- a/content/updates/2026-04-24.md
+++ b/content/updates/2026-04-24.md
@@ -5,7 +5,7 @@ date: 2026-04-24
 
 Listen, my second child is arriving any minute now. This transmission will be brief. I haven't decided if I will name him Poseidon, Gefs, or Turbulence.
 
-## Zarr v2 deprecation
+## Zarr v3 deprecation
 
 We're all-in on Icechunk. Our existing Zarr v2 datasets will continue updating for 90 days, at which point we will sunset them. Consider them deprecated and **update by July 23, 2026**.
 

--- a/content/updates/2026-04-24.md
+++ b/content/updates/2026-04-24.md
@@ -7,7 +7,7 @@ Listen, my second child is arriving any minute now. This transmission will be br
 
 ## Zarr v2 deprecation
 
-We're all-in on Icechunk. Our existing Zarr v2 datasets will continue updating for 90 days, at which point we will sunset them. Consider them deprecated and **update to the new access pattern by July 23, 2026**.
+We're all-in on Icechunk. Our existing Zarr v2 datasets will continue updating for 90 days, at which point we will sunset them. Consider them deprecated and **update by July 23, 2026**.
 
 
 ## Speaking of which
@@ -60,6 +60,7 @@ Find it at:
 - [AWS Registry](https://registry.opendata.aws/dynamical-dwd-icon-eu/)
 - [Earthmover Marketplace](https://app.earthmover.io/marketplace/69eae67968ef2387158671a1)
 - [Source Coop](https://source.coop/dynamical/dwd-icon-eu-forecast-5-day)
+- [The over-the-top release vid](https://www.youtube.com/watch?v=5iVzJ35Ojfk)
 
 ---
 

--- a/content/updates/2026-04-24.md
+++ b/content/updates/2026-04-24.md
@@ -1,0 +1,68 @@
+---
+title: "Time 2 Chunk (2.0), DWD ICON-EU, status for weather"
+date: 2026-04-24
+---
+
+Listen, my second child is arriving any minute now. This transmission will be brief. I haven't decided if I will name him Poseidon, Gefs, or Turbulence.
+
+## Zarr v2 deprecation
+
+We're all-in on Icechunk. Our existing Zarr v2 datasets will continue updating for 90 days, at which point we will sunset them. Consider them deprecated and update to the new access pattern.
+
+
+## Speaking of which
+
+The new access pattern:
+
+### Via dynamical-catalog
+
+```python
+import dynamical_catalog
+
+# Open a dataset as an xarray Dataset via its Icechunk repository
+ds = dynamical_catalog.open("noaa-gfs-forecast")
+
+# List all available datasets
+dynamical_catalog.list()
+```
+
+To more easily ensure the right set of dependencies and to make an increasingly variable set of opening incantations more accessible, we made a python library to list and open datasets.
+
+```python
+import dynamical_catalog
+
+# Get the underlying Zarr store if you want even more control
+store = dynamical_catalog.get_store("noaa-gfs-forecast")
+ds = xr.open_zarr(store)
+```
+
+### Via STAC
+
+We are STAC-maxxers now. https://stac.dynamical.org/catalog.json hosts ALL of the data used to create our documentation and catalogs. Point your robots at it for all the documentation they need to get going. STAC-as-skill.
+
+
+## ICON-EU
+
+Deutscher Wetterdienst's [ICON-EU](https://dynamical.org/catalog/dwd-icon-eu-forecast-5-day/) is now a cloud-optimized, live-updating Icechunk 2.0 Zarr. High-resolution 5-day forecasts over Europe, nested from DWD's global ICON model, at the 00/06/12/18 UTC cycles.
+
+What makes this one extra fun: as far as we can tell, **no other public archive of ICON-EU exists**. DWD only keeps a short rolling window on their own servers, so we'll keep growing the archive from here.
+
+Huge thanks to:
+
+- [Jack Kelly](https://www.linkedin.com/in/jackkelly0/) and [Open Climate Fix](https://openclimatefix.org/) for getting this off the ground and hoarding forecasts to kickstart the archive
+- The [DWD Open Data](https://www.dwd.de/EN/ourservices/opendata/opendata.html) program
+- [Source Cooperative](https://source.coop/) for hosting the upstream grib archive
+- AWS Open Data for the Icechunk storage
+
+Find it at:
+
+- [Docs](https://dynamical.org/catalog/dwd-icon-eu-forecast-5-day/)
+- [AWS Registry](https://registry.opendata.aws/dynamical-dwd-icon-eu/)
+- [Earthmover Marketplace](https://app.earthmover.io/marketplace/69eae67968ef2387158671a1)
+- [Source Coop](https://source.coop/dynamical/dwd-icon-eu-forecast-5-day)
+
+---
+
+Enjoy the [weather](https://www.youtube.com/watch?v=CEeCziXT2FE),
+
+MM

--- a/content/updates/2026-04-24.md
+++ b/content/updates/2026-04-24.md
@@ -21,15 +21,15 @@ import dynamical_catalog
 
 # Open a dataset as an xarray Dataset via its Icechunk repository
 ds = dynamical_catalog.open("noaa-gfs-forecast")
-
-# List all available datasets
-dynamical_catalog.list()
 ```
 
 To more easily ensure the right set of dependencies and to make an increasingly variable set of opening incantations more accessible, we made a python library to list and open datasets.
 
 ```python
 import dynamical_catalog
+
+# List all available datasets
+dynamical_catalog.list()
 
 # Get the underlying Zarr store if you want even more control
 store = dynamical_catalog.get_store("noaa-gfs-forecast")


### PR DESCRIPTION
## Summary
- Add the 2026-04-24 update post covering Zarr v2 deprecation, the new `dynamical-catalog` + STAC access patterns, the DWD ICON-EU launch, and a short status note.

## Test plan
- [ ] `npm start` and visit `/updates/2026-04-24/` — verify rendering, links, thumbnail, and both code blocks
- [ ] Confirm the four ICON-EU links (Docs, AWS Registry, Earthmover Marketplace, Source Coop) resolve