### PR TITLE
Clarify BY-NC-SA license applies to the website, not datasets

### DIFF
--- a/_includes/base.njk
+++ b/_includes/base.njk
@@ -109,7 +109,7 @@
         </div>
       </div>
       <div class="footer-base">
-        <span>dynamical.org · <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">BY-NC-SA 4.0</a></span>
+        <span>dynamical.org website · <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">BY-NC-SA 4.0</a></span>
         <span>Built {% currentBuildDate %}</span>
       </div>
     </footer>


### PR DESCRIPTION
The footer license read as if BY-NC-SA covered everything on the site, but catalog datasets are licensed CC BY 4.0 (not non-commercial). This scopes the footer label to the website ("dynamical.org website · BY-NC-SA 4.0") to avoid implying the datasets are NC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DKMygAgUv9iRNFyV5YGUH7)_