### PR TITLE
Shrink variable table to a single consistent font size

### DIFF
--- a/content/catalog-pages.njk
+++ b/content/catalog-pages.njk
@@ -53,6 +53,7 @@ eleventyComputed:
     border-collapse: collapse;
     width: 100%;
     border: 1px solid var(--border-color);
+    font-size: 1.25rem;
   }
   .var-table th,
   .var-table td {
@@ -85,7 +86,6 @@ eleventyComputed:
     display: block;
     margin-top: 0.15rem;
     color: var(--muted-text);
-    font-size: 1.25rem;
   }
   /* The unsharded chunk table has only two columns, so let it shrink to its
      content rather than stretching to the shared .data min-width. Sharded


### PR DESCRIPTION
## What

On mobile the main variable table read large: its cells inherited the `1.4rem` catalog content font, so bold monospace variable names and long-name lines dominated the narrow viewport.

Rather than add a mobile-only font-size override, this consolidates the table to **one** size:

- Set `table.var-table` to `1.25rem` — matching the `Dimensions:`/group notes sitting right beside it, and in line with the site's existing dense-table convention (`table.data.small` is `1.2rem`).
- Removed the now-redundant explicit `font-size: 1.25rem` on `.var-desc` (it inherits the table size).

Net effect: **fewer** font-size declarations, a consistent denser table on every viewport, and the variable name still stands out via `font-weight`/color rather than size.

## Before / after (390px mobile viewport)

Before, the names/long-names render noticeably larger than the note above them and run to the container edge; after, the whole table sits at one size, reads denser, and gains breathing room.

## Files

- `content/catalog-pages.njk` — page-scoped `<style>` only; no template logic changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LB4dMtPLuiQfBZAe1iSZLS

---
_Generated by [Claude Code](https://claude.ai/code/session_01LB4dMtPLuiQfBZAe1iSZLS)_