### PR TITLE
Group nested-zarr-group variables into disclosures on catalog pages

### DIFF
--- a/_data/catalog.js
+++ b/_data/catalog.js
@@ -99,7 +99,7 @@ function reshapeStacCollection(collection) {
     };
   });
 
-  const variables = Object.entries(cubeVars).map(([name, v]) => ({
+  const rawVariables = Object.entries(cubeVars).map(([name, v]) => ({
     name,
     long_name: v.long_name,
     short_name: v.short_name,
@@ -107,6 +107,13 @@ function reshapeStacCollection(collection) {
     units: v.unit,
     dimension_names: v.dimensions,
   }));
+
+  // Variables at the root zarr group (e.g. `temperature_2m`) are listed
+  // directly, unchanged from before. Variables under a nested zarr group
+  // (e.g. `model_level/geopotential_height`) are split off into named
+  // groups so the catalog page can render them behind disclosures instead
+  // of flooding a single flat table.
+  const { variables, variableGroups } = groupVariables(rawVariables);
 
   const summaryValue = (key) => {
     const value = (collection.summaries || {})[key];
@@ -153,9 +160,37 @@ function reshapeStacCollection(collection) {
     forecast_resolution: summaryValue("forecast_resolution"),
     dimensions,
     variables,
+    variableGroups,
     notebooks,
     validation_report_href,
   };
+}
+
+// Split cube:variables into root (single-level) variables and named groups
+// based on a `group/name` prefix in the variable's key, e.g.
+// `model_level/geopotential_height` belongs to the `model_level` group as
+// `geopotential_height`. Variables with no `/` stay in the flat root list.
+function groupVariables(rawVariables) {
+  const variables = [];
+  const groupsByName = {};
+  const groupOrder = [];
+
+  rawVariables.forEach((variable) => {
+    const slashIndex = variable.name.lastIndexOf("/");
+    if (slashIndex === -1) {
+      variables.push(variable);
+      return;
+    }
+    const groupName = variable.name.slice(0, slashIndex);
+    const name = variable.name.slice(slashIndex + 1);
+    if (!groupsByName[groupName]) {
+      groupsByName[groupName] = { name: groupName, variables: [] };
+      groupOrder.push(groupName);
+    }
+    groupsByName[groupName].variables.push({ ...variable, name });
+  });
+
+  return { variables, variableGroups: groupOrder.map((name) => groupsByName[name]) };
 }
 
 // Pair `rel:example` links into notebooks by the `{slug}.ipynb` filename

--- a/content/catalog-pages.njk
+++ b/content/catalog-pages.njk
@@ -26,7 +26,46 @@ eleventyComputed:
     background-color: rgb(250, 250, 250);
     color: rgb(45, 45, 45);
   }
+  .variable-group {
+    margin-top: 1rem;
+  }
+  .variable-group > summary {
+    cursor: pointer;
+    font-size: 1.1em;
+  }
+  .variable-group > summary > strong {
+    margin-left: 0.5em;
+  }
 </style>
+{% macro variableTable(variables) %}
+  <div class="table-container">
+    <table class="data">
+      <tr>
+        <th/>
+        <th class='right'>units</th>
+        <th class='right'>dimensions</th>
+      </tr>
+      {% for variable in variables %}
+        <tr>
+          <td>
+            <strong>{{ variable.name }}</strong>{% if variable.short_name %} (<code>{{ variable.short_name }}</code>){% endif %}
+            <p class="metadata-comment">{{ variable.long_name }}</p>
+            {% if variable.comment %}
+              <p class="metadata-comment">{{ variable.comment }}</p>
+            {% endif %}
+          </td>
+          <td class='right'>{{ variable.units }}</td>
+          <td class='right'>{{ variable.dimension_names.join(' × ') }}</td>
+        </tr>
+        <tr class="metadata-comment">
+          <td colspan="3">
+            <span></span>
+          </td>
+        </tr>
+      {% endfor %}
+    </table>
+  </div>
+{% endmacro %}
 <div class="content catalog-item">
   {%- set model = catalog.models | find('id', entry.model_id) %}
   <div>
@@ -150,33 +189,13 @@ eleventyComputed:
     </table>
   </div>
   <h2>Variables</h2>
-  <div class="table-container">
-    <table class="data">
-      <tr>
-        <th/>
-        <th class='right'>units</th>
-        <th class='right'>dimensions</th>
-      </tr>
-      {% for variable in entry.variables %}
-        <tr>
-          <td>
-            <strong>{{ variable.name }}</strong>{% if variable.short_name %} (<code>{{ variable.short_name }}</code>){% endif %}
-            <p class="metadata-comment">{{ variable.long_name }}</p>
-            {% if variable.comment %}
-              <p class="metadata-comment">{{ variable.comment }}</p>
-            {% endif %}
-          </td>
-          <td class='right'>{{ variable.units }}</td>
-          <td class='right'>{{ variable.dimension_names.join(' × ') }}</td>
-        </tr>
-        <tr class="metadata-comment">
-          <td colspan="3">
-            <span></span>
-          </td>
-        </tr>
-      {% endfor %}
-    </table>
-  </div>
+  {{ variableTable(entry.variables) }}
+  {% for group in entry.variableGroups %}
+    <details class="variable-group">
+      <summary><strong>{{ group.name | replace("_", " ") | title }}</strong> ({{ group.variables.length }} variable{{ "s" if group.variables.length != 1 }})</summary>
+      {{ variableTable(group.variables) }}
+    </details>
+  {% endfor %}
   <p class="metadata-comment">
     Don't see what you're looking for? Let us know at
     <a href="mailto:feedback@dynamical.org">feedback@dynamical.org</a>.

--- a/content/catalog-pages.njk
+++ b/content/catalog-pages.njk
@@ -36,6 +36,9 @@ eleventyComputed:
   .variable-group > summary > strong {
     margin-left: 0.5em;
   }
+  .variable-dimensions {
+    white-space: nowrap;
+  }
 </style>
 {% macro variableTable(variables) %}
   <div class="table-container">
@@ -43,7 +46,7 @@ eleventyComputed:
       <tr>
         <th/>
         <th class='right'>units</th>
-        <th class='right'>dimensions</th>
+        <th class='right variable-dimensions'>dimensions</th>
       </tr>
       {% for variable in variables %}
         <tr>
@@ -55,7 +58,7 @@ eleventyComputed:
             {% endif %}
           </td>
           <td class='right'>{{ variable.units }}</td>
-          <td class='right'>{{ variable.dimension_names.join(' × ') }}</td>
+          <td class='right variable-dimensions'>{{ variable.dimension_names.join(' × ') }}</td>
         </tr>
         <tr class="metadata-comment">
           <td colspan="3">


### PR DESCRIPTION
STAC collections can now list variables under a nested zarr group
(e.g. model_level/geopotential_height) alongside root-level ones
(e.g. temperature_2m). Split those out by group and render each group
in a <details> disclosure so datasets with many pressure/model-level
variables don't flood a single flat table; root variables render
unchanged.