### PR TITLE
Tabbed open-snippet variants on catalog pages

### DIFF
--- a/content/catalog-pages.njk
+++ b/content/catalog-pages.njk
@@ -103,6 +103,39 @@ eleventyComputed:
   .detail-prose table.data:has(thead th:nth-child(2):last-child) {
     min-width: 0;
   }
+
+  /* Tabs switching between the open-snippet variants (dynamical-catalog vs
+     pystac + icechunk) inside a code frame. Colors match the frame's fixed
+     dark palette in main.css (.frame/.frameHeader) rather than the page's
+     light/dark tokens — the code widget is always dark. */
+  .codeTabList {
+    display: flex;
+    gap: 4px;
+    padding: 0 8px;
+    background: black;
+    border-bottom: 1px solid #292929;
+  }
+  .codeTab {
+    appearance: none;
+    padding: 8px 16px;
+    border: none;
+    border-bottom: 2px solid transparent;
+    background: transparent;
+    color: #898989;
+    font: inherit;
+    font-size: 13px;
+    cursor: pointer;
+  }
+  .codeTab:hover {
+    color: #fafafa;
+  }
+  .codeTab[aria-selected="true"] {
+    color: #fafafa;
+    border-bottom-color: #fafafa;
+  }
+  .codeTabPanel[hidden] {
+    display: none;
+  }
 </style>
 <script type="application/ld+json">{{ entry.jsonld | dump | safe }}</script>
 {% macro variableTable(variables, groupName) %}
@@ -238,7 +271,22 @@ eleventyComputed:
         <div class="frameHeaderTitle">dynamical.org - {{ entry.title | truncate(30, true, '...') }}</div>
         <div class="frameHeaderSubtitle">{{ example.title }}</div>
       </div>
-      {{ example.code | highlight('py', 'frameContent frameContentDesktop') | safe }}
+      {% if example.variants %}
+        <div class="codeTabs">
+          <div class="codeTabList" role="tablist" aria-label="{{ example.title }} — open method">
+            {% for variant in example.variants %}
+              <button type="button" class="codeTab" role="tab" aria-selected="{{ 'true' if loop.first else 'false' }}"{% if not loop.first %} tabindex="-1"{% endif %}>{{ variant.label }}</button>
+            {% endfor %}
+          </div>
+          {% for variant in example.variants %}
+            <div class="codeTabPanel" role="tabpanel"{% if not loop.first %} hidden{% endif %}>
+              {{ variant.code | highlight('py', 'frameContent frameContentDesktop') | safe }}
+            </div>
+          {% endfor %}
+        </div>
+      {% else %}
+        {{ example.code | highlight('py', 'frameContent frameContentDesktop') | safe }}
+      {% endif %}
     </div>
   {% endfor %}
   <h2>Dimensions</h2>
@@ -291,4 +339,22 @@ eleventyComputed:
     <a href="https://doi.org/10.5281/zenodo.18777399"><img src="https://zenodo.org/badge/859043226.svg" alt="DOI"/></a>
     </p>
     <div class="detail-prose">{{ entry.description_details | markdown | safe }}</div>
+
+<script>
+  // Switch between open-snippet variants within each code frame.
+  document.querySelectorAll(".codeTabs").forEach((tabs) => {
+    const buttons = [...tabs.querySelectorAll(".codeTab")];
+    const panels = [...tabs.querySelectorAll(".codeTabPanel")];
+    buttons.forEach((button, i) => {
+      button.addEventListener("click", () => {
+        buttons.forEach((b, j) => {
+          const active = i === j;
+          b.setAttribute("aria-selected", active ? "true" : "false");
+          b.tabIndex = active ? 0 : -1;
+          panels[j].hidden = !active;
+        });
+      });
+    });
+  });
+</script>
 </div>

--- a/content/catalog-pages.njk
+++ b/content/catalog-pages.njk
@@ -104,20 +104,34 @@ eleventyComputed:
     min-width: 0;
   }
 
