### PR TITLE
Fix Updates link to point to dedicated page instead of anchor

### DIFF
--- a/_includes/base.njk
+++ b/_includes/base.njk
@@ -105,7 +105,7 @@
           <h2>Explore</h2>
           <ul>
             <li><a href="/#research">Research</a></li>
-            <li><a href="/#updates">Updates</a></li>
+            <li><a href="/updates">Updates</a></li>
             <li><a href="/catalog">Catalog</a></li>
             <li><a href="/podcast">Podcast</a></li>
             <li><a href="https://status.dynamical.org">Status</a></li>


### PR DESCRIPTION
## Summary
Changed the Updates navigation link in the footer from an anchor link (`/#updates`) to a dedicated page link (`/updates`), aligning with the site's page structure where Updates has its own dedicated page rather than being a section on the homepage.

## Changes
- Updated the "Updates" link in the footer navigation from `href="/#updates"` to `href="/updates"` in `_includes/base.njk`

## Details
This change ensures the navigation correctly routes users to the `/updates` page, which appears to be a dedicated content page in the site structure (similar to `/catalog` and `/podcast` links in the same navigation menu). The previous anchor link would have attempted to scroll to a non-existent `#updates` section on the homepage.

https://claude.ai/code/session_013jWCkHmgMow3wYWWKfyFPQ