### PR TITLE
Simplify SLA service-credit wording

### DIFF
--- a/content/sla.html
+++ b/content/sla.html
@@ -96,8 +96,8 @@ eleventyExcludeFromCollections: true
         </tr>
         <tr>
           <td>Service credit per breach</td>
-          <td>25% uptime / 20% timeliness (100% cap)</td>
-          <td>15% (50% monthly cap)</td>
+          <td>25% per breach · 100% monthly cap</td>
+          <td>15% per breach · 50% monthly cap</td>
           <td>—</td>
         </tr>
         <tr>


### PR DESCRIPTION
## Summary

Simplifies the "Service credit per breach" row in the Commercial SLA table so both tiers follow the same shape and both caps are explicitly monthly.

| | Before | After |
|---|---|---|
| Enterprise | `25% uptime / 20% timeliness (100% cap)` | `25% per breach · 100% monthly cap` |
| Startup | `15% (50% monthly cap)` | `15% per breach · 50% monthly cap` |

Both cells now read as **X% per breach · Y% monthly cap**, making it clear that credits accrue per breach and cap monthly. The Enterprise cell drops the separate uptime/timeliness rates (25%/20%) in favor of a single flat 25% per-breach rate.

## Notes

This is a copy-only change to `content/sla.html`; no logic or layout changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HokA43N82ZQTzCdP2xr7oo

---
_Generated by [Claude Code](https://claude.ai/code/session_01HokA43N82ZQTzCdP2xr7oo)_