### PR TITLE
Add dynamical.org products to status page with source/agency filters

### DIFF
--- a/_data/wxopticon.js
+++ b/_data/wxopticon.js
@@ -13,10 +13,48 @@ const DISPLAY_NAMES = {
   "noaa-hrrr-aws": "NOAA HRRR 48h",
   "noaa-hrrr-ftp": "NOAA HRRR 48h",
   "ecmwf-aifs-aws": "ECMWF AIFS Single",
+  "ecmwf-aifs-ens-aws": "ECMWF AIFS ENS",
   "ecmwf-ifs-ens-long-aws": "ECMWF IFS ENS 15-day",
   "ecmwf-ifs-ens-short-aws": "ECMWF IFS ENS 6-day",
   "dwd-icon-eu": "DWD ICON-EU 5-day",
+  // dynamical.org derived products (Icechunk stores).
+  "dynamical-noaa-gfs-forecast": "NOAA GFS",
+  "dynamical-noaa-gefs-forecast-35-day": "NOAA GEFS 35-day",
+  "dynamical-noaa-hrrr-forecast-48-hour": "NOAA HRRR 48h",
+  "dynamical-ecmwf-aifs-single-forecast": "ECMWF AIFS Single",
+  "dynamical-ecmwf-aifs-ens-forecast": "ECMWF AIFS ENS",
+  "dynamical-ecmwf-ifs-ens-forecast-15-day-0-25-degree": "ECMWF IFS ENS 15-day",
+  "dynamical-dwd-icon-eu-forecast-5-day": "DWD ICON-EU 5-day",
 };
