### PR TITLE
SEO/LLM discoverability — Tier 2: model hub pages + breadcrumb structured data

### DIFF
--- a/content/catalog-pages.njk
+++ b/content/catalog-pages.njk
@@ -111,9 +111,22 @@ eleventyComputed:
 {% endmacro %}
 <div class="content catalog-item">
   {%- set model = catalog.models | find('id', entry.model_id) %}
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://dynamical.org/" },
+      { "@type": "ListItem", "position": 2, "name": "Catalog", "item": "https://dynamical.org/catalog/" },
+      {% if model %}{ "@type": "ListItem", "position": 3, "name": {{ model.name | dump | safe }}, "item": "https://dynamical.org/catalog/models/{{ model.id | slugify }}/" },
+      { "@type": "ListItem", "position": 4, "name": {{ entry.title | dump | safe }}, "item": "https://dynamical.org{{ page.url }}" }{% else %}{ "@type": "ListItem", "position": 3, "name": {{ entry.title | dump | safe }}, "item": "https://dynamical.org{{ page.url }}" }{% endif %}
+    ]
+  }
+  </script>
   <div>
     <a href="/catalog">Catalog</a>
-    > {{ entry.title }}
+    {% if model %}&gt; <a href="/catalog/models/{{ model.id | slugify }}/">{{ model.name }}</a>{% endif %}
+    &gt; {{ entry.title }}
   </div>
   <div style="margin: 3rem 0;">
     {% include "catalog-entry-status.njk" %}

--- a/content/model-pages.njk
+++ b/content/model-pages.njk
@@ -8,7 +8,7 @@ permalink: 'catalog/models/{{model.id | slugify}}/'
 eleventyComputed:
   title: '{{ model.name }}'
   description: 'Cloud-optimized {{ model.name }} weather data from dynamical.org — free, analysis-ready Icechunk Zarr archives you can open directly with Xarray, no GRIB wrangling or bulk downloads.'
-  keywords: '{{ model.name }}, {{ model.name }} data, {{ model.name }} zarr, {{ model.name }} forecast, weather data, cloud-optimized, xarray, icechunk'
+  keywords: '{{ model.name }}, {{ model.name }} data, {{ model.name }} zarr, {{ model.name }} forecast, {{ model.name }} download, cloud-optimized weather data, analysis-ready, Xarray, Icechunk'
   socialTitle: '{{ model.name }} — dynamical.org'
 ---
 <style>

--- a/content/model-pages.njk
+++ b/content/model-pages.njk
@@ -3,18 +3,120 @@ pagination:
   data: catalog.models
   alias: model
   size: 1
+layout: base.njk
 permalink: 'catalog/models/{{model.id | slugify}}/'
-eleventyExcludeFromCollections: true
+eleventyComputed:
+  title: '{{ model.name }}'
+  description: 'Cloud-optimized {{ model.name }} weather data from dynamical.org — free, analysis-ready Icechunk Zarr archives you can open directly with Xarray, no GRIB wrangling or bulk downloads.'
+  keywords: '{{ model.name }}, {{ model.name }} data, {{ model.name }} zarr, {{ model.name }} forecast, weather data, cloud-optimized, xarray, icechunk'
+  socialTitle: '{{ model.name }} — dynamical.org'
 ---
