### PR TITLE
Build PR previews against staging STAC catalog

### DIFF
--- a/_data/catalog.js
+++ b/_data/catalog.js
@@ -2,13 +2,14 @@ const fetch = require("@11ty/eleventy-fetch");
 const fs = require("fs");
 const path = require("path");
 
-// On Cloudflare Pages, the `staging` branch builds against the staging STAC
-// catalog; everything else (prod and other previews) uses production. An
-// explicit STAC_BASE_URL always wins, e.g. `npm run start:staging` or pointing
-// at a locally-served stac/ tree.
+// On Cloudflare Pages, preview deployments (every branch except the production
+// `main` branch — i.e. PR previews) build against the staging STAC catalog so
+// catalog changes can be previewed before going live; production builds use
+// prod. An explicit STAC_BASE_URL always wins, e.g. `npm run start:staging` or
+// pointing at a locally-served stac/ tree.
 const STAC_BASE_URL =
   process.env.STAC_BASE_URL ||
-  (process.env.CF_PAGES_BRANCH === "staging"
+  (process.env.CF_PAGES_BRANCH && process.env.CF_PAGES_BRANCH !== "main"
     ? "https://stac-staging.dynamical.org"
     : "https://stac.dynamical.org");
 

--- a/_data/catalog.js
+++ b/_data/catalog.js
@@ -2,7 +2,15 @@ const fetch = require("@11ty/eleventy-fetch");
 const fs = require("fs");
 const path = require("path");
 
-const STAC_BASE_URL = process.env.STAC_BASE_URL || "https://stac.dynamical.org";
+// On Cloudflare Pages, the `staging` branch builds against the staging STAC
+// catalog; everything else (prod and other previews) uses production. An
+// explicit STAC_BASE_URL always wins, e.g. `npm run start:staging` or pointing
+// at a locally-served stac/ tree.
+const STAC_BASE_URL =
+  process.env.STAC_BASE_URL ||
+  (process.env.CF_PAGES_BRANCH === "staging"
+    ? "https://stac-staging.dynamical.org"
+    : "https://stac.dynamical.org");
 
 // `npm run build` sets this to "0s" so production builds always pick up the
 // latest STAC — we don't want to publish a site that references stale catalog

--- a/_data/validationReports.js
+++ b/_data/validationReports.js
@@ -1,10 +1,11 @@
 const fetch = require("@11ty/eleventy-fetch");
 
-// On Cloudflare Pages, the `staging` branch builds against the staging STAC
-// catalog; everything else uses production. Explicit STAC_BASE_URL always wins.
+// On Cloudflare Pages, preview deployments (every branch except production
+// `main` — i.e. PR previews) build against the staging STAC catalog; production
+// uses prod. Explicit STAC_BASE_URL always wins.
 const STAC_BASE_URL =
   process.env.STAC_BASE_URL ||
-  (process.env.CF_PAGES_BRANCH === "staging"
+  (process.env.CF_PAGES_BRANCH && process.env.CF_PAGES_BRANCH !== "main"
     ? "https://stac-staging.dynamical.org"
     : "https://stac.dynamical.org");
 const VALIDATION_BASE_URL =

--- a/_data/validationReports.js
+++ b/_data/validationReports.js
@@ -1,6 +1,12 @@
 const fetch = require("@11ty/eleventy-fetch");
 
-const STAC_BASE_URL = process.env.STAC_BASE_URL || "https://stac.dynamical.org";
+// On Cloudflare Pages, the `staging` branch builds against the staging STAC
+// catalog; everything else uses production. Explicit STAC_BASE_URL always wins.
+const STAC_BASE_URL =
+  process.env.STAC_BASE_URL ||
+  (process.env.CF_PAGES_BRANCH === "staging"
+    ? "https://stac-staging.dynamical.org"
+    : "https://stac.dynamical.org");
 const VALIDATION_BASE_URL =
   process.env.VALIDATION_REPORTS_BASE_URL ||
   "https://dataset-validation-reports.dynamical.org";

--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
   "scripts": {
     "build": "STAC_CACHE_DURATION=0s npx @11ty/eleventy",
     "start": "npx @11ty/eleventy --serve --port=8081",
+    "start:staging": "STAC_BASE_URL=https://stac-staging.dynamical.org npx @11ty/eleventy --serve --port=8081",
+    "build:staging": "STAC_BASE_URL=https://stac-staging.dynamical.org STAC_CACHE_DURATION=0s npx @11ty/eleventy",
     "clean": "rm -r docs .cache"
   },
   "repository": {


### PR DESCRIPTION
## Build PR previews against the staging STAC catalog

Companion to dynamical-org/dynamical-stac#31, which set up `stac-staging.dynamical.org`. This makes the website's **Cloudflare PR previews** consume it, so catalog/site changes can be previewed against staging data before merge. No separate staging branch or deploy mechanic — it rides the per-PR preview Cloudflare already builds.

### Behavior
| Build | `CF_PAGES_BRANCH` | STAC source |
|-------|-------------------|-------------|
| Production | `main` | `stac.dynamical.org` |
| Any PR preview | (PR branch) | `stac-staging.dynamical.org` |
| Local `npm start` | unset | `stac.dynamical.org` |
| Local `npm run start:staging` / explicit `STAC_BASE_URL` | — | override wins |

### What changed
- **`_data/catalog.js`** + **`_data/validationReports.js`**: STAC base URL = staging when `CF_PAGES_BRANCH` is set and ≠ `main`, else prod. Explicit `STAC_BASE_URL` always wins.
- **`package.json`**: `start:staging` / `build:staging` for local work against the staging catalog.

### Verification
- Resolution verified for all cases: unset→prod, `main`→prod, PR branch→staging, explicit override honored.
- Prod build pipeline runs clean (full site, catalog pages). Staging endpoint returns 200. (A clean local staging build was blocked only by a transient macOS negative-DNS cache for the new domain; Cloudflare's build network resolves it.)

### Note (out of scope, non-blocking)
A few display-only links in `content/catalog.njk`, `content/catalog-pages.njk`, `content/stac-redirect.njk` hardcode `stac.dynamical.org`; they don't affect which catalog a preview builds from.