+
+// "dynamical.org" = our published Icechunk catalog products (id prefixed
+// `dynamical-`); everything else is the upstream "Source" track.
+function trackOf(id) {
+  return id.startsWith("dynamical-") ? "dynamical" : "source";
+}
+
+// Derive the issuing agency from the id, ignoring the `dynamical-` prefix so
+// a derived product classifies the same as its upstream source.
+function agencyOf(id) {
+  const base = id.replace(/^dynamical-/, "");
+  if (/noaa|gfs|gefs|hrrr/.test(base)) return "NOAA";
+  if (/ecmwf|aifs|ifs/.test(base)) return "ECMWF";
+  if (/dwd|icon/.test(base)) return "DWD";
+  return null;
+}
+
+// Where the row's data comes from: our Icechunk catalog ("dynamical.org") for
+// derived products, or the upstream host for sources.
+function originOf(id) {
+  if (id.startsWith("dynamical-")) return "dynamical.org";
+  if (id.endsWith("-aws")) return "AWS";
+  if (id.endsWith("-ftp")) return "NOMADS";
+  if (id.startsWith("dwd-")) return "DWD";
+  return null;
+}
+
+// Order origins shown in the filter (and used as the row's left-column label).
+const ORIGIN_ORDER = ["dynamical.org", "AWS", "NOMADS", "DWD"];
 
 module.exports = async function () {
   const summary = await fetch(
@@ -27,8 +65,10 @@ module.exports = async function () {
   const products = summary.products.map((p) => ({
     id: p.id,
     label: DISPLAY_NAMES[p.id] ?? p.label ?? p.id,
+    track: trackOf(p.id),
+    agency: agencyOf(p.id),
+    origin: originOf(p.id),
     source: p.source,
-    source_label: p.id.endsWith("-aws") ? "AWS" : p.id.endsWith("-ftp") ? "NOMADS" : p.id.startsWith("dwd-") ? "DWD" : null,
     cadence_hours: p.cadence_hours,
     init_hours: [...new Set(p.recent_inits.map((i) => i.init_time.slice(11, 13)))].sort(),
     recent_init_count: Math.min(p.recent_inits.length, RECENT_INIT_COUNT),
@@ -55,8 +95,32 @@ module.exports = async function () {
     })(),
   }));
 
+  // Group rows by model (their shared display label). Within a group the
+  // dynamical.org row leads, then its upstream Source row(s). Groups with a
+  // dynamical.org product sort ahead of source-only models; both otherwise
+  // preserve first-appearance order from the summary (which clusters by
+  // agency). Map iteration + stable sort keep that order intact.
+  const byModel = new Map();
+  for (const p of products) {
+    if (!byModel.has(p.label)) byModel.set(p.label, []);
+    byModel.get(p.label).push(p);
+  }
+  const groups = [...byModel.entries()].map(([model, items]) => {
+    items.sort((a, b) => (a.track === b.track ? 0 : a.track === "dynamical" ? -1 : 1));
+    return {
+      model,
+      hasDynamical: items.some((p) => p.track === "dynamical"),
+      products: items,
+    };
+  });
+  groups.sort((a, b) => (a.hasDynamical === b.hasDynamical ? 0 : a.hasDynamical ? -1 : 1));
+
+  // Distinct origins present, in display order — drives the Source filter.
+  const origins = ORIGIN_ORDER.filter((o) => products.some((p) => p.origin === o));
+
   return {
-    products,
+    groups,
+    origins,
     window_days: summary.window_days,
   };
 };

--- a/_data/wxopticon.js
+++ b/_data/wxopticon.js
@@ -1,4 +1,5 @@
 const fetch = require("@11ty/eleventy-fetch");
+const markdownToc = require("../lib/markdown-toc.js");
 
 // Keep in sync with RECENT_INIT_COUNT in public/wxopticon.js
 const RECENT_INIT_COUNT = 10;
@@ -109,6 +110,8 @@ module.exports = async function () {
     items.sort((a, b) => (a.track === b.track ? 0 : a.track === "dynamical" ? -1 : 1));
     return {
       model,
+      // Anchor target for the table-of-contents link / group heading id.
+      slug: markdownToc.slugify(model),
       hasDynamical: items.some((p) => p.track === "dynamical"),
       products: items,
     };
@@ -118,9 +121,18 @@ module.exports = async function () {
   // Distinct origins present, in display order — drives the Source filter.
   const origins = ORIGIN_ORDER.filter((o) => products.some((p) => p.origin === o));
 
+  // Scroll-spy TOC of the model groups, reusing the same builder/CSS/JS as
+  // the validation report pages so the rail looks and behaves identically.
+  const tocHtml = markdownToc.buildTocHtml(
+    groups.map((g) => ({ level: 2, slug: g.slug, title: g.model })),
+  );
+
   return {
     groups,
     origins,
     window_days: summary.window_days,
+    tocHtml,
+    tocCss: markdownToc.CSS,
+    tocJs: markdownToc.JS,
   };
 };

--- a/content/wxopticon.njk
+++ b/content/wxopticon.njk
@@ -46,12 +46,29 @@ permalink: /status/
       </div>
     </div>
 
-    {% for product in wxopticon.products %}
-    <section class="status-row" data-product-id="{{ product.id }}">
+    <div class="status-filters">
+      <fieldset>
+        <legend>Source</legend>
+        {% for origin in wxopticon.origins %}
+        <label><input type="checkbox" name="source" value="{{ origin }}" checked> {{ origin }}</label>
+        {% endfor %}
+      </fieldset>
+      <fieldset>
+        <legend>Agency</legend>
+        <label><input type="checkbox" name="agency" value="NOAA" checked> NOAA</label>
+        <label><input type="checkbox" name="agency" value="ECMWF" checked> ECMWF</label>
+        <label><input type="checkbox" name="agency" value="DWD" checked> DWD</label>
+      </fieldset>
+    </div>
+
+    {% for group in wxopticon.groups %}
+    <section class="status-group">
+      <h2 class="status-group-heading">{{ group.model }}</h2>
+      {% for product in group.products %}
+      <section class="status-row" data-product-id="{{ product.id }}" data-origin="{{ product.origin }}" data-agency="{{ product.agency }}">
       <div>
-        <strong>{{ product.label }}</strong>
+        <strong>{{ product.origin }}</strong>
         <div style="font-size:1.2rem;">
-          {% if product.source_label %}<div>{{ product.source_label }}</div>{% endif %}
           <div>{{ product.source }}</div>
           <div>{{ product.cadence_hours }}h init cadence</div>
           <div>{{ product.init_hours | join('/') }}z</div>
@@ -77,6 +94,9 @@ permalink: /status/
         </div>
       </div>
       <div class="status-stats">
+        {% if product.track == 'dynamical' %}
+        <div class="status-ingestion-lag" data-slot="ingestion-lag" hidden></div>
+        {% endif %}
         <div class="status-eta" data-slot="eta">
           <strong data-slot="eta-init">—</strong>
           <span data-slot="eta-state" hidden></span>
@@ -87,8 +107,12 @@ permalink: /status/
         </div>
       </div>
       <div id="row-details-{{ product.id }}" class="status-row-details" data-slot="row-details" hidden></div>
+      </section>
+      {% endfor %}
     </section>
     {% endfor %}
+
+    <p data-slot="filter-empty" hidden>No products match the current filters.</p>
 
     <footer class="status-footer">
       <div>Updated <span data-slot="generated-at">—</span></div>

--- a/content/wxopticon.njk
+++ b/content/wxopticon.njk
@@ -4,7 +4,10 @@ title: status
 permalink: /status/
 ---
 
-<div class="content">
+<div class="content md-toc-content">
+  <div class="md-toc-rail">
+    <nav class="md-toc" aria-label="Models">{{ wxopticon.tocHtml | safe }}</nav>
+  </div>
   <main id="status-app">
     <div class="status-ribbon" data-slot="ribbon" hidden>
       Backend data is more than 10 minutes old — it may be stalled.
@@ -63,7 +66,7 @@ permalink: /status/
 
     {% for group in wxopticon.groups %}
     <section class="status-group">
-      <h2 class="status-group-heading">{{ group.model }}</h2>
+      <h2 class="status-group-heading" id="{{ group.slug }}">{{ group.model }}</h2>
       {% for product in group.products %}
       <section class="status-row" data-product-id="{{ product.id }}" data-origin="{{ product.origin }}" data-agency="{{ product.agency }}">
       <div>
@@ -119,6 +122,8 @@ permalink: /status/
       <div>{{ wxopticon.window_days }}-day rolling window · polls every 15s</div>
     </footer>
   </main>
+  <style>{{ wxopticon.tocCss | safe }}</style>
+  <script>{{ wxopticon.tocJs | safe }}</script>
 </div>
 
 <script src="/wxopticon.js?v={{ 'public/wxopticon.js' | fileHash }}" defer></script>

--- a/lib/markdown-toc.js
+++ b/lib/markdown-toc.js
@@ -222,14 +222,21 @@ const JS = String.raw`
 
   function update() {
     var line = window.innerHeight * 0.3;
-    var activeId = headings[0].id;
+    var activeId = null;
     for (var i = 0; i < headings.length; i++) {
+      // Skip headings that aren't rendered (e.g. a section hidden by a
+      // page filter): offsetParent is null for display:none elements, and
+      // their bounding rect collapses to the top of the page, which would
+      // otherwise wrongly count them as "scrolled past".
+      if (headings[i].offsetParent === null) continue;
+      if (activeId === null) activeId = headings[i].id;
       if (headings[i].getBoundingClientRect().top <= line) {
         activeId = headings[i].id;
       } else {
         break;
       }
     }
+    if (activeId === null) return;
 
     for (var id in entriesById) {
       entriesById[id].link.classList.remove('active');
@@ -259,4 +266,4 @@ const JS = String.raw`
 })();
 `;
 
-module.exports = { annotateHeadings, buildTocHtml, CSS, JS };
+module.exports = { slugify, annotateHeadings, buildTocHtml, CSS, JS };

--- a/public/main.css
+++ b/public/main.css
@@ -757,6 +757,21 @@ article img {
 /* status page (/status/) */
 /* ------------------------------------------------------------------ */
 
+.status-group {
+  margin-top: 2.4rem;
+}
+
+.status-group:first-of-type {
+  margin-top: 0;
+}
+
+.status-group-heading {
+  font-size: 1.6rem;
+  margin: 0;
+  padding-bottom: 0.4rem;
+  border-bottom: 1px solid var(--text-color);
+}
+
 .status-row {
   display: grid;
   grid-template-columns: 19rem 1fr 16rem;
@@ -766,8 +781,16 @@ article img {
   align-items: start;
 }
 
-.status-row:first-of-type {
+/* First row in each group sits directly under the heading rule — no
+   double divider. */
+.status-group .status-row:first-of-type {
   border-top: none;
+}
+
+/* The author display:grid above outranks the UA [hidden] rule, so filtered
+   rows need an explicit override to actually hide. */
+.status-row[hidden] {
+  display: none;
 }
 
 .status-row-body {
@@ -1075,6 +1098,50 @@ body.status-time-local .t-utc {
   justify-content: flex-end;
   align-items: center;
   gap: 1.2rem;
+}
+
+.status-filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.6rem;
+  margin: 1.5rem 0;
+  font-size: 1.2rem;
+}
+
+.status-filters fieldset {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 1.2rem;
+  border: 1px solid var(--border-muted-color);
+  padding: 0.6rem 1rem;
+}
+
+.status-filters legend {
+  padding: 0 0.4rem;
+  color: var(--muted-text);
+}
+
+.status-filters label {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  white-space: nowrap;
+  cursor: pointer;
+}
+
+.status-ingestion-lag {
+  margin-bottom: 0.8rem;
+}
+
+.status-ingestion-lag strong {
+  display: block;
+  color: var(--text-color);
+}
+
+.status-ingestion-lag span {
+  display: block;
+  white-space: nowrap;
 }
 
 .status-ribbon:not([hidden]) {

--- a/public/wxopticon.js
+++ b/public/wxopticon.js
@@ -411,10 +411,9 @@
 
   // Ingestion lag = time from upstream-source publish completion to our
   // derived-product publish completion (the dynamical.org SLA metric). Only
-  // dynamical.org rows carry the [data-slot="ingestion-lag"] node. Below
-  // MIN_INGESTION_SAMPLES (or while percentiles are still null) we say
-  // "insufficient data" plainly rather than rendering "—".
-  const MIN_INGESTION_SAMPLES = 20;
+  // dynamical.org rows carry the [data-slot="ingestion-lag"] node. The backend
+  // nulls the percentiles until it has enough samples, so we trust that signal:
+  // null percentiles → "insufficient data" rather than rendering "—".
   function renderIngestionLag(slot, product) {
     const stats = product.ingestion_lag_stats;
     if (!stats) {
@@ -423,7 +422,7 @@
       return;
     }
     slot.hidden = false;
-    if (stats.sample_init_count < MIN_INGESTION_SAMPLES || stats.p50_s == null) {
+    if (stats.p50_s == null) {
       slot.replaceChildren(
         el("strong", null, "ingestion lag"),
         el("span", null, "insufficient data")

--- a/public/wxopticon.js
+++ b/public/wxopticon.js
@@ -123,6 +123,14 @@
         if (show) groupVisible++;
       }
       group.hidden = groupVisible === 0;
+      // Keep the TOC rail in sync: drop the link for a group that's been
+      // fully filtered out so the contents only list visible models.
+      const heading = group.querySelector(".status-group-heading");
+      if (heading && heading.id) {
+        const tocLink = document.querySelector('.md-toc a[href="#' + heading.id + '"]');
+        const tocItem = tocLink && tocLink.closest("li");
+        if (tocItem) tocItem.hidden = group.hidden;
+      }
       visible += groupVisible;
     }
     if (filterEmptySlot) filterEmptySlot.hidden = visible > 0;

--- a/public/wxopticon.js
+++ b/public/wxopticon.js
@@ -36,6 +36,11 @@
   const ribbonSlot = app.querySelector('[data-slot="ribbon"]');
   const returnLiveBtn = app.querySelector('[data-slot="return-live"]');
 
+  const sourceInputs = app.querySelectorAll('input[name="source"]');
+  const agencyInputs = app.querySelectorAll('input[name="agency"]');
+  const filterEmptySlot = app.querySelector('[data-slot="filter-empty"]');
+  const FILTER_KEY = "wxopticon:filters";
+
   let mode = "live";           // "live" = polling summary.json, "scrub" = frozen historical snapshot
   let latest = null;           // last successful live summary payload
   let lastFetchError = null;   // null if the most recent live fetch succeeded
@@ -98,6 +103,63 @@
   }
 
   setTimeMode(localStorage.getItem(TIME_MODE_KEY) === "local", false);
+
+  // ---- source / agency filters ---------------------------------------------
+
+  // A row is visible only when both its source and its agency are selected.
+  // Both filter groups default to all-checked (show everything); the rows
+  // themselves carry data-origin / data-agency from the build-time skeleton,
+  // so filtering is a pure DOM read with no re-classification here.
+  function applyFilters(persist) {
+    const sources = new Set([...sourceInputs].filter((i) => i.checked).map((i) => i.value));
+    const agencies = new Set([...agencyInputs].filter((i) => i.checked).map((i) => i.value));
+    let visible = 0;
+    // Hide a model group's heading once all of its rows are filtered out.
+    for (const group of app.querySelectorAll(".status-group")) {
+      let groupVisible = 0;
+      for (const row of group.querySelectorAll(".status-row")) {
+        const show = sources.has(row.dataset.origin) && agencies.has(row.dataset.agency);
+        row.hidden = !show;
+        if (show) groupVisible++;
+      }
+      group.hidden = groupVisible === 0;
+      visible += groupVisible;
+    }
+    if (filterEmptySlot) filterEmptySlot.hidden = visible > 0;
+    if (persist) {
+      localStorage.setItem(
+        FILTER_KEY,
+        JSON.stringify({ sources: [...sources], agencies: [...agencies] })
+      );
+    }
+  }
+
+  function restoreFilters() {
+    let saved = null;
+    try {
+      saved = JSON.parse(localStorage.getItem(FILTER_KEY));
+    } catch {
+      saved = null;
+    }
+    // Only override a group's defaults when its saved selection is present, so
+    // a stale payload (e.g. the old track-based shape) leaves new filters fully
+    // checked rather than hiding everything.
+    if (Array.isArray(saved?.sources)) {
+      const s = new Set(saved.sources);
+      sourceInputs.forEach((i) => { i.checked = s.has(i.value); });
+    }
+    if (Array.isArray(saved?.agencies)) {
+      const a = new Set(saved.agencies);
+      agencyInputs.forEach((i) => { i.checked = a.has(i.value); });
+    }
+    applyFilters(false);
+  }
+
+  [...sourceInputs, ...agencyInputs].forEach((i) =>
+    i.addEventListener("change", () => applyFilters(true))
+  );
+
+  restoreFilters();
 
   // ---- formatting -----------------------------------------------------------
 
@@ -271,6 +333,7 @@
       stateText,
       fmtPercent(init.completion_pct),
       init.latency_s != null ? `latency ${fmtLatency(init.latency_s)}` : null,
+      init.ingestion_lag_s != null ? `ingest +${fmtLatency(init.ingestion_lag_s)}` : null,
     ].filter(Boolean).join(" · ");
     if (!init.lead_groups || init.lead_groups.length === 0) return base;
     const groupParts = init.lead_groups.map((g) => {
@@ -338,9 +401,41 @@
     if (track) track.replaceChildren(...renderTrackContents(init));
   }
 
+  // Ingestion lag = time from upstream-source publish completion to our
+  // derived-product publish completion (the dynamical.org SLA metric). Only
+  // dynamical.org rows carry the [data-slot="ingestion-lag"] node. Below
+  // MIN_INGESTION_SAMPLES (or while percentiles are still null) we say
+  // "insufficient data" plainly rather than rendering "—".
+  const MIN_INGESTION_SAMPLES = 20;
+  function renderIngestionLag(slot, product) {
+    const stats = product.ingestion_lag_stats;
+    if (!stats) {
+      slot.hidden = true;
+      slot.replaceChildren();
+      return;
+    }
+    slot.hidden = false;
+    if (stats.sample_init_count < MIN_INGESTION_SAMPLES || stats.p50_s == null) {
+      slot.replaceChildren(
+        el("strong", null, "ingestion lag"),
+        el("span", null, "insufficient data")
+      );
+    } else {
+      slot.replaceChildren(
+        el("strong", null, "ingestion lag"),
+        el("span", null, `p50 ${fmtLatency(stats.p50_s)}`),
+        el("span", null, `p95 ${fmtLatency(stats.p95_s)}`),
+        el("span", null, `p99 ${fmtLatency(stats.p99_s)}`)
+      );
+    }
+  }
+
   function hydrateRow(product) {
     const row = app.querySelector(`.status-row[data-product-id="${product.id}"]`);
     if (!row) return;
+
+    const lagSlot = row.querySelector('[data-slot="ingestion-lag"]');
+    if (lagSlot) renderIngestionLag(lagSlot, product);
 
     const grid = row.querySelector('[data-slot="grid"]');
     const inits = product.recent_inits.slice(-RECENT_INIT_COUNT);


### PR DESCRIPTION
Surface our published Icechunk catalog products on /status/ alongside the upstream sources from summary.json:

- Group rows by model (shared display label); within each group the dynamical.org row leads, then its upstream Source row(s). Model groups with a dynamical.org product sort ahead of source-only models.
- Source filter (dynamical.org / AWS / NOMADS / DWD) and multi-select Agency filter (NOAA / ECMWF / DWD), combined with AND. Group headings hide when all their rows are filtered out; selections persist to localStorage.
- Surface ingestion_lag_stats (p50/p95/p99) on dynamical.org rows, falling back to "insufficient data" below 20 samples or while percentiles are null. Per-init ingestion_lag_s added to bar tooltips.