### PR TITLE
Update: week of 2026-07-10

### DIFF
--- a/content/updates/2026-07-10.md
+++ b/content/updates/2026-07-10.md
@@ -1,0 +1,32 @@
+---
+title: "A v0.7 catalog library, a cleaner catalog, and high-res HRRR on the way"
+date: 2026-07-10
+description: "The dynamical-catalog Python library hits v0.7.0, catalog pages get tidy Forecasts/Analyses tables and better discoverability, and high-resolution HRRR plus Canada's HRDPS move toward release."
+---
+
+A quieter week on the "new datasets" front, but a lot landed that makes the catalog easier to use and sets up some high-resolution data we're excited about.
+
+## The catalog library hits v0.7.0
+
+[`dynamical-catalog`](https://pypi.org/project/dynamical-catalog/) — the little library you `pip install` to open our datasets as xarray in a couple of lines — is now at **v0.7.0**. It moves up to Zarr 3.2 and the latest Icechunk, and adds the `gribberish` GRIB decoder, which is what lets the new "virtual" datasets (below) read straight from source archives on the fly. If you use the library, a quick `pip install -U dynamical-catalog` gets you there.
+
+## A cleaner, more discoverable catalog
+
+Catalog pages now split cleanly into **Forecasts** and **Analyses** tables, and variables that live on vertical levels are tucked into expandable groups instead of one long wall — much easier to scan. Browse it at [dynamical.org/catalog](https://dynamical.org/catalog/).
+
+We also did a pass to make the site legible to search engines and to the LLMs people increasingly ask for data — an `llms.txt`, structured metadata on every dataset, and a proper sitemap. Small stuff individually; together it means you (and your favorite assistant) can actually find our data.
+
+## In the works: high-resolution HRRR and Canada's HRDPS
+
+Two high-res products are moving through the pipeline:
+
+- **NOAA HRRR (3 km, CONUS)** as a *virtual* dataset — readable as Zarr with all its vertical levels, decoded on demand straight from NOAA's archive, no giant re-copy required. We've been shaking it out (including a skew-T sounding notebook) and it's close.
+- **ECCC HRDPS**, Canada's high-resolution model — we've started archiving it, the first step toward a catalog entry.
+
+Neither is in the production catalog yet, but they're the next things we expect to ship.
+
+## Under the hood
+
+Our [MCP server](https://dynamical.org/) got a production hardening pass, and a dynamical.org-branded, in-chat map widget for exploring a dataset is in review. On the reliability side, we added end-to-end heartbeat monitoring to the dataset update jobs and kept polishing the automated validation that runs behind every dataset.
+
+More soon.


### PR DESCRIPTION
First run of the weekly changelog routine (see `dynamical-org/meta#121`), executed manually as a live test over **merged work from Jul 4–11, 2026**. Adds `content/updates/2026-07-10.md`.

**This is a draft for you to red-line** — get the substance/structure here, then add your personal intro and sign-off before merging.

### What's included (and the judgment calls)
- **Headline = `dynamical-catalog` v0.7.0** + the catalog UX / discoverability work — the genuinely user-facing things that shipped to production this week.
- **HRRR (virtual) and ECCC HRDPS are placed under "In the works," not announced as available** — both are still staging / pre-catalog, so per the posting guidelines I deliberately did not present them as GA or link to staging URLs. This is the main thing to sanity-check: if either is further along than I assumed, promote it.
- MCP + reliability kept to a short "under the hood" note.

### Links to verify
- The MCP "under the hood" line links to the homepage as a placeholder — swap in the real MCP server URL if there's a canonical one.
- Confirm the `dynamical-catalog` PyPI link and catalog link render as intended.

### On merge
Merging publishes to `/updates`, which regenerates `/feed/feed.xml` → Buttondown emails subscribers, and the social routine (Routine 2) will pick it up and queue LinkedIn/Mastodon/Bluesky posts for your approval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UXApCDgmFMNxt3VapRRifr

---
_Generated by [Claude Code](https://claude.ai/code/session_01UXApCDgmFMNxt3VapRRifr)_