### PR TITLE
Add Zarr group context to variable tables

### DIFF
--- a/content/catalog-pages.njk
+++ b/content/catalog-pages.njk
@@ -87,8 +87,11 @@ eleventyComputed:
   }
 </style>
 <script type="application/ld+json">{{ entry.jsonld | dump | safe }}</script>
-{% macro variableTable(variables) %}
+{% macro variableTable(variables, groupName) %}
   {%- set commonDims = variables[0].dimension_names | join(' × ') -%}
+  {% if groupName %}
+    <p class="var-note">These variables live in the <code>{{ groupName }}</code> Zarr group (e.g. pass <code>group="{{ groupName }}"</code> to <code>dynamical_catalog.open()</code> or <code>xr.open_zarr()</code>).</p>
+  {% endif %}
   <p class="var-dims-note">Dimensions: <code>{{ commonDims }}</code></p>
   <div class="table-container">
     <table class="var-table">
@@ -251,7 +254,7 @@ eleventyComputed:
   {% for group in entry.variableGroups %}
     <details class="variable-group">
       <summary><strong>{{ group.name | replace("_", " ") | title }}</strong> ({{ group.variables.length }} variable{{ "s" if group.variables.length != 1 }})</summary>
-      {{ variableTable(group.variables) }}
+      {{ variableTable(group.variables, group.name) }}
     </details>
   {% endfor %}
   <p class="metadata-comment">


### PR DESCRIPTION
## Summary
Enhanced variable documentation by displaying which Zarr group each set of variables belongs to, helping users understand how to access them via `dynamical_catalog.open()` or `xr.open_zarr()`.

## Changes
- Updated `variableTable` macro to accept an optional `groupName` parameter
- Added conditional note that displays the Zarr group name and usage example when a group name is provided
- Passed `group.name` when calling `variableTable` for each variable group in the catalog page template

## Implementation Details
The new note appears above the dimensions line and uses semantic markup (`<p>` with `<code>` elements) to clearly show users how to pass the group parameter to data access functions. The styling follows existing conventions with the `.var-note` class alongside the existing `.var-dims-note` class.

https://claude.ai/code/session_01K17q7puwEbcFAEeGRCgt5z