### PR TITLE
Adjust TOC rail breakpoint from 1180px to 1320px

### DIFF
--- a/lib/markdown-toc.js
+++ b/lib/markdown-toc.js
@@ -162,8 +162,13 @@ const CSS = `
 /* Narrow viewports: rail collapses out of the left margin and renders
    in document flow. No indicator — once scrolled past, the TOC is off-
    screen and scroll-spy is useless. The full H2/H3 tree renders
-   statically so the reader gets an upfront map of the report. */
-@media (max-width: 1180px) {
+   statically so the reader gets an upfront map of the report.
+   Breakpoint matches the smallest viewport that fits .content's 78rem
+   column plus 26rem (rail width + gap) on each side, with a little
+   breathing room — anything narrower and the rail clips off the left
+   edge. At the site's 1rem = 10px scale that's 78rem + 52rem = 1300px;
+   the extra 20px is the breathing margin. */
+@media (max-width: 1320px) {
   .md-toc-rail {
     position: static;
     width: auto;


### PR DESCRIPTION
## Summary
Updated the responsive design breakpoint for the table of contents (TOC) rail from 1180px to 1320px to better accommodate the site's layout at the 1rem = 10px scale.

## Changes
- Changed `@media (max-width: 1180px)` to `@media (max-width: 1320px)` in the markdown-toc CSS
- Expanded the comment documentation to explain the breakpoint calculation:
  - `.content` column width: 78rem
  - Rail width + gap on each side: 26rem each
  - Total: 78rem + 52rem = 1300px
  - Added 20px breathing margin for a final breakpoint of 1320px

## Details
The new breakpoint ensures the TOC rail doesn't clip off the left edge on narrower viewports. The calculation accounts for the site's specific layout dimensions and provides adequate spacing before the rail collapses into document flow on smaller screens.

https://claude.ai/code/session_011UVpQFBrT59sXrgdguxuF7