### PR TITLE
Add spacing between list items in article content

### DIFF
--- a/public/main.css
+++ b/public/main.css
@@ -158,6 +158,18 @@ p {
   margin-bottom: 1.2rem;
 }
 
+/* Give bullet/numbered lists in article content room to breathe. Without
+   this, multi-line list items (e.g. the SLA page) run together and are hard
+   to scan. Scoped to .content so nav/footer lists keep their own layout. */
+.content ul,
+.content ol {
+  margin-bottom: 1.2rem;
+}
+
+.content li + li {
+  margin-top: 0.6rem;
+}
+
 .small-note {
   font-size: 0.9em;
   color: var(--muted-text);


### PR DESCRIPTION
Multi-line list items (e.g. the SLA page bullets) previously ran
together with no vertical separation, hurting legibility. Add margin
between adjacent list items and below lists, scoped to .content so
nav and footer lists keep their own layout.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01MvuS7uPoubejUxz8CaKEkQ