### PR TITLE
Swap Better Stack browser tag for Sentry error monitoring

### DIFF
--- a/_data/metadata.js
+++ b/_data/metadata.js
@@ -8,7 +8,7 @@ module.exports = {
     name: "dynamical.org",
     email: "marshall@dynamical.org",
   },
-  // BetterStack Errors frontend (JS tag) ingest token. Publishable — it ships
-  // to the browser by design. App: "dynamical.org" (javascript_errors).
-  betterstackErrorsToken: "mvH2kP3pYS3hZ2LnroXKPcUx",
+  // Sentry browser error monitoring public key (Loader Script). Publishable — it
+  // ships to the browser by design. Project: "dynamical-org-site" (javascript).
+  sentryPublicKey: "22aeb0b766a9bdd85f61d2bb69646da1",
 };

--- a/_includes/base.njk
+++ b/_includes/base.njk
@@ -79,20 +79,16 @@
       ]
     }
     </script>
-    {% if metadata.betterstackErrorsToken %}<!-- BetterStack Errors: browser error tracking + pageview telemetry -->
+    {% if metadata.sentryPublicKey %}<!-- Sentry browser error monitoring (Loader Script): errors only, no tracing or replay -->
     <script>
-      !function(b,e,t,r){
-        b[t]=b[t]||function(...args){(b[t].q=b[t].q||[]).push(args)};
-        b[t].l=+new Date;
-        var s=e.createElement('script'); s.async=1; s.crossOrigin='anonymous';
-        s.src='https://betterstack.net/b.js?t='+r;
-        (e.head||e.getElementsByTagName('head')[0]).appendChild(s);
-      }(window,document,'betterstack','{{ metadata.betterstackErrorsToken }}');
-      // Only report from the production host; keeps local dev and *.pages.dev previews out of the dashboard.
-      if (location.hostname === 'dynamical.org') {
-        betterstack('init', { environment: 'production' });
-      }
-    </script>{% endif %}
+      // Defining sentryOnLoad defers init to us, so the loader only reports on the production host;
+      // keeps local dev and *.pages.dev previews out of the dashboard.
+      window.sentryOnLoad = function () {
+        if (location.hostname !== 'dynamical.org') return;
+        Sentry.init({ environment: 'production' });
+      };
+    </script>
+    <script src="https://js.sentry-cdn.com/{{ metadata.sentryPublicKey }}.min.js" crossorigin="anonymous" async></script>{% endif %}
   </head>
   <body>
     <nav aria-label="Primary">

--- a/content/privacy.html
+++ b/content/privacy.html
@@ -2,13 +2,13 @@
 layout: base.njk
 title: privacy policy
 socialTitle: dynamical.org privacy policy
-description: How dynamical.org handles data and privacy - mostly open, no-login access with minimal analytics.
+description: How dynamical.org handles data and privacy - mostly open, no-login access with minimal data collection.
 permalink: /privacy/
 ---
 
 <div class="content">
   <h1 style="margin-top: 4rem; margin-bottom: 1rem;">Privacy Policy</h1>
-  <p class="metadata-comment">Last updated: July 6, 2026</p>
+  <p class="metadata-comment">Last updated: July 24, 2026</p>
 
   <p>
     <strong>dynamical.org</strong> publishes a public catalog of cloud-optimized
@@ -28,12 +28,11 @@ permalink: /privacy/
       Cloudflare's own privacy policy.
     </li>
     <li>
-      <strong>Analytics and error monitoring:</strong> on the production site
-      (<code>dynamical.org</code>) we use BetterStack to record aggregate
-      page-view telemetry and JavaScript error reports. This helps us understand
-      which pages are useful and catch broken pages. It may include the page URL,
-      referrer, approximate location, and browser/device details. We do not use
-      it to build advertising profiles.
+      <strong>Error monitoring:</strong> on the production site
+      (<code>dynamical.org</code>) we use Sentry to capture JavaScript error
+      reports. This helps us catch broken pages. A report may include the page
+      URL, browser/device details, and a stack trace describing the error. We do
+      not use it to build advertising profiles.
     </li>
     <li>
       <strong>Newsletter:</strong> if you subscribe via the sign-up form, we
