### PR TITLE
SEO/LLM discoverability — Tier 1: homepage, canonical, keywords, structured data

### DIFF
--- a/_includes/base.njk
+++ b/_includes/base.njk
@@ -4,11 +4,12 @@
     <meta charset="utf-8"/>
     <meta name="Content-Type" content="text/html; charset=UTF-8"/>
     <meta name="author" content="Dynamical Team"/>
-    <meta name="keywords" content="Weather, data, zarr"/>
+    <meta name="keywords" content="{{ keywords or 'Weather, data, zarr' }}"/>
     <title>dynamical.org {{ '- ' + title if title else '' }}</title>
     <meta name="description" content="{{ description or metadata.description }}"/>
     <meta name="license" content="name=BY-NC-SA(4.0), url=https://creativecommons.org/licenses/by-nc-sa/4.0/"/>
     <meta name="viewport" content="width=device-width,initial-scale=1"/>
+    <link rel="canonical" href="https://dynamical.org{{ page.url }}"/>
     {% set isPodcast = tags and ("podcast" in tags) %}
     {# Titled pages get a unique social card; pages without a title (e.g. the many
        auto-generated scorecard pages) share one default brand card. #}

--- a/_includes/base.njk
+++ b/_includes/base.njk
@@ -4,7 +4,7 @@
     <meta charset="utf-8"/>
     <meta name="Content-Type" content="text/html; charset=UTF-8"/>
     <meta name="author" content="Dynamical Team"/>
-    <meta name="keywords" content="{{ keywords or 'Weather, data, zarr' }}"/>
+    <meta name="keywords" content="{{ keywords or 'cloud-optimized weather data, analysis-ready weather data, weather and climate data, weather data catalog, Zarr, Icechunk, Xarray, NOAA GFS, ECMWF IFS, HRRR' }}"/>
     <title>dynamical.org {{ '- ' + title if title else '' }}</title>
     <meta name="description" content="{{ description or metadata.description }}"/>
     <meta name="license" content="name=BY-NC-SA(4.0), url=https://creativecommons.org/licenses/by-nc-sa/4.0/"/>

--- a/_includes/podcast-episode.njk
+++ b/_includes/podcast-episode.njk
@@ -2,6 +2,26 @@
 layout: base.njk
 ---
 
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "PodcastEpisode",
+  "name": {{ title | dump | safe }},
+  "url": "https://dynamical.org{{ page.url }}",
+  "datePublished": "{{ page.date | isoDate }}",
+  {% if episode_number %}"episodeNumber": "{{ episode_number }}",{% endif %}
+  "description": {{ (description or metadata.description) | dump | safe }},
+  {% if audio_url %}"associatedMedia": { "@type": "MediaObject", "contentUrl": "{{ audio_url }}", "encodingFormat": "audio/mpeg" },{% endif %}
+  "partOfSeries": {
+    "@type": "PodcastSeries",
+    "name": "weathering",
+    "url": "https://dynamical.org/podcast/",
+    "webFeed": "https://dynamical.org/feed/podcast.xml"
+  },
+  "publisher": { "@id": "https://dynamical.org/#organization" }
+}
+</script>
+
 <div class="content">
   <h1>{{ title }}</h1>
   <a href="{{ apple_url }}">

