### PR TITLE
Fix "Try it out" link typo (dynamicalorg → dynamical.org)

### DIFF
--- a/content/updates/2026-07-13.md
+++ b/content/updates/2026-07-13.md
@@ -12,7 +12,7 @@ If anyone has Morpheus' phone number let him know I'm ready to be picked up on t
 
 ## noaa-hrrr-forecast-48-hour-virtual is now available
 
-It is our first **virtual** dataset. It's low-latency, optimized for spatial access (i.e. good for maps) and has all variables and vertical levels. [Try it out](https://dynamicalorg/catalog/noaa-hrrr-forecast-48-hour-virtual/).
+It is our first **virtual** dataset. It's low-latency, optimized for spatial access (i.e. good for maps) and has all variables and vertical levels. [Try it out](https://dynamical.org/catalog/noaa-hrrr-forecast-48-hour-virtual/).
 
 ![noaa-hrrr-forecast-48-hour-virtual](https://dynamical.org/assets/catalog-thumbnails/noaa-hrrr-forecast-48-hour-virtual.jpg)
 


### PR DESCRIPTION
## Summary

Fixes a typo in the "Try it out" link in the 2026-07-13 update post. The URL was missing the dot in the domain (`https://dynamicalorg/...`), so the link was broken.

## Changes

- `content/updates/2026-07-13.md`: `https://dynamicalorg/catalog/noaa-hrrr-forecast-48-hour-virtual/` → `https://dynamical.org/catalog/noaa-hrrr-forecast-48-hour-virtual/`

The other `dynamicalorg` occurrences in the repo are LinkedIn post URL slugs (e.g. `introducing-dynamicalorg-...`) and were intentionally left unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V9McaQua9fUJCpGrQ3rhLa

---
_Generated by [Claude Code](https://claude.ai/code/session_01V9McaQua9fUJCpGrQ3rhLa)_