### PR TITLE
Add BetterStack error tracking + frontend telemetry

### DIFF
--- a/_data/metadata.js
+++ b/_data/metadata.js
@@ -8,4 +8,7 @@ module.exports = {
     name: "dynamical.org",
     email: "marshall@dynamical.org",
   },
+  // BetterStack Errors frontend (JS tag) ingest token. Publishable — it ships
+  // to the browser by design. App: "dynamical.org" (javascript_errors).
+  betterstackErrorsToken: "jBWijdgJFX4ZGVJiDRJQ5SEv",
 };

--- a/_includes/base.njk
+++ b/_includes/base.njk
@@ -35,6 +35,20 @@
     <link rel="apple-touch-icon" href="https://assets.dynamical.org/identity/logo/favicon/apple-touch-icon.png"/>
     <link rel="alternate" href="/feed/feed.xml" type="application/atom+xml" title="{{ metadata.title }}"/>
     <link rel="alternate" href="/feed/feed.json" type="application/json" title="{{ metadata.title }}"/>
+    {% if metadata.betterstackErrorsToken %}<!-- BetterStack Errors: browser error tracking + pageview telemetry -->
+    <script>
+      !function(b,e,t,r){
+        b[t]=b[t]||function(...args){(b[t].q=b[t].q||[]).push(args)};
+        b[t].l=+new Date;
+        var s=e.createElement('script'); s.async=1; s.crossOrigin='anonymous';
+        s.src='https://betterstack.net/b.js?t='+r;
+        (e.head||e.getElementsByTagName('head')[0]).appendChild(s);
+      }(window,document,'betterstack','{{ metadata.betterstackErrorsToken }}');
+      // Only report from the production host; keeps local dev and *.pages.dev previews out of the dashboard.
+      if (location.hostname === 'dynamical.org') {
+        betterstack('init', { environment: 'production' });
+      }
+    </script>{% endif %}
   </head>
   <body>
     <nav aria-label="Primary">


### PR DESCRIPTION
# 91 — BetterStack telemetry, uptime & error tracking

## Goal

Bring dynamical.org under the same BetterStack observability umbrella as
`scorecard` and `wxopticon`, adapted to this project's architecture.

## Context: why this differs from the sibling projects

`scorecard` and `wxopticon` are **Python / Modal** services. They integrate
BetterStack server-side:

- **Logs** — `logtail-python` `LogtailHandler` → BetterStack telemetry source
- **Errors** — `sentry-sdk` → BetterStack Errors app (Sentry-compatible DSN)
- **Uptime** — heartbeat URL pinged from inside the cron/daemon (`/`, `/fail`)
- Tokens live in a per-project Modal secret (`betterstack-<project>`).

dynamical.org is a **static 11ty site on Cloudflare Pages**: no server runtime,
no CI workflow, no cron. The only code that executes at runtime is client-side
JS (`public/globe.js`, `public/scorecard.js`, inline module scripts in
`content/scorecard*.njk`). So the integration shape changes:

| Pillar | scorecard/wxopticon (Python) | dynamical.org (static site) |
|---|---|---|
| Errors | `sentry-sdk` server-side | **BetterStack JS tag** (browser, Sentry-compatible) |
| Telemetry/logs | `logtail-python` → source | **JS tag** auto pageviews + events |
| Uptime | heartbeat ping in cron | **already done** — URL monitors |

## Decisions (confirmed)

- **JS tag only** for frontend instrumentation (no separate `@logtail/browser`
  source — would be redundant; the JS tag streams events to BetterStack too).
- **Capture scope: errors + pageviews**, no session replay (public info site;
  keep the privacy footprint minimal).

## Current BetterStack state (already present — verified via MCP)

- **Uptime monitors**: `dynamical.org`, `status.dynamical.org`, `STAC catalog`
  → ✅ uptime pillar is effectively complete.
- **Errors apps**: `scorecard`, `wxopticon` (both `python_errors`). No
  JavaScript errors app yet.
- **Telemetry sources**: `scorecard`, `wxopticon` (both `python`).
- **Heartbeats**: `scorecard daily`, `wxopticon tick`, `wxopticon listener`.

## Plan