--- a/_includes/research-post.njk
+++ b/_includes/research-post.njk
@@ -2,6 +2,26 @@
 layout: base.njk
 ---
 
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "TechArticle",
+  "headline": {{ title | dump | safe }},
+  "datePublished": "{{ page.date | isoDate }}",
+  "dateModified": "{{ page.date | isoDate }}",
+  "description": {{ (description or metadata.description) | dump | safe }},
+  "url": "https://dynamical.org{{ page.url }}",
+  "mainEntityOfPage": "https://dynamical.org{{ page.url }}",
+  "image": "https://dynamical.org/assets/og/{{ page.url | ogSlug }}.png",
+  "author": {% if authors %}[
+    {%- for author in authors %}
+    { "@type": "Person", "name": {{ (author.name or author) | dump | safe }}{% if author.url %}, "url": {{ author.url | dump | safe }}{% endif %} }{% if not loop.last %},{% endif %}
+    {%- endfor %}
+  ]{% else %}{ "@id": "https://dynamical.org/#organization" }{% endif %},
+  "publisher": { "@id": "https://dynamical.org/#organization" }
+}
+</script>
+
 {# Annotate headings + build the scroll-spy TOC over the rendered body. #}
 {% set toc = content | tocify %}
 

--- a/_includes/update.njk
+++ b/_includes/update.njk
@@ -2,6 +2,22 @@
 layout: base.njk
 ---
 
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BlogPosting",
+  "headline": {{ title | dump | safe }},
+  "datePublished": "{{ page.date | isoDate }}",
+  "dateModified": "{{ page.date | isoDate }}",
+  "description": {{ (description or metadata.description) | dump | safe }},
+  "url": "https://dynamical.org{{ page.url }}",
+  "mainEntityOfPage": "https://dynamical.org{{ page.url }}",
+  "image": "https://dynamical.org/assets/og/{{ page.url | ogSlug }}.png",
+  "author": { "@id": "https://dynamical.org/#organization" },
+  "publisher": { "@id": "https://dynamical.org/#organization" }
+}
+</script>
+
 <div class="content">
     <p><a href="/updates">← back to all updates</a></p>
     <h1>{{ title }}</h1>

--- a/content/about.html
+++ b/content/about.html
@@ -1,6 +1,7 @@
 ---
 layout: base.njk
 title: about
+keywords: "dynamical.org, open weather data, weather data infrastructure, cloud-optimized weather data, analysis-ready weather data, Zarr, Icechunk, public benefit corporation, weather data access, climate data"
 redirects_from: /about.html
 ---
 

--- a/content/catalog-pages.njk
+++ b/content/catalog-pages.njk
@@ -9,7 +9,7 @@ permalink: 'catalog/{{entry.id | slugify}}/'
 eleventyComputed:
   title: '{{entry.title}}'
   description: '{{ entry.description_meta }}'
-  keywords: '{{ entry.model_name }}, {{ entry.title }}, weather data, forecast data, cloud-optimized, zarr, icechunk, xarray'
+  keywords: '{{ entry.model_name }}, {{ entry.title }}, {{ entry.model_name }} zarr, {{ entry.model_name }} data, {% if entry.forecast_domain %}weather forecast data{% else %}weather analysis data, reanalysis{% endif %}, cloud-optimized weather data, analysis-ready, Xarray, Icechunk'
   socialTitle: '{{ entry.title }} — dynamical.org'
   socialImage: '{{ entry.thumbnail }}'
 ---

--- a/content/catalog-pages.njk
+++ b/content/catalog-pages.njk
@@ -9,6 +9,7 @@ permalink: 'catalog/{{entry.id | slugify}}/'
 eleventyComputed:
   title: '{{entry.title}}'
   description: '{{ entry.description_meta }}'
+  keywords: '{{ entry.model_name }}, {{ entry.title }}, weather data, forecast data, cloud-optimized, zarr, icechunk, xarray'
   socialTitle: '{{ entry.title }} — dynamical.org'
   socialImage: '{{ entry.thumbnail }}'
 ---

--- a/content/catalog.njk
+++ b/content/catalog.njk
@@ -1,6 +1,7 @@
 ---
 layout: base.njk
 title: catalog
+keywords: "cloud-optimized weather data, weather data catalog, analysis-ready weather data, weather forecast data, reanalysis data, GRIB alternative, Zarr, Icechunk, Xarray, NOAA GFS, GEFS, HRRR, ECMWF IFS, DWD ICON, open weather data"
 ---
 
 <style>

--- a/content/index.html
+++ b/content/index.html
@@ -1,6 +1,7 @@
 ---
 layout: base.njk
