### PR TITLE
Cache-bust main.css URL with a content hash

### DIFF
--- a/_data/assets.js
+++ b/_data/assets.js
@@ -1,0 +1,20 @@
+// Content-hash of static assets, for cache-busting their URLs.
+//
+// Cloudflare Pages serves /main.css with `Cache-Control: public,
+// max-age=14400` (4h), so a CSS change can take up to 4h to reach consumers
+// who already cached the old file. Appending `?v=<hash>` changes the URL
+// whenever the file's contents change, forcing a fresh fetch. The HTML itself
+// is served `max-age=0, must-revalidate`, so the new markup — and the new
+// versioned URL — reaches consumers immediately on their next navigation.
+const fs = require("fs");
+const path = require("path");
+const crypto = require("crypto");
+
+function hash(file) {
+  const buf = fs.readFileSync(path.join(__dirname, "..", "public", file));
+  return crypto.createHash("sha256").update(buf).digest("hex").slice(0, 8);
+}
+
+module.exports = {
+  mainCss: hash("main.css"),
+};

--- a/_includes/base.njk
+++ b/_includes/base.njk
@@ -28,7 +28,7 @@
     <meta name="twitter:title" content="{{ ogTitle }}"/>
     <meta name="twitter:description" content="{{ ogDescription }}"/>
     <meta name="twitter:image" content="{{ ogImage }}"/>
-    <link rel="stylesheet" type="text/css" href="/main.css"/>
+    <link rel="stylesheet" type="text/css" href="/main.css?v={{ assets.mainCss }}"/>
     <link rel="preconnect" href="https://fonts.googleapis.com"/>
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
     <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;700&display=swap" rel="stylesheet"/>


### PR DESCRIPTION
Fixes stale CSS for consumers: Cloudflare Pages serves `/main.css` with `max-age=14400` (4h), so CSS updates didn't reach browsers that had cached the old file for up to 4h.

Appends `?v=<content-hash>` to the stylesheet `href` (computed at build from `public/main.css`). The HTML is served `max-age=0, must-revalidate`, so the new versioned URL propagates immediately — and it self-corrects on every future CSS change.