### 1. Create the BetterStack Errors application (JavaScript)
- New Errors app named `dynamical.org`, platform **JavaScript** (via MCP
  `telemetry_create_application_tool`, team `dynamical.org`).
- Copy the frontend ingest **token** from its Frontend tab. This token is
  **publishable** (it ships to the browser) — no secret management needed,
  unlike the Modal secrets in the sibling repos.

### 2. Add the token to site metadata
- Add `betterstackErrorsToken: "<token>"` to `_data/metadata.js`.
  (Public token, so inlining is fine; metadata keeps it in one obvious place.)

### 3. Inject the JS tag in the base layout
- In `_includes/base.njk`, immediately before `</head>` (line ~38), add the
  async snippet, **gated to the production hostname** so local `npm start`
  (localhost) and `*.pages.dev` preview builds don't pollute the dashboard:

  ```html
  {% if metadata.betterstackErrorsToken %}
  <script>
    !function(b,e,t,r){
      b[t]=b[t]||function(...args){(b[t].q=b[t].q||[]).push(args)};
      b[t].l=+new Date;
      var s=e.createElement('script'); s.async=1; s.crossOrigin='anonymous';
      s.src='https://betterstack.net/b.js?t='+r;
      (e.head||e.getElementsByTagName('head')[0]).appendChild(s);
    }(window,document,'betterstack','{{ metadata.betterstackErrorsToken }}');
    if (location.hostname === 'dynamical.org') {
      betterstack('init', { environment: 'production' });
    }
  </script>
  {% endif %}
  ```
  - `autoPageview` defaults to `true` → pageviews captured automatically.
  - No `sentry.replay*` options → no session replay (matches confirmed scope).

### 4. Verify
- `npm run build`, grep `docs/` to confirm the snippet rendered on pages.
- Deploy via merge → open dynamical.org, trigger a test error in console
  (`throw new Error('betterstack-test')`), confirm it lands in the Errors app's
  Live tail / Verify panel. Confirm a pageview is recorded.

### 5. (Documented non-goals)
- **No build heartbeat.** Cloudflare Pages builds are event-driven (per commit),
  not periodic; a heartbeat monitor expects a fixed cadence, so it's a poor fit.
  Build-failure visibility already comes from Cloudflare Pages notifications.
- **No `@logtail/browser` logs source** (redundant with JS-tag events).
- **No uptime changes** — monitors already exist.

## Files touched
- `_data/metadata.js` — add `betterstackErrorsToken`
- `_includes/base.njk` — add gated JS-tag snippet before `</head>`
- BetterStack (out-of-repo): new `dynamical.org` JavaScript Errors app

## ⚠️ Required one-time manual step (BetterStack UI)

The JS-tag **collection toggles default to ON**, including session replay and
browser fingerprinting — which exceeds the agreed "errors + pageviews, minimal
privacy footprint" scope. There is **no MCP/API tool** to flip these, so set
them in the app's **Frontend tab**:
<https://errors.betterstack.com/team/t552704/applications/2524966>

- **Record session replays** → OFF (records visitor DOM/interactions)
- **Collect browser fingerprint** → OFF (cross-session user identification)
- Keep **Collect frontend errors** ON and **Record website analytics** ON.
- Optional: **Auto-capture anonymous user events** OFF for an even smaller
  footprint (pageviews still recorded).

## Status

- [x] 1. Create BetterStack Errors app `dynamical.org` (javascript_errors, id
  `2524966`, token `jBWijdgJFX4ZGVJiDRJQ5SEv`)
- [x] 2. Add token to `_data/metadata.js`
- [x] 3. Add gated JS-tag snippet to `_includes/base.njk`
- [ ] 4. **Manual**: disable session replay + fingerprint in Frontend tab
- [ ] 5. Verify after deploy (build grep + console test error → Live tail)

## Risks / notes
- Token is public by design (frontend tag); not a leak.
- Ad-blockers / privacy extensions may block `betterstack.net` — acceptable,
  same caveat BetterStack documents for browser logging.
- Hostname gate means preview deploys won't report; if we later want preview
  signal, switch to `environment: location.hostname === 'dynamical.org' ?
  'production' : 'preview'` and always init.