-title: home
+title: "Cloud-optimized weather & climate data"
+description: "dynamical.org is a public catalog of cloud-optimized, analysis-ready weather and climate datasets — NOAA GFS, GEFS, HRRR and MRMS, ECMWF IFS and AIFS, and DWD ICON — published as free Zarr archives you can open directly with Xarray."
 redirects_from: /index.html
 templateEngineOverride: njk
 ---
@@ -10,6 +11,13 @@ templateEngineOverride: njk
   <div class="hero-content">
     <p class="mission-statement">
       A lab advancing how we <strong>access</strong>, <strong>understand</strong>, and <strong>act</strong> on data about our world.
+    </p>
+    <p class="mission-sub">
+      dynamical.org is a public catalog of cloud-optimized weather and climate data. We
+      republish forecasts and analyses from models like NOAA GFS, GEFS, HRRR and MRMS,
+      ECMWF IFS and AIFS, and DWD ICON as free, analysis-ready
+      <a href="/catalog">Zarr archives</a> you can open directly with Xarray — no GRIB
+      wrangling, no bulk downloads.
     </p>
   </div>
   <div class="hero-visual">
@@ -22,6 +30,17 @@ templateEngineOverride: njk
     <div id="globe-footnote" class="globe-footnote"></div>
   </div>
 </div>
+
+<section class="content home-section" id="data">
+  <div class="home-section-head">
+    <h2 class="block-label"><a href="/catalog">Data catalog</a></h2>
+  </div>
+  <ul class="index-list">
+    {%- for model in catalog.models %}
+    <li><a href="/catalog/models/{{ model.id }}/">{{ model.name }}</a></li>
+    {%- endfor %}
+  </ul>
+</section>
 
 <section class="content home-section" id="research">
   <div class="home-section-head">

--- a/content/index.html
+++ b/content/index.html
@@ -2,6 +2,7 @@
 layout: base.njk
 title: "Cloud-optimized weather & climate data"
 description: "dynamical.org is a public catalog of cloud-optimized, analysis-ready weather and climate datasets — NOAA GFS, GEFS, HRRR and MRMS, ECMWF IFS and AIFS, and DWD ICON — published as free Zarr archives you can open directly with Xarray."
+keywords: "cloud-optimized weather data, analysis-ready weather data, weather and climate data, weather data catalog, Zarr, Icechunk, Xarray, NOAA GFS, ECMWF IFS, HRRR"
 redirects_from: /index.html
 templateEngineOverride: njk
 ---

--- a/content/index.html
+++ b/content/index.html
@@ -12,13 +12,6 @@ templateEngineOverride: njk
     <p class="mission-statement">
       A lab advancing how we <strong>access</strong>, <strong>understand</strong>, and <strong>act</strong> on data about our world.
     </p>
-    <p class="mission-sub">
-      dynamical.org is a public catalog of cloud-optimized weather and climate data. We
-      republish forecasts and analyses from models like NOAA GFS, GEFS, HRRR and MRMS,
-      ECMWF IFS and AIFS, and DWD ICON as free, analysis-ready
-      <a href="/catalog">Zarr archives</a> you can open directly with Xarray — no GRIB
-      wrangling, no bulk downloads.
-    </p>
   </div>
   <div class="hero-visual">
     <canvas id="globe-canvas"></canvas>
@@ -30,17 +23,6 @@ templateEngineOverride: njk
     <div id="globe-footnote" class="globe-footnote"></div>
   </div>
 </div>
-
-<section class="content home-section" id="data">
-  <div class="home-section-head">
-    <h2 class="block-label"><a href="/catalog">Data catalog</a></h2>
-  </div>
-  <ul class="index-list">
-    {%- for model in catalog.models %}
-    <li><a href="/catalog/models/{{ model.id }}/">{{ model.name }}</a></li>
-    {%- endfor %}
-  </ul>
-</section>
 
 <section class="content home-section" id="research">
   <div class="home-section-head">