-  /* Tabs switching between the open-snippet variants (dynamical-catalog vs
-     pystac + icechunk) inside a code frame. Colors match the frame's fixed
-     dark palette in main.css (.frame/.frameHeader) rather than the page's
-     light/dark tokens — the code widget is always dark. */
+  /* Open-snippet variants (dynamical-catalog vs pystac + icechunk) share the
+     code frame's header: tabs on the left, a muted label on the right. Colors
+     match the frame's fixed dark palette in main.css (.frame/.frameHeader)
+     rather than the page's light/dark tokens — the code widget is always dark.
+     The header's own space-between handles the fallback (no tabs): the label
+     just sits left-aligned on its own. */
+  .frameTitle {
+    color: #898989;
+    font-size: 13px;
+    /* Keep the header a single 40px row: the label shrinks and ellipsizes
+       (min-width:0 lets it shrink below its content in the flex row) rather
+       than wrapping or pushing the tabs. */
+    min-width: 0;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
   .codeTabList {
     display: flex;
-    gap: 4px;
-    padding: 0 8px;
-    background: black;
-    border-bottom: 1px solid #292929;
+    height: 100%;
+    flex-shrink: 0;
   }
   .codeTab {
     appearance: none;
-    padding: 8px 16px;
+    display: flex;
+    align-items: center;
+    height: 100%;
+    padding: 0 12px;
     border: none;
     border-bottom: 2px solid transparent;
     background: transparent;
@@ -135,6 +149,13 @@ eleventyComputed:
   }
   .codeTabPanel[hidden] {
     display: none;
+  }
+  /* Match the frame chrome's own breakpoint (main.css hides .frameHeaderTitle
+     here too): on narrow screens keep the tabs, drop the label. */
+  @media screen and (max-width: 1000px) {
+    .frameTitle {
+      display: none;
+    }
   }
 </style>
 <script type="application/ld+json">{{ entry.jsonld | dump | safe }}</script>
@@ -268,22 +289,21 @@ eleventyComputed:
   {% for example in entry.examples %}
     <div class="frame">
       <div class="frameHeader">
-        <div class="frameHeaderTitle">dynamical.org - {{ entry.title | truncate(30, true, '...') }}</div>
-        <div class="frameHeaderSubtitle">{{ example.title }}</div>
-      </div>
-      {% if example.variants %}
-        <div class="codeTabs">
+        {% if example.variants %}
           <div class="codeTabList" role="tablist" aria-label="{{ example.title }} — open method">
             {% for variant in example.variants %}
               <button type="button" class="codeTab" role="tab" aria-selected="{{ 'true' if loop.first else 'false' }}"{% if not loop.first %} tabindex="-1"{% endif %}>{{ variant.label }}</button>
             {% endfor %}
           </div>
-          {% for variant in example.variants %}
-            <div class="codeTabPanel" role="tabpanel"{% if not loop.first %} hidden{% endif %}>
-              {{ variant.code | highlight('py', 'frameContent frameContentDesktop') | safe }}
-            </div>
-          {% endfor %}
-        </div>
+        {% endif %}
+        <div class="frameTitle">{{ entry.title }} · {{ example.title }}</div>
+      </div>
+      {% if example.variants %}
+        {% for variant in example.variants %}
+          <div class="codeTabPanel" role="tabpanel"{% if not loop.first %} hidden{% endif %}>
+            {{ variant.code | highlight('py', 'frameContent frameContentDesktop') | safe }}
+          </div>
+        {% endfor %}
       {% else %}
         {{ example.code | highlight('py', 'frameContent frameContentDesktop') | safe }}
       {% endif %}
@@ -341,10 +361,12 @@ eleventyComputed:
     <div class="detail-prose">{{ entry.description_details | markdown | safe }}</div>
 
 <script>
-  // Switch between open-snippet variants within each code frame.
-  document.querySelectorAll(".codeTabs").forEach((tabs) => {
-    const buttons = [...tabs.querySelectorAll(".codeTab")];
-    const panels = [...tabs.querySelectorAll(".codeTabPanel")];
+  // Switch between open-snippet variants within each code frame. Tabs live in
+  // the frame header, panels in the frame body, so scope the lookup to .frame.
+  document.querySelectorAll(".frame").forEach((frame) => {
+    const buttons = [...frame.querySelectorAll(".codeTab")];
+    const panels = [...frame.querySelectorAll(".codeTabPanel")];
+    if (buttons.length === 0) return;
     buttons.forEach((button, i) => {
       button.addEventListener("click", () => {
         buttons.forEach((b, j) => {

--- a/content/catalog-pages.njk
+++ b/content/catalog-pages.njk
@@ -104,22 +104,14 @@ eleventyComputed:
     min-width: 0;
   }
 
-  /* Open-snippet variants (dynamical-catalog vs pystac + icechunk) share the
-     code frame's header: tabs on the left, a muted label on the right. Colors
-     match the frame's fixed dark palette in main.css (.frame/.frameHeader)
-     rather than the page's light/dark tokens — the code widget is always dark.
-     The header's own space-between handles the fallback (no tabs): the label
-     just sits left-aligned on its own. */
-  .frameTitle {
-    color: #898989;
-    font-size: 13px;
-    /* Keep the header a single 40px row: the label shrinks and ellipsizes
-       (min-width:0 lets it shrink below its content in the flex row) rather
-       than wrapping or pushing the tabs. */
-    min-width: 0;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
+  /* Open-snippet variants (dynamical-catalog vs pystac + icechunk) live in the
+     code frame: tabs top-left, the dynamical.org mark top-right, and the
+     example title in a status bar beneath the code. Colors are the frame's
+     fixed dark palette (see .frame/.frameHeader in main.css) — the widget is
+     always dark regardless of page theme. The frame is a query container so the
+     mark can drop from wordmark to icon before it would crowd the tabs. */
+  .frame {
+    container-type: inline-size;
   }
   .codeTabList {
     display: flex;
@@ -150,11 +142,53 @@ eleventyComputed:
   .codeTabPanel[hidden] {
     display: none;
   }
-  /* Match the frame chrome's own breakpoint (main.css hides .frameHeaderTitle
-     here too): on narrow screens keep the tabs, drop the label. */
-  @media screen and (max-width: 1000px) {
-    .frameTitle {
+  /* Brand mark, top-right. The hosted lockup carries ~13% empty space below its
+     artwork; scaling the image past a clipped box crops that padding so the
+     mark matches the icon's height and stays vertically centered (18 × 91.73/80
+     ≈ 20.6). */
+  .frameBrand {
+    display: flex;
+    align-items: center;
+    flex-shrink: 0;
+    opacity: 0.8;
+  }
+  .frameBrand-wordmark {
+    display: block;
+    height: 18px;
+    overflow: hidden;
+  }
+  .frameBrand-wordmark img {
+    display: block;
+    height: 20.6px;
+  }
+  .frameBrand-icon {
+    display: none;
+    height: 18px;
+    width: auto;
+  }
+  .frameStatus {
+    padding: 8px 16px;
+    background: black;
+    border-top: 1px solid #292929;
+    color: #898989;
+    font-size: 13px;
+    line-height: 1.35;
+  }
+  /* When the frame gets narrow, drop the wordmark to the icon and tighten the
+     header so the mark clears the two tabs. */
+  @container (max-width: 520px) {
+    .frameBrand-wordmark {
       display: none;
+    }
+    .frameBrand-icon {
+      display: block;
+    }
+    .frameHeader {
+      padding: 0 10px;
+      gap: 8px;
+    }
+    .codeTab {
+      padding: 0 9px;
     }
   }
 </style>
@@ -296,7 +330,10 @@ eleventyComputed:
             {% endfor %}
           </div>
         {% endif %}
-        <div class="frameTitle">{{ entry.title }} · {{ example.title }}</div>
+        <span class="frameBrand" aria-hidden="true">
+          <span class="frameBrand-wordmark"><img src="https://assets.dynamical.org/identity/logo/lockup/lockup-white.svg" alt=""></span>
+          <img class="frameBrand-icon" src="https://assets.dynamical.org/identity/logo/icon/icon-white.svg" alt="">
+        </span>
       </div>
       {% if example.variants %}
         {% for variant in example.variants %}
@@ -307,6 +344,7 @@ eleventyComputed:
       {% else %}
         {{ example.code | highlight('py', 'frameContent frameContentDesktop') | safe }}
       {% endif %}
+      <div class="frameStatus">{{ entry.title }} · {{ example.title }}</div>
     </div>
   {% endfor %}
   <h2>Dimensions</h2>


### PR DESCRIPTION
Refs dynamical-org/meta#141 (task 2 — web).

Renders each dataset's open snippet as tabs so users can pick between the `dynamical-catalog` library and the library-free `pystac + icechunk` (over HTTPS) approach. Depends on the new `variants` array emitted by dynamical-org/dynamical-stac#57.

## Changes
- `content/catalog-pages.njk`: each `.frame` renders `example.variants` as a `role="tablist"` of buttons + panels. Vanilla-JS switcher (toggles `aria-selected`/`hidden`), page-scoped CSS matching the frame's fixed dark palette.
- **Backward compatible**: when `example.variants` is absent (current prod STAC) it falls back to the existing single `example.code` render, so the site is safe to deploy before the STAC PR merges.

## Preview
Cloudflare PR previews build against `stac-staging`, which picks up the `variants` field once dynamical-stac#57 merges to `main`. Until then this preview shows the fallback (single snippet).