### PR TITLE
Update "delayed" definition: p95 + 1 minute grace

### DIFF
--- a/content/research/when-the-forecast-is-ready.md
+++ b/content/research/when-the-forecast-is-ready.md
@@ -15,7 +15,7 @@ summary: >-
 
 Forecast production is a factory assembly line, a fulfillment center, and a delivery route all in one. Lewis Fry Richardson's Weather Forecasting Factory was not too far off.
 
-{% figure "/assets/notes/conlin-1.jpg" %}“Weather Forecasting Factory” by Stephen Conlin, 1986. Based on the description in Weather Prediction by Numerical Process, by L.F. Richardson, Cambridge University Press, 1922, and on advice from Prof. John Byrne, Trinity College Dublin. Image: ink and water colour, c. 50 x 38.5 cm. © Stephen Conlin 1986. All Rights Reserved ´. (Courtesy: Hendrik Hoffmann, School of Mathematics & Statistics, University College Dublin){% endfigure %}
+{% figure "/assets/notes/conlin-1.jpg" %}“Weather Forecasting Factory” by Stephen Conlin, 1986. Based on the description in Weather Prediction by Numerical Process, by L.F. Richardson, Cambridge University Press, 1922, and on advice from Prof. John Byrne, Trinity College Dublin. Image: ink and water colour, c. 50 x 38.5 cm. © Stephen Conlin 1986. All Rights Reserved ´. (Courtesy: Hendrik Hoffmann, School of Mathematics & Statistics, University College Dublin [Source](https://www.emetsoc.org/resources/rff/)){% endfigure %}
 
 Every dataset in the dynamical.org catalog (so far) is downstream of a model run that
 someone else produces on their own cadence. And the initialization is just the beginning (literally and philosophically). Then the files start landing, one by one, eventually
@@ -137,7 +137,7 @@ is currently allowlisted, so [get in touch](mailto:feedback@dynamical.org) if
 you'd like to try it. You can even attach a small sandboxed Python function that runs
 against the just-arrived dataset and shapes the payload or filters out deliveries you don't want.
 
-{% figure "/assets/notes/wxopticon-slack.jpg" %}It also supports Slack-style webhooks.{% endfigure %}
+{% figure "/assets/notes/wxopticon-slack.png" %}It also supports Slack-style webhooks.{% endfigure %}
 
 ## Prefer polling? The status feed
 

--- a/content/research/when-the-forecast-is-ready.md
+++ b/content/research/when-the-forecast-is-ready.md
@@ -55,7 +55,7 @@ hours become available:
 | `started`    | the first file of a run lands (any lead time)                     |
 | `progress`   | every lead ≤ a lead-group horizon is available (e.g. `progress:f240`) |
 | `complete`   | the full run is available — you don't need to know group names    |
-| `delayed`    | the expected completion time (p95) passed while the run is still in flight |
+| `delayed`    | the run is still in flight a minute past its expected completion time (p95) |
 
 I went back and forth on the correct threshold for "delayed," and I think it could be an area where further tweaks are needed. As we roll out our own [SLA](/sla), we will treat delayed for dynamical.org as a commitment rather than being driven by historical stats.
 


### PR DESCRIPTION
Companion to [dynamical-org/wxopticon#69](https://github.com/dynamical-org/wxopticon/pull/69).

## Changes

- **"When the forecast is ready" article** — updates the `delayed` readiness-boundary definition to match wxopticon's threshold change: a run is `delayed` once it's still in flight **one minute past** its expected completion (p95), rather than the instant it crosses p95. p95 stays the expected-completion ETA; `delayed` is now a slightly-stricter alarm.
- Adds a source link to the "Weather Forecasting Factory" figure caption (unrelated pre-existing edit, included per request).