@@ -73,7 +72,7 @@ permalink: /privacy/
   <p>
     We rely on a small number of third parties to run the site, each with its own
     privacy practices: <strong>Cloudflare</strong> (hosting and CDN),
-    <strong>BetterStack</strong> (analytics and error monitoring),
+    <strong>Sentry</strong> (error monitoring),
     <strong>Buttondown</strong> (newsletter email), and <strong>GitHub</strong>
     (sign-in for experimental features). Dataset files are stored on cloud object
     storage (such as Amazon S3 and Cloudflare R2).


### PR DESCRIPTION
Migrates the site's frontend JavaScript error tracking from Better Stack to Sentry, part of the org-wide migration (dynamical-org/meta#145).

## Changes
- **`_data/metadata.js`** — replace `betterstackErrorsToken` with `sentryPublicKey` (`22aeb0b766a9bdd85f61d2bb69646da1`, Sentry project `dynamical-org-site`). Like the token it replaces, this public key is client-side by design and fine to commit; the injection stays gated on its presence.
- **`_includes/base.njk`** — remove the `betterstack.net/b.js` snippet; add the Sentry **Loader Script** (`https://js.sentry-cdn.com/<key>.min.js`, async). We define `window.sentryOnLoad` so the loader defers init to us, and `Sentry.init({ environment: 'production' })` runs only when `location.hostname === 'dynamical.org'` — mirroring the previous production-host gating that kept local dev and `*.pages.dev` previews out of the dashboard. Errors only: no performance tracing, no session replay, to keep the payload small.
- **`content/privacy.html`** — replace the Better Stack disclosure with a minimal, accurate Sentry error-monitoring disclosure (see wording below); bump the "last updated" date.

## Analytics gap (intentional)
The Better Stack tag provided **both** error tracking and pageview analytics. Per the team decision, this PR drops the Better Stack tag entirely and migrates only error tracking to Sentry. The site **temporarily loses pageview analytics**; its replacement (Sentry metrics or PostHog) is a separately tracked decision, out of scope here. Accordingly the privacy policy's analytics claim is removed rather than restated for Sentry — Sentry is disclosed for error monitoring only.

## Privacy-policy wording
"What we collect" bullet, retitled from "Analytics and error monitoring" to **"Error monitoring"**:

> on the production site (`dynamical.org`) we use Sentry to capture JavaScript error reports. This helps us catch broken pages. A report may include the page URL, browser/device details, and a stack trace describing the error. We do not use it to build advertising profiles.

Service-providers list: `BetterStack (analytics and error monitoring)` → `Sentry (error monitoring)`. The front-matter description "…with minimal analytics" → "…with minimal data collection".

## CSP
The site defines **no Content-Security-Policy** anywhere — no `_headers` file, no hosting config (no netlify.toml / vercel.json / wrangler.toml), no `http-equiv` CSP meta tag. Nothing to update to allow `js.sentry-cdn.com` or the Sentry ingest domain.

## Subresource Integrity
No `integrity` hash on the loader `<script>`: the Sentry Loader Script is intentionally mutable (Sentry serves updated SDK bundles at that URL based on dashboard loader settings), so a pinned SRI hash would break on every Sentry-side update. `crossorigin="anonymous"` is set, per Sentry's documented usage.

## Verification
- `npm run build` renders `docs/privacy/index.html` containing the Sentry loader script and `window.sentryOnLoad` init.
- `grep -rin betterstack docs/` after build: **no matches** — no Better Stack references remain in rendered output.
- Only Better Stack references in the source repo were the three files changed here.

Note: a pre-existing build failure in `content/catalog-pages.njk` (the `highlight` Nunjucks filter) surfaced when building from a fresh worktree with freshly-installed deps; it is unrelated to this change (the tracked checkout builds clean) and did not affect the pages touched here.

Draft — do not merge or deploy.