--- a/content/index.html
+++ b/content/index.html
@@ -2,7 +2,6 @@
 layout: base.njk
 title: "Cloud-optimized weather & climate data"
 description: "dynamical.org is a public catalog of cloud-optimized, analysis-ready weather and climate datasets — NOAA GFS, GEFS, HRRR and MRMS, ECMWF IFS and AIFS, and DWD ICON — published as free Zarr archives you can open directly with Xarray."
-keywords: "cloud-optimized weather data, analysis-ready weather data, weather and climate data, weather data catalog, Zarr, Icechunk, Xarray, NOAA GFS, ECMWF IFS, HRRR"
 redirects_from: /index.html
 templateEngineOverride: njk
 ---

--- a/content/index.html
+++ b/content/index.html
@@ -1,7 +1,6 @@
 ---
 layout: base.njk
 title: "Cloud-optimized weather & climate data"
-description: "dynamical.org is a public catalog of cloud-optimized, analysis-ready weather and climate datasets — NOAA GFS, GEFS, HRRR and MRMS, ECMWF IFS and AIFS, and DWD ICON — published as free Zarr archives you can open directly with Xarray."
 redirects_from: /index.html
 templateEngineOverride: njk
 ---

--- a/content/podcast.njk
+++ b/content/podcast.njk
@@ -2,6 +2,7 @@
 layout: base.njk
 title: weathering
 description: "At the intersection of weather forecasting, technology, and the unknowable. A scattered mix of academic papers, good books, philosophy, and the human relationship with weather. Hosted by Marshall, Marta, and Alden."
+keywords: "weathering podcast, weather podcast, forecasting podcast, meteorology podcast, weather and climate, weather forecasting"
 ---
 
 <script type="application/ld+json">

--- a/content/podcast.njk
+++ b/content/podcast.njk
@@ -4,6 +4,18 @@ title: weathering
 description: "At the intersection of weather forecasting, technology, and the unknowable. A scattered mix of academic papers, good books, philosophy, and the human relationship with weather. Hosted by Marshall, Marta, and Alden."
 ---
 
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "PodcastSeries",
+  "name": "weathering",
+  "url": "https://dynamical.org{{ page.url }}",
+  "description": {{ description | dump | safe }},
+  "webFeed": "https://dynamical.org/feed/podcast.xml",
+  "publisher": { "@id": "https://dynamical.org/#organization" }
+}
+</script>
+
 <div class="content">
   <img src="/assets/weathering/weathering_logo_figs.png" alt="weathering logo" style="width: 100%; max-width: 300px; margin-bottom: 1rem;">
   <p>{{ description }}</p>

--- a/content/podcast/podcast.11tydata.js
+++ b/content/podcast/podcast.11tydata.js
@@ -3,6 +3,10 @@ module.exports = {
     "podcast"
   ],
   "layout": "podcast-episode.njk",
+  // Section-level keyword base; individual episodes can override with their own
+  // `keywords` frontmatter.
+  keywords:
+    "weathering podcast, weather podcast, forecasting podcast, meteorology, weather and climate",
   permalink: function(data) {
     return `/podcast/${data.page.fileSlug}/`;
   }

