### PR TITLE
Minimize catalog.js reshaping; read STAC fields directly

### DIFF
--- a/_data/catalog.js
+++ b/_data/catalog.js
@@ -178,38 +178,35 @@ function reshapeStacCollection(collection) {
     : null;
 
   return {
+    // Use the STAC Collection directly for everything it already exposes at
+    // the top level: id, title, description, attribution, model_id,
+    // model_name, description_summary/details/model, examples, license,
+    // version, keywords, summaries, extent, links, assets, cube:*. Templates
+    // read these STAC-native fields (entry.id, entry.title, ...) as-is.
+    ...collection,
+    // Below: only fields that require transforming STAC structures, or
+    // derived values the site needs.
+    dimensions,
+    variables,
+    variableGroups,
+    notebooks,
+    distributions,
     thumbnail,
-    description_meta: plainTextExcerpt(collection.description_summary),
+    validation_report_href,
     license_md: licenseMd(licenseLinks),
-    name: collection.title,
-    dataset_id: collection.id,
-    description: collection.description,
-    attribution: collection.attribution,
-    model_id: collection.model_id,
-    model_name: collection.model_name,
-    description_summary: collection.description_summary,
-    description_details: collection.description_details,
-    description_model: collection.description_model,
-    examples: collection.examples,
+    license_url: licenseLink ? licenseLink.href : null,
+    description_meta: plainTextExcerpt(collection.description_summary),
+    // STAC summaries are single-element arrays; unwrap to scalars.
     spatial_domain: summaryValue("spatial_domain"),
     spatial_resolution: summaryValue("spatial_resolution"),
     time_domain: summaryValue("time_domain"),
     time_resolution: summaryValue("time_resolution"),
     forecast_domain: summaryValue("forecast_domain"),
     forecast_resolution: summaryValue("forecast_resolution"),
-    dimensions,
-    variables,
-    variableGroups,
-    notebooks,
-    validation_report_href,
-    // Machine-readable metadata for structured data (JSON-LD, llms.txt).
-    distributions,
+    // Extracted from STAC extent for structured data (JSON-LD).
     spatial_bbox: collection.extent?.spatial?.bbox?.[0] || null,
     temporal_interval: collection.extent?.temporal?.interval?.[0] || null,
-    license: collection.license || null,
-    license_url: licenseLink ? licenseLink.href : null,
-    version: collection.version || null,
-    keywords: collection.keywords || null,
+    // Canonical public URLs.
     stac_href: `${STAC_PUBLIC_URL}/${collection.id}/collection.json`,
     catalog_url: `${SITE_URL}catalog/${collection.id}/`,
   };
@@ -251,7 +248,7 @@ function buildDatasetJsonLd(entry) {
     "@context": "https://schema.org",
     "@type": "Dataset",
     "@id": entry.catalog_url,
-    name: entry.name,
+    name: entry.title,
     description: entry.description_meta || plainTextExcerpt(entry.description),
     url: entry.catalog_url,
     sameAs: entry.stac_href,
@@ -293,8 +290,8 @@ function buildDatasetJsonLd(entry) {
 function validateEntries(entries) {
   const problems = [];
   for (const e of entries) {
-    const id = e.dataset_id || "(unknown id)";
-    if (!e.name) problems.push(`${id}: missing title`);
+    const id = e.id || "(unknown id)";
+    if (!e.title) problems.push(`${id}: missing title`);
     if (!e.distributions.some((a) => a.roles.includes("data"))) {
       problems.push(`${id}: no data-role asset (STAC assets: ${e.distributions.map((a) => a.key).join(", ") || "none"})`);
     }

--- a/content/aws-open-data-registry.njk
+++ b/content/aws-open-data-registry.njk
@@ -18,13 +18,13 @@ Description: |
     <p>These datasets have been translated to cloud-optimized Icechunk Zarr format by <a href="https://dynamical.org">dynamical.org</a>.</p>
     <ul>
     {%- for entry in entries %}
-      <li><a href="https://dynamical.org/catalog/{{ entry.dataset_id | slugify }}/">{{ entry.name }}</a> - {{ entry.description | safe }}</li>
+      <li><a href="https://dynamical.org/catalog/{{ entry.id | slugify }}/">{{ entry.title }}</a> - {{ entry.description | safe }}</li>
     {%- endfor %}
     </ul>
 Documentation: https://dynamical.org/catalog/
 Contact: feedback@dynamical.org
 ManagedBy: "[dynamical.org](https://dynamical.org)"
-UpdateFrequency: "{% for entry in entries %}{{entry.name}}: {{ entry.time_resolution }}{% if not loop.last %}; {% endif %}{% endfor %}"
+UpdateFrequency: "{% for entry in entries %}{{entry.title}}: {{ entry.time_resolution }}{% if not loop.last %}; {% endif %}{% endfor %}"
 Tags:
   - aws-pds
   - weather
@@ -49,7 +49,7 @@ DataAtWork:
   Tutorials:
     {%- for entry in entries %}
       {%- for notebook in entry.notebooks %}
-    - Title: "{{ entry.name }} — {{ notebook.title }}"
+    - Title: "{{ entry.title }} — {{ notebook.title }}"
       URL: {{ notebook.githubUrl }}
       NotebookURL: {{ notebook.githubUrl }}
       AuthorName: dynamical.org

--- a/content/catalog-pages.njk
+++ b/content/catalog-pages.njk
@@ -5,11 +5,11 @@ pagination:
   alias: entry
   size: 1
   addAllPagesToCollections: true
-permalink: 'catalog/{{entry.dataset_id | slugify}}/'
+permalink: 'catalog/{{entry.id | slugify}}/'
 eleventyComputed:
-  title: '{{entry.name}}'
+  title: '{{entry.title}}'
   description: '{{ entry.description_meta }}'
-  socialTitle: '{{ entry.name }} — dynamical.org'
+  socialTitle: '{{ entry.title }} — dynamical.org'
   socialImage: '{{ entry.thumbnail }}'
 ---
 
@@ -75,11 +75,11 @@ eleventyComputed:
   {%- set model = catalog.models | find('id', entry.model_id) %}
   <div>
     <a href="/catalog">Catalog</a>
-    > {{ entry.name }}
+    > {{ entry.title }}
   </div>
   <div style="margin: 3rem 0;">
     {% include "catalog-entry-status.njk" %}
-    <h1>{{ entry.name }}</h1>
+    <h1>{{ entry.title }}</h1>
   </div>
   <table>
     <tr>
@@ -110,10 +110,10 @@ eleventyComputed:
     {% endif %}
   </table>
   <p>
-    <span><a href="https://stac.dynamical.org/{{ entry.dataset_id }}/collection.json">STAC</a> (<a href="https://radiantearth.github.io/stac-browser/#/external/stac.dynamical.org/{{ entry.dataset_id }}/collection.json">browse</a>)</span>
-    {%- set validationReport = validationReports.entries | find('datasetId', entry.dataset_id) %}
+    <span><a href="https://stac.dynamical.org/{{ entry.id }}/collection.json">STAC</a> (<a href="https://radiantearth.github.io/stac-browser/#/external/stac.dynamical.org/{{ entry.id }}/collection.json">browse</a>)</span>
+    {%- set validationReport = validationReports.entries | find('datasetId', entry.id) %}
     {% if validationReport %}
-      · <a href="/catalog/{{ entry.dataset_id }}/validation/">validation report</a>
+      · <a href="/catalog/{{ entry.id }}/validation/">validation report</a>
     {% elif entry.validation_report_href %}
       · <a href="{{ entry.validation_report_href }}">validation report</a>
     {% endif %}
@@ -126,12 +126,12 @@ eleventyComputed:
     <h3>Related Datasets</h3>
     <ul>
       {% for dataset in model.datasets %}
-        {% if dataset.dataset_id != entry.dataset_id and dataset.status != "deprecated" %}
+        {% if dataset.id != entry.id and dataset.status != "deprecated" %}
           <li>
             {% if dataset.status == 'live' or dataset.status == 'available' %}
-              <a href="/catalog/{{ dataset.dataset_id | slugify }}">{{ dataset.name }}</a>
+              <a href="/catalog/{{ dataset.id | slugify }}">{{ dataset.title }}</a>
             {% else %}
-              {{ dataset.name }} ({{ dataset.status }})
+              {{ dataset.title }} ({{ dataset.status }})
             {% endif %}
             - {{ dataset.description | safe }}
           </li>
@@ -161,7 +161,7 @@ eleventyComputed:
   {% for example in entry.examples %}
     <div class="frame">
       <div class="frameHeader">
-        <div class="frameHeaderTitle">dynamical.org - {{ entry.name | truncate(30, true, '...') }}</div>
+        <div class="frameHeaderTitle">dynamical.org - {{ entry.title | truncate(30, true, '...') }}</div>
         <div class="frameHeaderSubtitle">{{ example.title }}</div>
       </div>
       {{ example.code | highlight('py', 'frameContent frameContentDesktop') | safe }}

--- a/content/catalog.njk
+++ b/content/catalog.njk
@@ -28,9 +28,9 @@ title: catalog
             {% endif %}
             <td>
               {% if entry.status == 'live' or entry.status == 'available' %}
-                <a href="/catalog/{{ entry.dataset_id | slugify }}">{{ entry.name | replace(model.name, '') | trim }}</a>
+                <a href="/catalog/{{ entry.id | slugify }}">{{ entry.title | replace(model.name, '') | trim }}</a>
               {% else %}
-                {{ entry.name | replace(model.name, '') | trim }} ({{ entry.status }})
+                {{ entry.title | replace(model.name, '') | trim }} ({{ entry.status }})
               {% endif %}
             </td>
             <td>{{ entry.spatial_resolution }}</td>

--- a/content/catalog/validation.11ty.js
+++ b/content/catalog/validation.11ty.js
@@ -189,10 +189,10 @@ class ValidationReportPage {
   render({ entry, catalog }) {
     const catalogEntry =
       catalog && catalog.entries
-        ? catalog.entries.find((e) => e.dataset_id === entry.datasetId)
+        ? catalog.entries.find((e) => e.id === entry.datasetId)
         : null;
     const datasetName =
-      (catalogEntry && catalogEntry.name) ||
+      (catalogEntry && catalogEntry.title) ||
       extractDatasetName(entry.markdown, entry.datasetId);
     return renderFragment(entry, datasetName);
   }

--- a/content/earthmover-readmes.njk
+++ b/content/earthmover-readmes.njk
@@ -3,7 +3,7 @@ pagination:
   data: catalog.entries
   alias: entry
   size: 1
-permalink: 'earthmover/{{entry.dataset_id}}.md'
+permalink: 'earthmover/{{entry.id}}.md'
 ---
 {%- set model = catalog.models | find('id', entry.model_id) -%}
 

--- a/content/llms-full.njk
+++ b/content/llms-full.njk
@@ -15,7 +15,7 @@ Datasets are cloud-optimized weather/climate archives distributed as Icechunk (Z
 ## {{ model.name | safe }}
 {% if model.description %}{{ model.description | safe }}
 {% endif %}{% for entry in model.datasets %}
-### {{ entry.name | safe }}
+### {{ entry.title | safe }}
 
 - Page: {{ entry.catalog_url }}
 - STAC Collection: {{ entry.stac_href }}

--- a/content/llms.njk
+++ b/content/llms.njk
@@ -23,7 +23,7 @@ Forecast datasets archive past and present model runs; each run is identified by
 {% for model in catalog.models %}
 ### {{ model.name | safe }}
 {%- for dataset in model.datasets %}
-- **[{{ dataset.name | safe }}]({{ dataset.catalog_url }})** (`{{ dataset.dataset_id }}`) - {{ dataset.spatial_domain | safe }}, {{ dataset.spatial_resolution | safe }}.{% if dataset.forecast_domain %} {{ dataset.forecast_domain | safe }}; {{ dataset.forecast_resolution | safe }}.{% endif %} {{ dataset.time_domain | safe }}; {{ dataset.time_resolution | replace("Forecasts initialized ", "") | safe }}. STAC: {{ dataset.stac_href }}
+- **[{{ dataset.title | safe }}]({{ dataset.catalog_url }})** (`{{ dataset.id }}`) - {{ dataset.spatial_domain | safe }}, {{ dataset.spatial_resolution | safe }}.{% if dataset.forecast_domain %} {{ dataset.forecast_domain | safe }}; {{ dataset.forecast_resolution | safe }}.{% endif %} {{ dataset.time_domain | safe }}; {{ dataset.time_resolution | replace("Forecasts initialized ", "") | safe }}. STAC: {{ dataset.stac_href }}
 {%- endfor %}
 {% endfor %}
 ## Data access


### PR DESCRIPTION
## Context

`_data/catalog.js`'s `reshapeStacCollection` re-declared ~10 fields that the STAC Collection already exposes under the *same* name (`description`, `description_summary/details/model`, `attribution`, `model_id`, `model_name`, `examples`, `license`, `version`) and renamed two more (`name`←`title`, `dataset_id`←`id`). That intermediate copy was noise and a second place to drift from STAC.

This PR makes the reshape **minimal**: spread the STAC Collection directly and only transform where real logic is needed.

## Change

`reshapeStacCollection` now returns `{ ...collection, <computed> }`:

- **Straight from STAC (via spread):** `id`, `title`, `description`, `attribution`, `model_id`, `model_name`, `description_summary/details/model`, `examples`, `license`, `version`, `summaries`, `extent`, `links`, `assets`, `cube:*`.
- **Kept as computed (genuine logic):** `dimensions`, `variables`+`variableGroups`, `notebooks`, `distributions` (reshape nested STAC structures); `license_md`/`license_url` (parse license links); `thumbnail` (filesystem check); `description_meta` (excerpt); `spatial_bbox`/`temporal_interval` (extract from `extent`); `stac_href`/`catalog_url` (URLs); the six `summaries` scalars (STAC stores them as single-element arrays); plus `jsonld`, `status`, and model grouping.

Templates, the JSON-LD builder, and the validation guard now read **STAC-native** `entry.title` / `entry.id` instead of `entry.name` / `entry.dataset_id`. Updated: `content/catalog-pages.njk`, `content/catalog.njk`, `content/llms.njk`, `content/llms-full.njk`, `content/earthmover-readmes.njk`, `content/aws-open-data-registry.njk`, `content/catalog/validation.11ty.js`, and `_data/catalog.js`. (`model.id`/`model.name` are unchanged — those live on the grouped model object.)

## Verification

- `npm run build` succeeds; the drift guard (`validateEntries`) still passes.
- **Built output diffed against `main` — byte-identical** for all catalog/JSON-LD/llms/aws/earthmover output (the only diffs across the two builds were the `Built <timestamp>` footer and the "latest content" popup, both unrelated to this change).
- Spot-checked: catalog page `<h1>`/STAC links, catalog index links, `/aws/*.yaml`, `/earthmover/*.md`, validation page titles, `llms.txt` — all render correctly with `title`/`id`.

## Net effect

8 files, −3 net lines, and ~10 fewer hand-maintained field copies — the reshape now only holds transformations that carry real logic, with everything else read straight from STAC.
