### PR TITLE
Add PostHog analytics (production host only)

### DIFF
--- a/_data/metadata.js
+++ b/_data/metadata.js
@@ -11,4 +11,6 @@ module.exports = {
   // Sentry browser error monitoring public key (Loader Script). Publishable — it
   // ships to the browser by design. Project: "dynamical-org-site" (javascript).
   sentryPublicKey: "22aeb0b766a9bdd85f61d2bb69646da1",
+  // PostHog analytics project key. Publishable — it ships to the browser by design.
+  posthogKey: "phc_xbHxt83tRzdNzE5kDuz6smaEwkCjN9QSz9SsTfquqDxP",
 };

--- a/_includes/base.njk
+++ b/_includes/base.njk
@@ -89,6 +89,17 @@
       };
     </script>
     <script src="https://js.sentry-cdn.com/{{ metadata.sentryPublicKey }}.min.js" crossorigin="anonymous" async></script>{% endif %}
+    {% if metadata.posthogKey %}<!-- PostHog analytics: pageviews and interactions; anonymous visitors get no person profile -->
+    <script>
+      if (location.hostname === 'dynamical.org') {
+        !function(t,e){var o,n,p,r;e.__SV||(window.posthog && window.posthog.__loaded)||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host.replace(".i.posthog.com","-assets.i.posthog.com")+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="Ji Yi init fn mn Hr pn bn cn capture calculateEventProperties Sn register register_once register_for_session unregister unregister_for_session Tn getFeatureFlag getFeatureFlagPayload getFeatureFlagResult getAllFeatureFlags isFeatureEnabled reloadFeatureFlags updateFlags updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures on onFeatureFlags onSurveysLoaded onSessionId getSurveys getActiveMatchingSurveys renderSurvey displaySurvey cancelPendingSurvey canRenderSurvey canRenderSurveyAsync Mn identify setPersonProperties unsetPersonProperties group resetGroups setPersonPropertiesForFlags resetPersonPropertiesForFlags setGroupPropertiesForFlags resetGroupPropertiesForFlags reset shutdown setIdentity clearIdentity get_distinct_id getGroups get_session_id get_session_replay_url alias set_config startSessionRecording stopSessionRecording sessionRecordingStarted captureException addExceptionStep captureLog startExceptionAutocapture stopExceptionAutocapture loadToolbar get_property getSessionProperty Cn xn createPersonProfile setInternalOrTestUser In hn Pn opt_in_capturing opt_out_capturing has_opted_in_capturing has_opted_out_capturing get_explicit_consent_status is_capturing clear_opt_in_out_capturing debug Ur Rt getPageViewId captureTraceFeedback captureTraceMetric an".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
+        posthog.init('{{ metadata.posthogKey }}', {
+          api_host: 'https://us.i.posthog.com',
+          defaults: '2026-05-30',
+          person_profiles: 'identified_only',
+        });
+      }
+    </script>{% endif %}
   </head>
   <body>
     <nav aria-label="Primary">

--- a/content/privacy.html
+++ b/content/privacy.html
@@ -28,6 +28,13 @@ permalink: /privacy/
       Cloudflare's own privacy policy.
     </li>
     <li>
+      <strong>Analytics:</strong> on the production site
+      (<code>dynamical.org</code>) we use PostHog to collect aggregate usage
+      analytics such as page views and interactions. We do not create person
+      profiles for anonymous visitors and we do not use it to build
+      advertising profiles.
+    </li>
+    <li>
       <strong>Error monitoring:</strong> on the production site
       (<code>dynamical.org</code>) we use Sentry to capture JavaScript error
       reports. This helps us catch broken pages. A report may include the page
@@ -73,6 +80,7 @@ permalink: /privacy/
     We rely on a small number of third parties to run the site, each with its own
     privacy practices: <strong>Cloudflare</strong> (hosting and CDN),
     <strong>Sentry</strong> (error monitoring),
+    <strong>PostHog</strong> (analytics),
     <strong>Buttondown</strong> (newsletter email), and <strong>GitHub</strong>
     (sign-in for experimental features). Dataset files are stored on cloud object
     storage (such as Amazon S3 and Cloudflare R2).


### PR DESCRIPTION
Restores the aggregate analytics the site lost when the Better Stack tag was removed (#145). Same conventions as the Sentry loader: key lives in `_data/metadata.js` (publishable client-side token), injection gated on its presence and on `location.hostname === "dynamical.org"` so local dev and pages.dev previews stay out. `person_profiles: identified_only` keeps anonymous visitors profile-less. Privacy policy gains an Analytics bullet and lists PostHog as a service provider. Build verified (2790 pages).