--- a/content/research/research.11tydata.js
+++ b/content/research/research.11tydata.js
@@ -1,6 +1,10 @@
 module.exports = {
   tags: ["research"],
   layout: "research-post.njk",
+  // Section-level keyword base; individual notes can override with their own
+  // `keywords` frontmatter.
+  keywords:
+    "weather forecasting research, forecast evaluation, weather product design, weather data science, cloud-optimized weather data, dynamical.org",
   // Long-form pieces surface their abstract as the page/social-card description.
   eleventyComputed: {
     description: (data) => data.summary || data.description,

--- a/content/scorecard.njk
+++ b/content/scorecard.njk
@@ -1,6 +1,7 @@
 ---
 layout: base
 title: Scorecard
+keywords: "weather forecast accuracy, forecast verification, weather model skill scores, forecast evaluation, weather model comparison, GFS vs HRRR accuracy, forecast error, ASOS observations, weather forecast benchmark"
 ---
 
 <style>

--- a/content/updates.njk
+++ b/content/updates.njk
@@ -1,6 +1,7 @@
 ---
 layout: base.njk
 title: updates
+keywords: "weather data news, dataset releases, dynamical.org updates, changelog, new weather datasets, cloud-optimized weather data"
 redirect_from: [/follow, /follow.html]
 ---
 

--- a/content/updates/updates.11tydata.js
+++ b/content/updates/updates.11tydata.js
@@ -1,4 +1,8 @@
 module.exports = {
   tags: ["updates"],
   layout: "update.njk",
+  // Section-level keyword base; individual posts can override with their own
+  // `keywords` frontmatter.
+  keywords:
+    "dynamical.org, weather data update, cloud-optimized weather data, Zarr, dataset release, weather data news",
 };

--- a/public/main.css
+++ b/public/main.css
@@ -710,6 +710,12 @@ a.work-item:hover h3 { text-decoration: underline; }
   margin: 0;
   text-wrap: pretty;
 }
+.mission-sub {
+  margin: 1.5rem 0 0;
+  max-width: 52ch;
+  color: var(--muted-text);
+  text-wrap: pretty;
+}
 .home-section { margin-top: 6rem; }
 .home-section-head {
   display: flex;

--- a/public/main.css
+++ b/public/main.css
@@ -710,12 +710,6 @@ a.work-item:hover h3 { text-decoration: underline; }
   margin: 0;
   text-wrap: pretty;
 }
-.mission-sub {
-  margin: 1.5rem 0 0;
-  max-width: 52ch;
-  color: var(--muted-text);
-  text-wrap: pretty;
-}
 .home-section { margin-top: 6rem; }
 .home-section-head {
   display: flex;


### PR DESCRIPTION
## Context

First PR in a prioritized SEO / LLM-discoverability roadmap. The site is already unusually strong here (per-dataset `Dataset` JSON-LD, `llms.txt`/`llms-full.txt`, MCP server, sitemap, feeds, dynamic OG cards). This PR closes the highest-impact / lowest-effort gaps to existing pages. Larger structural work (model hub pages in PR #119, a `/learn/` guides + glossary section) follows separately.

## Changes

**Homepage** (`content/index.html`)
- Replaced `title: home` (which rendered `<title>dynamical.org - home</title>`) with a descriptive title and added a page-specific meta description. These are invisible SEO metadata only — the homepage's visual design is unchanged.

**Sitewide head** (`_includes/base.njk`)
- Added `<link rel="canonical">` on every page (canonical was previously only implied via `og:url`).
- Made the `keywords` meta per-page with the existing sitewide value as fallback.

**Per-page keywords** (`content/catalog-pages.njk`)
- Catalog pages now emit `keywords` derived from the model name plus standard terms (STAC `keywords` are frequently absent; strengthening that source is planned for a later PR).

**Structured data (JSON-LD)**
- `BlogPosting` on updates (`_includes/update.njk`).
- `TechArticle` on research notes, mapping the `authors` front matter to `Person` nodes (`_includes/research-post.njk`).
- `PodcastEpisode` on episodes and `PodcastSeries` on the podcast index (`_includes/podcast-episode.njk`, `content/podcast.njk`).
- All reference the existing sitewide `#organization` node.

## Verification

- `npm run build` completes and passes the catalog `validateEntries` gate.
- Confirmed in `docs/`: homepage `<title>`/description, `<link rel="canonical">` on homepage + catalog pages, per-page `keywords`, and each new JSON-LD block.
- Parsed every emitted `application/ld+json` block with `JSON.parse` — all valid.

## Notes

`docs/` is build output and not checked in. An earlier revision of this PR also added a visible homepage intro paragraph and a "Data catalog" section; those were removed per review — only the `<title>`/description metadata remains from the homepage change.
