### PR TITLE
Make /updates a lean archive index linking to individual update pages

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -309,6 +309,28 @@ module.exports = function (eleventyConfig) {
     return DateTime.fromJSDate(dateObj, { zone: "utc" }).toISO();
   });
 
+  // Derive a short plain-text summary from rendered HTML for archive listings
+  // (e.g. the /updates index). Strips tags/entities, collapses whitespace, and
+  // truncates on a word boundary. A page's own `description` frontmatter should
+  // win over this when present.
+  eleventyConfig.addFilter("excerpt", (content, maxLength) => {
+    const limit = maxLength || 220;
+    const text = String(content || "")
+      .replace(/<[^>]+>/g, " ")
+      .replace(/&amp;/g, "&")
+      .replace(/&lt;/g, "<")
+      .replace(/&gt;/g, ">")
+      .replace(/&quot;/g, '"')
+      .replace(/&#(?:39|x27);/g, "'")
+      .replace(/&nbsp;/g, " ")
+      .replace(/\s+/g, " ")
+      .trim();
+    if (text.length <= limit) return text;
+    const truncated = text.slice(0, limit);
+    const lastSpace = truncated.lastIndexOf(" ");
+    return (lastSpace > 0 ? truncated.slice(0, lastSpace) : truncated) + "…";
+  });
+
   eleventyConfig.addGlobalData("contributors", async () => {
     const githubHeaders = process.env.GITHUB_TOKEN
       ? { Authorization: `Bearer ${process.env.GITHUB_TOKEN}` }

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -315,14 +315,21 @@ module.exports = function (eleventyConfig) {
   // win over this when present.
   eleventyConfig.addFilter("excerpt", (content, maxLength) => {
     const limit = maxLength || 220;
+    // Decode the handful of entities we care about in a single pass. Sequential
+    // per-entity replaces can double-unescape (e.g. "&amp;lt;" -> "&lt;" -> "<"),
+    // so match them all at once and never re-scan the replacement text.
+    const entities = {
+      "&amp;": "&",
+      "&lt;": "<",
+      "&gt;": ">",
+      "&quot;": '"',
+      "&#39;": "'",
+      "&#x27;": "'",
+      "&nbsp;": " ",
+    };
     const text = String(content || "")
       .replace(/<[^>]+>/g, " ")
-      .replace(/&amp;/g, "&")
-      .replace(/&lt;/g, "<")
-      .replace(/&gt;/g, ">")
-      .replace(/&quot;/g, '"')
-      .replace(/&#(?:39|x27);/g, "'")
-      .replace(/&nbsp;/g, " ")
+      .replace(/&(?:amp|lt|gt|quot|#39|#x27|nbsp);/g, (m) => entities[m])
       .replace(/\s+/g, " ")
       .trim();
     if (text.length <= limit) return text;

--- a/content/updates.njk
+++ b/content/updates.njk
@@ -29,11 +29,13 @@ redirect_from: [/follow, /follow.html]
 </div>
 
 <div class="content">
-{%- for post in collections.updates | reverse -%}
-  <article>
-    <h2>{{ post.data.title }}</h2>
-    <em>{{ post.page.date | readableDate }}</em>
-    {{ post.content | safe }}
-  </article>
-{%- endfor -%}
+  <ul class="update-index">
+  {%- for post in collections.updates | reverse -%}
+    <li class="update-index-item">
+      <time datetime="{{ post.page.date | isoDate }}">{{ post.page.date | readableDate }}</time>
+      <h2><a href="{{ post.url }}">{{ post.data.title }}</a></h2>
+      <p>{{ post.data.description or (post.templateContent | excerpt) }}</p>
+    </li>
+  {%- endfor -%}
+  </ul>
 </div>

--- a/content/updates/2024-06-25.md
+++ b/content/updates/2024-06-25.md
@@ -1,6 +1,7 @@
 ---
 title: Introducing dynamical.org
 date: 2024-06-25
+description: "Introducing dynamical.org — and over a hundred of you have already signed up to test our first release: a GFS analysis with a long historical record."
 ---
 
 Introducing dynamical! 

--- a/content/updates/2024-07-09.md
+++ b/content/updates/2024-07-09.md
@@ -1,6 +1,7 @@
 ---
 title: "Let there be zarr: GFS hourly analysis is live"
 date: 2024-07-09
+description: "Our very first catalog entry is live: an hourly GFS analysis from 2015 to present, with docs and an example notebook. Testers, fire up your rigs."
 ---
 
 Last week, we announced [dynamical.org](http://dynamical.org/) to the world. The response was unexpected\*: in just seven days, over a hundred nerds registered themselves as testers with many more following along for the ride.

--- a/content/updates/2024-09-26.md
+++ b/content/updates/2024-09-26.md
@@ -1,6 +1,7 @@
 ---
 title: "September update"
 date: 2024-09-26
+description: "GEFS forecasts are on deck, survey feedback is shaping the roadmap, and we're assembling a steering committee — plus meteorological prose from Huckleberry Finn."
 ---
 
 Ahoy weatherheads! It’s been a busy few months for us as we shift gears from dreaming to building.

--- a/content/updates/2025-01-10.md
+++ b/content/updates/2025-01-10.md
@@ -1,6 +1,7 @@
 ---
 title: "Alden @ AMS; GEFS zarrs?!"
 date: 2025-01-10
+description: "Catch Alden presenting at AMS with our first fiscal sponsor, Hydro-Québec — and GEFS is almost here, with operational updates going live this week."
 ---
 
 CALLING ALL WEATHER DWEEBS! Bracing for a winter storm here in Nashville, where I moved to from Boston in order to escape winter storms. 3 to 7 inches they say - good thing I brought the XC skis!

--- a/content/updates/2025-03-12.md
+++ b/content/updates/2025-03-12.md
@@ -1,6 +1,7 @@
 ---
 title: "About GEFS-fing Time & Introducing Our Steering Committee"
 date: 2025-03-12
+description: "Our first non-demo release lands: NOAA's GEFS 35-day forecasts, 115TB of live-updating Zarr v3 — and we introduce the steering committee guiding it all."
 ---
 
 Weatherlings, the time has come for our first non-demo release. Weighing in at **115TB** compressed and **815TB** (!) uncompressed, GEFS ain’t messing around.

--- a/content/updates/2025-03-20.md
+++ b/content/updates/2025-03-20.md
@@ -1,6 +1,7 @@
 ---
 title: "1 Million Requests!"
 date: 2025-03-20
+description: "A million requests from 51 countries in GEFS's first week. Here's our Phase 1 dataset slate — and three ways you can help make it happen."
 ---
 
 While modest on the scale of Computers, 1M is not bad for our baby’s first week in the world. The gigabytes are flying and we’ve received requests from 51 countries over the last few days. No single person has downloaded the whole dataset, so thank you but also WHAT ARE YOU WAITING FOR?!

--- a/content/updates/2025-04-29.md
+++ b/content/updates/2025-04-29.md
@@ -1,6 +1,7 @@
 ---
 title: "GEFS analysis is live!"
 date: 2025-04-29
+description: "GEFS analysis is live: 25+ years, live-updating, and designed to pair with the forecast dataset — as satisfying as peeling a citrus in one piece."
 ---
 
 Well, technically it's been live for a few days. Check out our new [GEFS analysis](https://dynamical.org/catalog/noaa-gefs-analysis/), which is derived from the [GEFS forecast](https://dynamical.org/catalog/noaa-gefs-forecast-35-day/) catalog item.

--- a/content/updates/2025-06-14.md
+++ b/content/updates/2025-06-14.md
@@ -1,6 +1,7 @@
 ---
 title: "introducing a new pod; GFS forecasts incoming"
 date: 2025-06-14
+description: "We started a podcast. It's called Weathering, and episode one dives into the limits of atmospheric predictability. Also: GFS forecasts are landing imminently."
 ---
 
 Not even my proprietary UniverseCast™ Reality Ensemble Forecast⁺ could have predicted this. The most unlikely of scenarios: A **podcast**? Yes, a podcast. And it's called [**Weathering**](https://dynamical.org/podcast).

--- a/content/updates/2025-07-02.md
+++ b/content/updates/2025-07-02.md
@@ -1,6 +1,7 @@
 ---
 title: "🟢 GFS is live"
 date: 2025-07-02
+description: "GFS forecasts are live — four years of 16-day hourly forecasts, four times a day. Plus steering committee notes and podcast episode two on Aardvark Weather."
 ---
 
 ## GFS forecasts are live

--- a/content/updates/2025-09-29.md
+++ b/content/updates/2025-09-29.md
@@ -1,6 +1,7 @@
 ---
 title: "Wake up, babe. A new zarr just dropped."
 date: 2025-09-29
+description: "HRRR forecasts are live and updating, Icechunk versions are in testing, and we hacked together a simple scorecard for 2m temp and precip."
 ---
 
 The last time I wrote you all, the summer sweltered, determinism was still alive (now [it is dead](https://dynamical.org/podcast/), and only 11 AI weather papers had been published in Nature (now the total is up to 188,732).

--- a/content/updates/2025-11-20.md
+++ b/content/updates/2025-11-20.md
@@ -1,6 +1,7 @@
 ---
 title: "🟢 ECMWF IFS ENS live and updating"
 date: 2025-11-20
+description: "The European Centre's IFS ENS forecast is now live and updating in the catalog — because ensembles are so hot right now. Icechunk versions available for testing."
 ---
 
 Colder temps may be here (where I live, at least), but ensembles are _so hot right now_. Can we agree on that? No? Ha ha get it!?

--- a/content/updates/2026-01-08.md
+++ b/content/updates/2026-01-08.md
@@ -1,6 +1,7 @@
 ---
 title: "Preview of dynamical.org Icechunk Zarrs are now listed on the Registry of Open Data on AWS!"
 date: 2026-01-08
+description: "Our Icechunk Zarrs are now on the AWS Registry of Open Data — here's why Icechunk, and the two small breaking changes coming with Icechunk 2.0."
 ---
 
 Check out the Icechunk example usage in our docs for [IFS ENS](https://dynamical.org/catalog/ecmwf-ifs-ens-forecast-15-day-0-25-degree/), [GFS](https://dynamical.org/catalog/noaa-gfs-forecast/), and [HRRR](https://dynamical.org/catalog/noaa-hrrr-forecast-48-hour/) forecasts to get started or browse these datasets on the [Registry of Open Data on AWS](https://registry.opendata.aws/?search=managedBy:dynamical.org).

--- a/content/updates/2026-01-23.md
+++ b/content/updates/2026-01-23.md
@@ -1,6 +1,7 @@
 ---
 title: "January cornucopia: AMS | HRRR analysis | more"
 date: 2026-01-23
+description: "Find Alden at AMS, dig into the new HRRR analysis, and celebrate full Icechunk catalog parity — now listed on the AWS Registry and Earthmover's Marketplace."
 ---
 
 What say the pantheon of forecasts? Shall AMS travel be a disaster?

--- a/content/updates/2026-03-10.md
+++ b/content/updates/2026-03-10.md
@@ -1,6 +1,7 @@
 ---
 title: "Warmer temps, datasets heating up."
 date: 2026-03-10
+description: "A heap of updates: a live 21-variable GFS analysis, HRRR analysis extended back to 2014, more variables everywhere, experimental ASOS obs, and a DWD ICON-EU grib archive."
 ---
 
 It's Spring and unlike hobbits (I'm reading LOTR), who would be thinking about gardens and second breakfast and whether Farmer Maggot's mushroom crop will come in early, we are staring at grib files. Just kidding, we are walking outside enjoying the warm weather ... while talking on the _phone_ about grib files.

--- a/content/updates/2026-03-31.md
+++ b/content/updates/2026-03-31.md
@@ -1,6 +1,7 @@
 ---
 title: "Rain, radar, and reckless optimism."
 date: 2026-04-01
+description: "ECMWF's AIFS Single AI forecast and NOAA's MRMS radar join the catalog, we cross 200M monthly requests, and we're testing a dynamical-catalog Python library."
 ---
 
 Salutations, wxers. To balance out all the April 1 corporate tomfoolery I'm going to be less of a goofball today. Let's see if I can keep it STRICTLY BUSINESS.

--- a/content/updates/2026-04-17.md
+++ b/content/updates/2026-04-17.md
@@ -1,6 +1,7 @@
 ---
 title: "dynamical.org - icechunk 2.0 upgrade cometh"
 date: 2026-04-17
+description: "A quick housekeeping note: Icechunk 2 is out. Update your Python library before April 24 — and note it now requires Python 3.12 or higher."
 ---
 
 Short one today — a quick housekeeping note for anyone pulling from our icechunk data products.

--- a/content/updates/2026-04-24.md
+++ b/content/updates/2026-04-24.md
@@ -1,6 +1,7 @@
 ---
 title: "Time 2 Chunk (2.0), DWD ICON-EU, status for weather"
 date: 2026-04-24
+description: "Zarr v3 is deprecated — migrate to Icechunk by July 23. Meet the new access patterns via dynamical-catalog and STAC, plus the freshly live DWD ICON-EU forecast."
 ---
 
 Listen, my second child is arriving any minute now. This transmission will be brief. I haven't decided if I will name him Poseidon, Gefs, or Turbulence.

--- a/content/updates/2026-06-01.md
+++ b/content/updates/2026-06-01.md
@@ -1,6 +1,7 @@
 ---
 title: "AIFS ENS and validation reports"
 date: 2026-06-01
+description: "ECMWF AIFS ENS joins the catalog, we're adding in-depth validation reports to every dataset, and there's a dynamical.org post on the AWS Public Sector Blog."
 ---
 
 I was tempted, but alas Gefs (short for Gefsfry) did not make the cut for the name of my newborn son. He's here and everyone is healthy - so I'm getting back to it. Some catch-up:

--- a/public/main.css
+++ b/public/main.css
@@ -566,16 +566,19 @@ article img {
 }
 
 /* Updates archive index (/updates): a lean list of entries — date, linked
-   title, and a short summary — each linking to its own /updates/<date>/ page. */
+   title, and a short summary — each linking to its own /updates/<date>/ page.
+   Capped to a reading measure so the hairline separators track the text
+   rather than stretching the full 78rem content width. */
 .update-index {
   list-style: none;
   margin: 0;
   padding: 0;
+  max-width: 58rem;
 }
 
 .update-index-item {
-  padding: 2rem 0;
-  border-top: 1px solid var(--border-color);
+  padding: 3rem 0;
+  border-top: 1px solid var(--popup-border);
 }
 
 /* Override the generic `.content li + li` spacing so the bordered rows stay
@@ -584,34 +587,35 @@ article img {
   margin-top: 0;
 }
 
-.update-index-item:last-child {
-  border-bottom: 1px solid var(--border-color);
-}
-
 .update-index-item time {
   display: block;
-  font-size: 1.3rem;
+  margin-bottom: 1rem;
+  font-size: 1.2rem;
   color: var(--muted-text);
   text-transform: uppercase;
-  letter-spacing: 0.05em;
+  letter-spacing: 0.08em;
 }
 
 .update-index-item h2 {
-  margin: 0.3rem 0 0.6rem;
+  margin: 0 0 0.9rem;
+  font-size: 2rem;
+  line-height: 1.25;
 }
 
 .update-index-item h2 a {
+  color: var(--text-color);
   text-decoration: none;
 }
 
 .update-index-item h2 a:hover {
+  color: var(--link-color);
   text-decoration: underline;
 }
 
 .update-index-item p {
   margin: 0;
   color: var(--muted-text);
-  max-width: 70ch;
+  line-height: 1.6;
 }
 
 /* Low-tech figures (figure shortcode or inline <figure> HTML). */

--- a/public/main.css
+++ b/public/main.css
@@ -565,6 +565,55 @@ article img {
   margin-bottom: 2.5rem;
 }
 
+/* Updates archive index (/updates): a lean list of entries — date, linked
+   title, and a short summary — each linking to its own /updates/<date>/ page. */
+.update-index {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.update-index-item {
+  padding: 2rem 0;
+  border-top: 1px solid var(--border-color);
+}
+
+/* Override the generic `.content li + li` spacing so the bordered rows stay
+   flush and evenly spaced (including the first item). */
+.update-index .update-index-item + .update-index-item {
+  margin-top: 0;
+}
+
+.update-index-item:last-child {
+  border-bottom: 1px solid var(--border-color);
+}
+
+.update-index-item time {
+  display: block;
+  font-size: 1.3rem;
+  color: var(--muted-text);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.update-index-item h2 {
+  margin: 0.3rem 0 0.6rem;
+}
+
+.update-index-item h2 a {
+  text-decoration: none;
+}
+
+.update-index-item h2 a:hover {
+  text-decoration: underline;
+}
+
+.update-index-item p {
+  margin: 0;
+  color: var(--muted-text);
+  max-width: 70ch;
+}
+
 /* Low-tech figures (figure shortcode or inline <figure> HTML). */
 figure {
   margin: 2rem 0;


### PR DESCRIPTION
## What & why

Each update in `content/updates/*.md` already renders as its own standalone page at `/updates/<date>/` (via the `update.njk` layout), and both the RSS feed and the sitemap already point at those individual URLs. But the human-facing `/updates` page dumped **every** update's full content inline, so:

- each update lived at two URLs (inline on `/updates` *and* at `/updates/<date>/`) — duplicate content, both listed in the sitemap
- the individual pages were effectively **orphaned** — reachable via the feed or by guessing the URL, but never linked from the site's own navigation (nav, footer, and about page all point to `/updates`)

This reworks `/updates` into a lean archive index (à la the Ink & Switch newsletter): each entry is a row with its date, a linked title, and a short summary, linking out to its standalone page. That makes the individual pages the canonical home for update content — matching the feed and sitemap — and removes the duplicated full text.

## Changes

- **`.eleventy.js`** — add an `excerpt` filter that derives a plain-text summary from rendered HTML (strips tags/entities, collapses whitespace, truncates on a word boundary). A page's own `description` frontmatter wins over the auto-excerpt when present, so future updates can override the summary.
- **`content/updates.njk`** — replace the inline full-content loop with a `.update-index` list of entries (date · linked title · summary). The newsletter subscribe form is unchanged.
- **`public/main.css`** — add styles for `.update-index`, including an override so the generic `.content li + li` spacing doesn't disrupt the bordered rows.

## Verification

Built locally with `npx @11ty/eleventy`:
- all 18 individual `/updates/<date>/` pages generate
- `/updates` renders as the index, each title linking to its `/updates/<date>/` page with a clean auto-excerpt
- `docs/feed/feed.xml` entries still link to the individual pages
- `docs/sitemap.xml` still lists both the index and the individual pages

No manual CSS cache-bust needed — `_data/assets.js` hashes `main.css` contents automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JMzRTAYmRax9pggx6JYqnz

---
_Generated by [Claude Code](https://claude.ai/code/session_01JMzRTAYmRax9pggx6JYqnz)_