### PR TITLE
Handle CDN load failures gracefully on scorecard/catalog pages

### DIFF
--- a/content/catalog/asos-parquet.njk
+++ b/content/catalog/asos-parquet.njk
@@ -137,8 +137,16 @@ df = duckdb.execute("""
 </div>
 
 <script type="module">
-  const duckdb = await import('https://cdn.jsdelivr.net/npm/@duckdb/duckdb-wasm@1.28.0/+esm');
-  const Plot = await import('https://cdn.jsdelivr.net/npm/@observablehq/plot@0.6.13/+esm');
+  // duckdb-wasm and Observable Plot load from a third-party CDN; a failed import
+  // would otherwise reject this module's top-level await uncaught. Load them
+  // defensively so a CDN outage leaves a status message instead of an error.
+  let duckdb, Plot;
+  try {
+    duckdb = await import('https://cdn.jsdelivr.net/npm/@duckdb/duckdb-wasm@1.28.0/+esm');
+    Plot = await import('https://cdn.jsdelivr.net/npm/@observablehq/plot@0.6.13/+esm');
+  } catch (error) {
+    console.error('Failed to load duckdb-wasm / Observable Plot from CDN', error);
+  }
 
   const DATA_BASE_URL = 'https://data.source.coop/dynamical/asos-parquet';
 
@@ -588,5 +596,9 @@ ORDER BY station, valid`
     }
   });
 
-  initDuckDB();
+  if (duckdb && Plot) {
+    initDuckDB();
+  } else {
+    updateStatus('Failed to load the query engine (CDN unavailable). Please reload to try again.');
+  }
 </script>

--- a/content/scorecard-state.njk
+++ b/content/scorecard-state.njk
@@ -59,116 +59,123 @@ permalink: /scorecard/us-state/{{ state.abbr | slug }}/
     <script src="https://d3js.org/d3.v7.min.js"></script>
     <script src="https://unpkg.com/topojson-client@3"></script>
     <script>
-      const width = 975;
-      const height = 610;
-      const stateName = "{{ state.name }}";
-      const stateAbbr = "{{ state.abbr }}";
-      const svg = d3
-        .select("#map-container")
-        .append("svg")
-        .attr("viewBox", [0, 0, width, height])
-        .attr("width", "100%")
-        .attr("height", "auto")
-        .attr("style", "max-width: 100%;");
-      d3.json("https://cdn.jsdelivr.net/npm/us-atlas@3/states-10m.json").then(us => {
-        const state = topojson
-          .feature(us, us.objects.states)
-          .features
-          .find(d => d.properties.name === stateName);
-        let projection = d3
-          .geoIdentity()
-          .reflectY(true)
-          .fitExtent([
-            [
-              0, 0
-            ],
-            [
-              width, height
-            ]
-          ], state);
-        if (stateAbbr === "AK") {
-          projection = d3.geoAlbersUsa().fitExtent([
-            [
-              0, 0
-            ],
-            [
-              width, height
-            ]
-          ], state);
-        } else if (stateAbbr === "HI") {
-          projection = d3.geoMercator().fitExtent([
-            [
-              0, 0
-            ],
-            [
-              width, height
-            ]
-          ], state);
-        }
-        const path = d3.geoPath(projection);
-        // 2. Draw the state fill (no border yet)
-        svg
-          .append("path")
-          .datum(state)
-          .attr("d", path)
-          .attr("fill", "#fff")
-          .attr("stroke", "none");
-        // 2b. Draw county boundaries within the state
-        d3.json("https://cdn.jsdelivr.net/npm/us-atlas@3/counties-10m.json").then(usCounties => {
-          const counties = topojson.feature(usCounties, usCounties.objects.counties).features;
-          const stateIdStr = String(state.id).padStart(2, "0");
-          const countiesInState = counties.filter(c => String(c.id).padStart(5, "0").startsWith(stateIdStr));
-          svg
-            .append("g")
-            .attr("class", "counties")
-            .selectAll("path")
-            .data(countiesInState)
-            .enter()
-            .append("path")
-            .attr("d", path)
-            .attr("fill", "none")
-            .attr("stroke", "#bbb")
-            .attr("stroke-width", 0.5);
-          // Draw the state border on top for clarity
+      // d3 and topojson load from third-party CDNs and the atlas geometry is
+      // fetched from another; any can be unavailable for a given visitor, so
+      // guard on the libraries and catch the fetches — a missing map degrades
+      // silently rather than throwing an uncaught error.
+      (() => {
+        if (typeof d3 === "undefined" || typeof topojson === "undefined") return;
+        const width = 975;
+        const height = 610;
+        const stateName = "{{ state.name }}";
+        const stateAbbr = "{{ state.abbr }}";
+        const svg = d3
+          .select("#map-container")
+          .append("svg")
+          .attr("viewBox", [0, 0, width, height])
+          .attr("width", "100%")
+          .attr("height", "auto")
+          .attr("style", "max-width: 100%;");
+        d3.json("https://cdn.jsdelivr.net/npm/us-atlas@3/states-10m.json").then(us => {
+          const state = topojson
+            .feature(us, us.objects.states)
+            .features
+            .find(d => d.properties.name === stateName);
+          let projection = d3
+            .geoIdentity()
+            .reflectY(true)
+            .fitExtent([
+              [
+                0, 0
+              ],
+              [
+                width, height
+              ]
+            ], state);
+          if (stateAbbr === "AK") {
+            projection = d3.geoAlbersUsa().fitExtent([
+              [
+                0, 0
+              ],
+              [
+                width, height
+              ]
+            ], state);
+          } else if (stateAbbr === "HI") {
+            projection = d3.geoMercator().fitExtent([
+              [
+                0, 0
+              ],
+              [
+                width, height
+              ]
+            ], state);
+          }
+          const path = d3.geoPath(projection);
+          // 2. Draw the state fill (no border yet)
           svg
             .append("path")
             .datum(state)
             .attr("d", path)
-            .attr("fill", "none")
-            .attr("stroke", "#000")
-            .attr("stroke-width", 1);
-        });
-        // 3. Project stations
-        const stations = {{ scorecard.index.stations | dump | safe }}.filter(s => s.state_abbr === stateAbbr);
-        svg
-          .selectAll(".station")
-          .data(stations)
-          .enter()
-          .append("a")
-          .attr("xlink:href", d => `/scorecard/station/${
-            d.id
-          }/`)
-          .append("circle")
-          .attr("class", "station")
-          .attr("r", 5)
-          .attr("fill", "blue")
-          .attr("cx", d => projection([d.longitude, d.latitude])[0])
-          .attr("cy", d => projection([d.longitude, d.latitude])[1])
-          .append("title")
-          .text(d => d.name);
-        // Crop SVG viewBox to the state's vertical bounds to remove extra whitespace
-        const bounds = path.bounds(state);
-        const y0 = bounds[0][1];
-        const y1 = bounds[1][1];
-        const shapeHeight = y1 - y0;
-        console.log(shapeHeight)
-        svg.attr("viewBox", [
-          0,
-          y0,
-          width,
-          shapeHeight * 1.1
-        ]);
-      });
+            .attr("fill", "#fff")
+            .attr("stroke", "none");
+          // 2b. Draw county boundaries within the state
+          d3.json("https://cdn.jsdelivr.net/npm/us-atlas@3/counties-10m.json").then(usCounties => {
+            const counties = topojson.feature(usCounties, usCounties.objects.counties).features;
+            const stateIdStr = String(state.id).padStart(2, "0");
+            const countiesInState = counties.filter(c => String(c.id).padStart(5, "0").startsWith(stateIdStr));
+            svg
+              .append("g")
+              .attr("class", "counties")
+              .selectAll("path")
+              .data(countiesInState)
+              .enter()
+              .append("path")
+              .attr("d", path)
+              .attr("fill", "none")
+              .attr("stroke", "#bbb")
+              .attr("stroke-width", 0.5);
+            // Draw the state border on top for clarity
+            svg
+              .append("path")
+              .datum(state)
+              .attr("d", path)
+              .attr("fill", "none")
+              .attr("stroke", "#000")
+              .attr("stroke-width", 1);
+          }).catch(() => {});
+          // 3. Project stations
+          const stations = {{ scorecard.index.stations | dump | safe }}.filter(s => s.state_abbr === stateAbbr);
+          svg
+            .selectAll(".station")
+            .data(stations)
+            .enter()
+            .append("a")
+            .attr("xlink:href", d => `/scorecard/station/${
+              d.id
+            }/`)
+            .append("circle")
+            .attr("class", "station")
+            .attr("r", 5)
+            .attr("fill", "blue")
+            .attr("cx", d => projection([d.longitude, d.latitude])[0])
+            .attr("cy", d => projection([d.longitude, d.latitude])[1])
+            .append("title")
+            .text(d => d.name);
+          // Crop SVG viewBox to the state's vertical bounds to remove extra whitespace
+          const bounds = path.bounds(state);
+          const y0 = bounds[0][1];
+          const y1 = bounds[1][1];
+          const shapeHeight = y1 - y0;
+          console.log(shapeHeight)
+          svg.attr("viewBox", [
+            0,
+            y0,
+            width,
+            shapeHeight * 1.1
+          ]);
+        }).catch(() => {});
+      })();
     </script>
     <script type="module">
       import { renderMetric, VARIABLE_METRICS, DEFAULT_METRIC, METRIC_CONFIG } from '/scorecard.js?v={{ "public/scorecard.js" | fileHash }}';

--- a/content/scorecard-station.njk
+++ b/content/scorecard-station.njk
@@ -123,55 +123,62 @@ permalink: /scorecard/station/{{ station.id }}/
 <script src="https://d3js.org/d3.v7.min.js"></script>
 <script src="https://unpkg.com/topojson-client@3"></script>
 <script>
-  const station = {{ station | dump | safe }};
-  const width = 600;
-  const height = 400;
-  const svg = d3
-    .select("#map-container")
-    .append("svg")
-    .attr("viewBox", [0, 0, width, height])
-    .attr("width", "100%")
-    .attr("height", "auto")
-    .attr("style", "max-width: 100%;");
-  d3.json("https://cdn.jsdelivr.net/npm/us-atlas@3/states-10m.json").then(us => {
-    const state = topojson
-      .feature(us, us.objects.states)
-      .features
-      .find(d => d.properties.name === station.state_name);
-    if (! state) {
-      console.error("Could not find state for station:", station);
-      return;
-    }
-    let projection = d3.geoIdentity().reflectY(true);
-    // Use Albers projection for Alaska and Hawaii
-    if (station.state_abbr === "AK" || station.state_abbr === "HI") {
-      projection = d3.geoAlbersUsa();
-    }
-    const path = d3.geoPath(projection);
-    // Fit the projection to the state
-    projection.fitExtent([
-      [
-        0, 0
-      ],
-      [
-        width, height
-      ]
-    ], state);
-    svg
-      .append("g")
-      .attr("fill", "#fff")
-      .attr("stroke", "#000")
-      .selectAll("path")
-      .data([state])
-      .join("path")
-      .attr("d", path);
-    svg
-      .append("circle")
-      .attr("cx", projection([station.longitude, station.latitude])[0])
-      .attr("cy", projection([station.longitude, station.latitude])[1])
-      .attr("r", 5)
-      .attr("fill", "blue");
-  });
+  // d3 and topojson load from third-party CDNs and the atlas geometry is
+  // fetched from another; any can be unavailable for a given visitor, so guard
+  // on the libraries and catch the fetch — a missing map degrades silently
+  // rather than throwing an uncaught error.
+  (() => {
+    if (typeof d3 === "undefined" || typeof topojson === "undefined") return;
+    const station = {{ station | dump | safe }};
+    const width = 600;
+    const height = 400;
+    const svg = d3
+      .select("#map-container")
+      .append("svg")
+      .attr("viewBox", [0, 0, width, height])
+      .attr("width", "100%")
+      .attr("height", "auto")
+      .attr("style", "max-width: 100%;");
+    d3.json("https://cdn.jsdelivr.net/npm/us-atlas@3/states-10m.json").then(us => {
+      const state = topojson
+        .feature(us, us.objects.states)
+        .features
+        .find(d => d.properties.name === station.state_name);
+      if (! state) {
+        console.error("Could not find state for station:", station);
+        return;
+      }
+      let projection = d3.geoIdentity().reflectY(true);
+      // Use Albers projection for Alaska and Hawaii
+      if (station.state_abbr === "AK" || station.state_abbr === "HI") {
+        projection = d3.geoAlbersUsa();
+      }
+      const path = d3.geoPath(projection);
+      // Fit the projection to the state
+      projection.fitExtent([
+        [
+          0, 0
+        ],
+        [
+          width, height
+        ]
+      ], state);
+      svg
+        .append("g")
+        .attr("fill", "#fff")
+        .attr("stroke", "#000")
+        .selectAll("path")
+        .data([state])
+        .join("path")
+        .attr("d", path);
+      svg
+        .append("circle")
+        .attr("cx", projection([station.longitude, station.latitude])[0])
+        .attr("cy", projection([station.longitude, station.latitude])[1])
+        .attr("r", 5)
+        .attr("fill", "blue");
+    }).catch(() => {});
+  })();
 
 </script>
 <script type="module">

--- a/content/scorecard.njk
+++ b/content/scorecard.njk
@@ -74,64 +74,71 @@ keywords: "weather forecast accuracy, forecast verification, weather model skill
     <script src="https://d3js.org/d3.v7.min.js"></script>
     <script src="https://unpkg.com/topojson-client@3"></script>
     <script>
-      const width = 975;
-      const height = 610;
-      const projection = d3
-        .geoAlbersUsa()
-        .scale(1300)
-        .translate([487.5, 305]);
-      const path = d3.geoPath();
-      const svg = d3
-        .select("#map-container")
-        .append("svg")
-        .attr("viewBox", [0, 0, width, height])
-        .attr("width", "100%")
-        .attr("height", "auto")
-        .attr("style", "max-width: 100%;");
-      d3.json("https://cdn.jsdelivr.net/npm/us-atlas@3/states-albers-10m.json").then(us => {
-        svg
-          .append("g")
-          .attr("fill", "#fff")
-          .attr("stroke", "#000")
-          // Create <a> elements and link each to its state page, then append the path inside
-          .selectAll("a.state-link")
-          .data(topojson.feature(us, us.objects.states).features)
-          .join("a")
-          .attr("class", "state-link")
-          .attr("xlink:href", d => {
-            const states = {{ scorecard.index.states | dump | safe }};
-            const stateObj = states.find(s => s.name === d.properties.name);
-            return stateObj
-              ? `/scorecard/us-state/${
-                stateObj.abbr.toLowerCase()
-              }/`
-              : null;
-          })
-          .style("cursor", "pointer")
-          .append("path")
-          .attr("d", path);
-        svg
-          .append("path")
-          .attr("fill", "none")
-          .attr("stroke", "#000")
-          .attr("stroke-linejoin", "round")
-          .attr("d", path(topojson.mesh(us, us.objects.states, (a, b) => a !== b)));
-        const stations = {{ scorecard.index.stations | dump | safe }};
-        svg
-          .selectAll(".station")
-          .data(stations)
-          .enter()
-          .filter(d => projection([d.longitude, d.latitude]))
-          .append("circle")
-          .attr("class", "station")
-          .attr("cx", d => projection([d.longitude, d.latitude])[0])
-          .attr("cy", d => projection([d.longitude, d.latitude])[1])
-          .attr("r", 3)
-          .attr("fill", "blue")
-          .style("pointer-events", "none")
-          .append("title")
-          .text(d => d.name);
-      });
+      // d3 and topojson load from third-party CDNs and the atlas geometry is
+      // fetched from another; any can be unavailable for a given visitor, so
+      // guard on the libraries and catch the fetch — a missing map degrades
+      // silently rather than throwing an uncaught error.
+      (() => {
+        if (typeof d3 === "undefined" || typeof topojson === "undefined") return;
+        const width = 975;
+        const height = 610;
+        const projection = d3
+          .geoAlbersUsa()
+          .scale(1300)
+          .translate([487.5, 305]);
+        const path = d3.geoPath();
+        const svg = d3
+          .select("#map-container")
+          .append("svg")
+          .attr("viewBox", [0, 0, width, height])
+          .attr("width", "100%")
+          .attr("height", "auto")
+          .attr("style", "max-width: 100%;");
+        d3.json("https://cdn.jsdelivr.net/npm/us-atlas@3/states-albers-10m.json").then(us => {
+          svg
+            .append("g")
+            .attr("fill", "#fff")
+            .attr("stroke", "#000")
+            // Create <a> elements and link each to its state page, then append the path inside
+            .selectAll("a.state-link")
+            .data(topojson.feature(us, us.objects.states).features)
+            .join("a")
+            .attr("class", "state-link")
+            .attr("xlink:href", d => {
+              const states = {{ scorecard.index.states | dump | safe }};
+              const stateObj = states.find(s => s.name === d.properties.name);
+              return stateObj
+                ? `/scorecard/us-state/${
+                  stateObj.abbr.toLowerCase()
+                }/`
+                : null;
+            })
+            .style("cursor", "pointer")
+            .append("path")
+            .attr("d", path);
+          svg
+            .append("path")
+            .attr("fill", "none")
+            .attr("stroke", "#000")
+            .attr("stroke-linejoin", "round")
+            .attr("d", path(topojson.mesh(us, us.objects.states, (a, b) => a !== b)));
+          const stations = {{ scorecard.index.stations | dump | safe }};
+          svg
+            .selectAll(".station")
+            .data(stations)
+            .enter()
+            .filter(d => projection([d.longitude, d.latitude]))
+            .append("circle")
+            .attr("class", "station")
+            .attr("cx", d => projection([d.longitude, d.latitude])[0])
+            .attr("cy", d => projection([d.longitude, d.latitude])[1])
+            .attr("r", 3)
+            .attr("fill", "blue")
+            .style("pointer-events", "none")
+            .append("title")
+            .text(d => d.name);
+        }).catch(() => {});
+      })();
     </script>
     <script type="module">
       import { renderMetric, VARIABLE_METRICS, DEFAULT_METRIC, METRIC_CONFIG } from '/scorecard.js?v={{ "public/scorecard.js" | fileHash }}';


### PR DESCRIPTION
## Summary

Follow-up to the reverted #135. Instead of vendoring the third-party libraries, this keeps loading them from their CDNs (jsdelivr et al. are reliable enough that these failures are rare) and adds **defensive handling** so an occasional CDN hiccup degrades gracefully instead of throwing the uncaught errors seen in Better Stack:

- `topojson is not defined` — a `<script>` (topojson-client / d3) failing to load, referenced later in a callback.
- `Failed to fetch (cdn.jsdelivr.net)` — the `d3.json` us-atlas fetch rejecting with no `.catch`.
- `Importing a module script failed` — the ASOS catalog page's top-level `await import()` of duckdb-wasm / Observable Plot rejecting uncaught.

## Changes

- **`content/scorecard.njk`, `content/scorecard-state.njk`, `content/scorecard-station.njk`** — wrap each map script so it runs only when `d3` and `topojson` are both defined, and add `.catch(() => {})` to the `d3.json` atlas fetch(es) (two in the state page). On any CDN failure the map simply doesn't render; no console/tracking error.
- **`content/catalog/asos-parquet.njk`** — wrap the top-level `duckdb-wasm` / `Observable Plot` imports in `try/catch`; on failure show a status message ("Failed to load the query engine…") and skip init. The Run Query button is `disabled` by default and only enabled on successful init, so it correctly stays disabled.

Not touched: `public/scorecard.js` already wraps its duckdb/Plot imports in `try/catch` (`renderMetric`/`renderObs` fall back to "Failed to load chart"), so it needed no change. The `platform.ilmiya.com` jQuery errors and Better Stack's own RUM blips are third-party, out of scope (already ignored in Better Stack).

## Verification

`npm run build` renders all pages, and each affected inline script — extracted from the generated HTML with template tags resolved — passes `node --check` (the three map scripts as classic scripts, the ASOS block as a module). Guards and `.catch` confirmed present in the built output. (The build's unrelated `contributors` GitHub-API fetch 401s under a scoped token; verified identical on clean `main`, and stubbed only locally to complete the build — not part of this diff.)

Closes #136.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012cgJ77b8tDCDy8G6S2Mr15)_