### PR TITLE
Remove extraneous comments per code-style standard

### DIFF
--- a/_data/catalog.js
+++ b/_data/catalog.js
@@ -148,7 +148,7 @@ function reshapeStacCollection(collection) {
   }));
 
   // Variables at the root zarr group (e.g. `temperature_2m`) are listed
-  // directly, unchanged from before. Variables under a nested zarr group
+  // directly. Variables under a nested zarr group
   // (e.g. `model_level/geopotential_height`) are split off into named
   // groups so the catalog page can render them behind disclosures instead
   // of flooding a single flat table.

--- a/content/catalog/validation.11ty.js
+++ b/content/catalog/validation.11ty.js
@@ -85,10 +85,8 @@ function styleTables(html) {
 }
 
 // The page generates its own H1 from the catalog entry name, so any H1
-// emitted by the rendered markdown is redundant. reformatters PR #614
-// drops the H1 from validation_summary.md; this strip keeps the page
-// looking right against both the current bucket output (still includes
-// the H1) and the post-#614 output (no H1).
+// emitted by the rendered markdown is redundant. Strip it so the page
+// looks right whether or not the source markdown includes an H1.
 function stripH1(html) {
   return html.replace(/<h1>[\s\S]*?<\/h1>\s*/g, "");
 }


### PR DESCRIPTION
Comment-hygiene pass over hand-written JS/config. The repo's JS comments are almost entirely timeless documentation of build quirks and design rationale, which were kept. Only two comments carried change-narrative / PR references:

- `content/catalog/validation.11ty.js` — `stripH1` comment referenced 'reformatters PR #614' and narrated pre/post-#614 output. Rewritten to state the timeless fact (page emits its own H1, so a markdown H1 is redundant; strip handles either case).
- `_data/catalog.js` — dropped 'unchanged from before' from the root-vs-nested variable comment.

No code changed. Build not run (Node.js unavailable in this environment); changes are comment-only so there is no syntax risk.