-<!doctype html>
-<html>
-  <head>
-    <meta charset="utf-8">
-    <meta http-equiv="refresh" content="0; url=/catalog#:~:text={{ model.name | replace(' ', '%20') }}">
-    <link rel="canonical" href="/catalog#:~:text={{ model.name | replace(' ', '%20') }}">
-    <title>{{ model.name }} – dynamical.org</title>
-  </head>
-  <body>
-    <p>Redirecting to <a href="/catalog#:~:text={{ model.name | replace(' ', '%20') }}">catalog</a>…</p>
-  </body>
-</html>
+<style>
+  /* Mirrors the catalog index list styles (content/catalog.njk). */
+  .cat-name {
+    font-weight: 700;
+    text-decoration: underline;
+    color: var(--link-color);
+  }
+  .cat-type-tag {
+    margin-left: 1rem;
+    font-size: 1rem;
+    font-weight: 400;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+  }
+  .cat-meta {
+    margin-top: 0.3rem;
+    color: var(--muted-text);
+  }
+</style>
+
+{%- set liveDatasets = [] -%}
+{%- for ds in model.datasets -%}
+  {%- if ds.status != "deprecated" -%}{%- set _ = liveDatasets.push(ds) -%}{%- endif -%}
+{%- endfor -%}
+{%- set forecasts = [] -%}
+{%- set analyses = [] -%}
+{%- for ds in liveDatasets -%}
+  {%- if ds.forecast_domain -%}{%- set _ = forecasts.push(ds) -%}
+  {%- else -%}{%- set _ = analyses.push(ds) -%}{%- endif -%}
+{%- endfor -%}
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://dynamical.org/" },
+    { "@type": "ListItem", "position": 2, "name": "Catalog", "item": "https://dynamical.org/catalog/" },
+    { "@type": "ListItem", "position": 3, "name": {{ model.name | dump | safe }}, "item": "https://dynamical.org{{ page.url }}" }
+  ]
+}
+</script>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "CollectionPage",
+  "name": {{ (model.name + " datasets") | dump | safe }},
+  "url": "https://dynamical.org{{ page.url }}",
+  "description": {{ description | dump | safe }},
+  "isPartOf": { "@id": "https://dynamical.org/#website" },
+  "publisher": { "@id": "https://dynamical.org/#organization" },
+  "hasPart": [
+    {%- for ds in liveDatasets %}
+    { "@type": "Dataset", "name": {{ ds.title | dump | safe }}, "url": "https://dynamical.org/catalog/{{ ds.id | slugify }}/" }{% if not loop.last %},{% endif %}
+    {%- endfor %}
+  ]
+}
+</script>
+
+<div class="content">
+  <div>
+    <a href="/catalog">Catalog</a>
+    &gt; {{ model.name }}
+  </div>
+
+  <h1 style="margin: 3rem 0 1rem;">{{ model.name }}</h1>
+
+  {% if model.description %}
+    <p style="text-wrap: balance">{{ model.description | markdown | safe }}</p>
+  {% endif %}
+
+  <p>
+    dynamical.org republishes {{ model.name }} as free, analysis-ready
+    <a href="/catalog">Icechunk Zarr archives</a> — open them directly with Xarray, no
+    GRIB wrangling or bulk downloads.
+  </p>
+
+  {% macro variantRow(ds) %}
+    {%- set vars = "all variables" if ds.optimization == "space" else (ds.variable_count | string) + " variables" -%}
+    <li>
+      {%- set optTag %}<span class="cat-type-tag">{{ "space-optimized" if ds.optimization == "space" else "time-optimized" }}</span>{% endset -%}
+      {% if ds.status == 'live' or ds.status == 'available' %}
+        <a href="/catalog/{{ ds.id | slugify }}/">
+          <span class="cat-name">{{ ds.title }}</span>{{ optTag | safe }}
+          <div class="cat-meta">{{ ds.spatial_domain | replace("Continental United States", "CONUS") }} · {{ vars }} · {{ ds.spatial_resolution | stripApprox }}</div>
+        </a>
+      {% else %}
+        <span class="cat-name">{{ ds.title }} ({{ ds.status }})</span>{{ optTag | safe }}
+        <div class="cat-meta">{{ ds.spatial_domain | replace("Continental United States", "CONUS") }} · {{ vars }} · {{ ds.spatial_resolution | stripApprox }}</div>
+      {% endif %}
+    </li>
+  {% endmacro %}
+
+  {% if forecasts.length %}
+    <h2 style="margin-top: 3rem;">Forecasts</h2>
+    <ul class="index-list">{% for ds in forecasts %}{{ variantRow(ds) }}{% endfor %}</ul>
+  {% endif %}
+
+  {% if analyses.length %}
+    <h2 style="margin-top: 3rem;">Analyses</h2>
+    <ul class="index-list">{% for ds in analyses %}{{ variantRow(ds) }}{% endfor %}</ul>
+  {% endif %}
+
+  <h2 style="margin-top: 3rem;">Data access</h2>
+  <ul>
+    <li><a href="https://stac.dynamical.org/catalog.json">STAC catalog</a> (<a href="https://radiantearth.github.io/stac-browser/#/external/stac.dynamical.org/catalog.json">browse</a>) — the machine-readable source of truth.</li>
+    <li><a href="/aws/dynamical-{{ model.id }}.yaml">AWS Open Data Registry entry</a> · <a href="https://dynamical-{{ model.id }}.s3.amazonaws.com/index.html">browse the S3 bucket</a></li>
+  </ul>
+</div>


### PR DESCRIPTION
## Context

Second PR in the SEO / LLM-discoverability roadmap, and the highest single-ROI structural change. It's independent of Tier 1 (PR #117) and branches off `main` so the two can merge in either order.

Two things drive this:
1. `/catalog/models/<id>/` were **meta-refresh redirect stubs** — ~8 high-value URLs (GFS, GEFS, HRRR, MRMS, IFS ENS, AIFS x2, ICON-EU) that redirected to a catalog anchor and were excluded from the sitemap, so they couldn't rank for the highest-volume model-name queries ("NOAA GFS data", "HRRR forecast").
2. Catalog pages had a two-level breadcrumb with no structured data.

## Changes

**Model hub pages** (`content/model-pages.njk`)
- Rebuilt the redirect stubs into full indexable pages, one per model, using `base.njk` and the existing `catalog.models` grouping from `_data/catalog.js`.
- Each hub shows: the model overview prose (`description_model`), its dataset variants grouped into **Forecasts** and **Analyses** (linking to the individual `/catalog/<id>/` pages, reusing the catalog index's list pattern), and a **Data access** section (STAC catalog, AWS Open Data Registry YAML, S3 bucket browse).
- Removed `eleventyExcludeFromCollections` so the hubs now appear in `sitemap.xml`.
- Emits `CollectionPage` + `BreadcrumbList` JSON-LD; sets a descriptive title, description, and per-page keywords.

**Breadcrumbs on catalog pages** (`content/catalog-pages.njk`)
- Added the model level to the visible breadcrumb — `Catalog > Model > Dataset`, with the model linking to its new hub.
- Emits matching `BreadcrumbList` JSON-LD (falls back to a 3-level chain if a dataset has no model).

## Verification

- `npm run build` completes and passes the catalog `validateEntries` gate.
- All 8 hub pages generate under `docs/catalog/models/<id>/`, appear in `docs/sitemap.xml`, and link to their variant pages. Analysis-only models (MRMS) correctly render only an Analyses section; no unrendered template tokens remain.
- Parsed every emitted `application/ld+json` block with `JSON.parse` — all valid (hubs: sitewide `@graph` + `BreadcrumbList` + `CollectionPage`; catalog pages: `@graph` + `Dataset` + `BreadcrumbList`).

## Notes

- `docs/` is build output and not checked in.
- The sitewide `<link rel="canonical">` these hubs will carry comes from Tier 1 (PR #117) — it applies automatically once both branches are on `main`.
- Draft pending review. Follow-up PR will add the `/learn/` guides + glossary section (Tier 2.2), which needs a domain-expert skim of drafted prose.


---
_Generated by [Claude Code](https://claude.ai/code/session_01SkQZ9eB8ny3R4xyyxiomEh)_