### PR TITLE
Fix BetterStack frontend token

### DIFF
--- a/_data/metadata.js
+++ b/_data/metadata.js
@@ -10,5 +10,5 @@ module.exports = {
   },
   // BetterStack Errors frontend (JS tag) ingest token. Publishable — it ships
   // to the browser by design. App: "dynamical.org" (javascript_errors).
-  betterstackErrorsToken: "jBWijdgJFX4ZGVJiDRJQ5SEv",
+  betterstackErrorsToken: "mvH2kP3pYS3hZ2LnroXKPcUx",
 };


### PR DESCRIPTION
The JS tag needs the Frontend-tab token, not the app DSN key (which produced 'Invalid token' in prod). One-line swap in `_data/metadata.js`.