### PR TITLE
Fix grammar: "forecast" to "forecasts" in forecast-evaluation

### DIFF
--- a/content/areas/forecast-evaluation.md
+++ b/content/areas/forecast-evaluation.md
@@ -9,4 +9,4 @@ variable, by region, against observations or against a reanalysis, with metrics
 that reward sharpness or metrics that reward calibration. Each choice encodes an
 opinion about what "good" means.
 
-We explore the tradeoffs of these choices, with the aim to create a framework to determine _which_ forecast to trust for a given situation. We are particularly interested in how probabilistic forecasts should be optimally leveraged in human-driven decision-making processes.
+We explore the tradeoffs of these choices, with the aim to create a framework to determine _which_ forecasts to trust for a given situation. We are particularly interested in how probabilistic forecasts should be optimally leveraged in human-driven decision-making processes.


### PR DESCRIPTION
## Summary
Minor grammar correction in the forecast evaluation content page.

## Changes
- Changed "which forecast to trust" to "which forecasts to trust" in the forecast-evaluation area description to use correct plural form

## Details
This is a simple grammar fix that improves the accuracy of the documentation. The sentence now correctly uses the plural "forecasts" to match the context of discussing multiple forecast options and tradeoffs.

https://claude.ai/code/session_01TrwKMFq6CNZKixykUa4FiZ