### PR TITLE
Label the uptime window from what was measured

### DIFF
--- a/content/status.njk
+++ b/content/status.njk
@@ -110,7 +110,7 @@ sitemap: false
     <section aria-labelledby="platform-heading">
       <header>
         <h2 id="platform-heading">Platform</h2>
-        <p>Public services · trailing 90-day uptime</p>
+        <p>Public services · measured uptime</p>
       </header>
       <ul class="index-list status-list" id="status-platform"></ul>
     </section>

--- a/public/status.mjs
+++ b/public/status.mjs
@@ -93,8 +93,24 @@ function statusMark(status) {
 // uptime_since rather than a fixed "90 days". Both detectors were recreated
 // during the Sentry migration, so the real window is hours today and grows on
 // its own; hardcoding a period asserted coverage the data did not have.
-export function formatUptimeWindow(since, now = new Date()) {
-  const seconds = (now.getTime() - Date.parse(since)) / 1000;
+//
+// `asOf` must be the feed's generated_at, not the viewer's clock. The percentage
+// was computed over uptime_since → generated_at, so measuring the label against
+// `now` would let it keep growing after the data stopped — a stale feed would
+// claim "3 days" for a 19-hour measurement, which is the same defect this
+// function exists to remove, just smaller. It also makes the label immune to
+// viewer clock skew, which otherwise makes the line vanish on a slow clock.
+//
+// uptime_since must carry a UTC offset. Date.parse treats an offset-less
+// date-time as *local*, so a naive value — exactly what Python's
+// datetime.isoformat() produces without tzinfo — would silently shift the window
+// by the viewer's offset. The publisher's _utc_iso refuses naive timestamps, but
+// the two repos deploy independently, so this end verifies rather than trusts.
+export function formatUptimeWindow(since, asOf) {
+  if (typeof since !== "string" || !/(?:Z|[+-]\d{2}:?\d{2})$/.test(since)) {
+    return null;
+  }
+  const seconds = (asOf.getTime() - Date.parse(since)) / 1000;
   if (!Number.isFinite(seconds) || seconds <= 0) return null;
   const days = Math.floor(seconds / 86400);
   if (days >= 1) return `${days} day${days === 1 ? "" : "s"}`;
@@ -114,7 +130,7 @@ export function formatUptime(uptime) {
   return capped.replace(/\.?0+$/, "");
 }
 
-function renderGroup(list, entries, kind) {
+function renderGroup(list, entries, kind, asOf) {
   list.replaceChildren();
   for (const entry of entries) {
     const item = document.createElement("li");
@@ -146,12 +162,10 @@ function renderGroup(list, entries, kind) {
       item.append(detail);
     }
     if (kind === "endpoint" && Number.isFinite(entry.uptime)) {
-      const window = entry.uptime_since
-        ? formatUptimeWindow(entry.uptime_since)
-        : null;
-      if (window) {
+      const measured = formatUptimeWindow(entry.uptime_since, asOf);
+      if (measured) {
         const detail = document.createElement("p");
-        detail.textContent = `${formatUptime(entry.uptime)}% uptime over the last ${window}`;
+        detail.textContent = `${formatUptime(entry.uptime)}% uptime over the last ${measured}`;
         item.append(detail);
       }
     }
@@ -205,7 +219,12 @@ function renderStatus(root, data) {
       : null,
   );
   groups.hidden = false;
-  renderGroup(root.querySelector("#status-platform"), data.endpoints, "endpoint");
+  renderGroup(
+    root.querySelector("#status-platform"),
+    data.endpoints,
+    "endpoint",
+    new Date(data.generated_at),
+  );
   renderGroup(root.querySelector("#status-datasets"), data.datasets, "dataset");
 }
 

--- a/public/status.mjs
+++ b/public/status.mjs
@@ -89,10 +89,25 @@ function statusMark(status) {
   return { operational: "●", degraded: "▲", down: "×", unknown: "?" }[status];
 }
 
-// uptime_90d is not validated in validateStatusData at all; the load-bearing
-// guard is the Number.isFinite check at the call site in renderGroup, without
-// which a string value would throw here. Trims trailing zeros, and never lets
-// rounding promote an imperfect figure to a flat "100%".
+// The measured window the publisher actually observed, rendered from
+// uptime_since rather than a fixed "90 days". Both detectors were recreated
+// during the Sentry migration, so the real window is hours today and grows on
+// its own; hardcoding a period asserted coverage the data did not have.
+export function formatUptimeWindow(since, now = new Date()) {
+  const seconds = (now.getTime() - Date.parse(since)) / 1000;
+  if (!Number.isFinite(seconds) || seconds <= 0) return null;
+  const days = Math.floor(seconds / 86400);
+  if (days >= 1) return `${days} day${days === 1 ? "" : "s"}`;
+  const hours = Math.floor(seconds / 3600);
+  if (hours >= 1) return `${hours} hour${hours === 1 ? "" : "s"}`;
+  const minutes = Math.max(1, Math.floor(seconds / 60));
+  return `${minutes} minute${minutes === 1 ? "" : "s"}`;
+}
+
+// uptime is not validated in validateStatusData at all; the load-bearing guard
+// is the Number.isFinite check at the call site in renderGroup, without which a
+// string value would throw here. Trims trailing zeros, and never lets rounding
+// promote an imperfect figure to a flat "100%".
 export function formatUptime(uptime) {
   const rounded = uptime.toFixed(3);
   const capped = rounded === "100.000" && uptime < 100 ? "99.999" : rounded;
@@ -130,10 +145,15 @@ function renderGroup(list, entries, kind) {
       detail.append("Last successful update ", time);
       item.append(detail);
     }
-    if (kind === "endpoint" && Number.isFinite(entry.uptime_90d)) {
-      const detail = document.createElement("p");
-      detail.textContent = `${formatUptime(entry.uptime_90d)}% uptime over the last 90 days`;
-      item.append(detail);
+    if (kind === "endpoint" && Number.isFinite(entry.uptime)) {
+      const window = entry.uptime_since
+        ? formatUptimeWindow(entry.uptime_since)
+        : null;
+      if (window) {
+        const detail = document.createElement("p");
+        detail.textContent = `${formatUptime(entry.uptime)}% uptime over the last ${window}`;
+        item.append(detail);
+      }
     }
     list.append(item);
   }

--- a/test/fixtures/status.json
+++ b/test/fixtures/status.json
@@ -45,8 +45,7 @@
     {
       "id": "ecmwf-ifs-ens-forecast-15-day-0-25-degree",
       "name": "ECMWF IFS ENS forecast, 15 day, 0.25 degree",
-      "status": "operational",
-      "last_successful_update": "2026-07-24T14:20:00Z"
+      "status": "down"
     },
     {
       "id": "noaa-gefs-forecast-35-day",
@@ -79,27 +78,10 @@
       "last_successful_update": "2026-07-24T18:30:00Z"
     },
     {
-      "id": "nasa-smap-level3-36km-v9",
-      "name": "NASA SMAP Level 3, 36 km, v9",
-      "status": "down"
-    },
-    {
       "id": "noaa-gfs-forecast",
       "name": "NOAA GFS forecast",
       "status": "operational",
       "last_successful_update": "2026-07-24T18:00:00Z"
-    },
-    {
-      "id": "noaa-ndvi-cdr-analysis",
-      "name": "NOAA NDVI CDR analysis",
-      "status": "operational",
-      "last_successful_update": "2026-07-23T22:10:00Z"
-    },
-    {
-      "id": "u-arizona-swann-analysis",
-      "name": "University of Arizona SWANN analysis",
-      "status": "operational",
-      "last_successful_update": "2026-07-24T06:00:00Z"
     }
   ],
   "endpoints": [
@@ -107,13 +89,15 @@
       "id": "dynamical-org",
       "name": "dynamical.org",
       "status": "operational",
-      "uptime_90d": 99.982
+      "uptime": 99.982,
+      "uptime_since": "2026-04-25T19:55:00Z"
     },
     {
       "id": "stac-catalog",
       "name": "STAC catalog",
       "status": "operational",
-      "uptime_90d": 100.0
+      "uptime": 100.0,
+      "uptime_since": "2026-07-24T08:30:00Z"
     }
   ]
 }

--- a/test/status.test.mjs
+++ b/test/status.test.mjs
@@ -4,6 +4,7 @@ import test from "node:test";
 
 import {
   formatUptime,
+  formatUptimeWindow,
   isStatusDataStale,
   summarizeOverallStatus,
   validateStatusData,
@@ -28,7 +29,8 @@ const operationalData = {
       id: "dynamical-org",
       name: "dynamical.org",
       status: "operational",
-      uptime_90d: 99.9,
+      uptime: 99.9,
+      uptime_since: "2026-04-26T19:55:00Z",
     },
   ],
 };
@@ -36,14 +38,31 @@ const operationalData = {
 test("accepts the published feed shape", () => {
   // Returns a normalized copy, not the same reference, so compare by value.
   assert.deepEqual(validateStatusData(fixture), fixture);
-  assert.equal(fixture.datasets.length, 17);
+  // 14, matching the collections in stac.dynamical.org/catalog.json — the
+  // publisher deliberately excludes contrib datasets and source archivers.
+  assert.equal(fixture.datasets.length, 14);
   assert.deepEqual(summarizeOverallStatus(fixture), {
     status: "down",
     incidents: [
       { name: "NOAA HRRR forecast, 48 hour", status: "degraded" },
-      { name: "NASA SMAP Level 3, 36 km, v9", status: "down" },
+      { name: "ECMWF IFS ENS forecast, 15 day, 0.25 degree", status: "down" },
     ],
   });
+});
+
+test("labels the uptime window from what was measured", () => {
+  // The publisher sends the window it actually observed, so the page must never
+  // assert "90 days" for a monitor that has only been running for hours.
+  const now = new Date("2026-07-25T00:00:00Z");
+
+  assert.equal(formatUptimeWindow("2026-04-26T00:00:00Z", now), "90 days");
+  assert.equal(formatUptimeWindow("2026-07-24T00:00:00Z", now), "1 day");
+  assert.equal(formatUptimeWindow("2026-07-24T12:36:00Z", now), "11 hours");
+  assert.equal(formatUptimeWindow("2026-07-24T23:00:00Z", now), "1 hour");
+  assert.equal(formatUptimeWindow("2026-07-24T23:58:00Z", now), "2 minutes");
+  // A window that has not elapsed, or is unparseable, has nothing to claim.
+  assert.equal(formatUptimeWindow("2026-07-25T00:00:00Z", now), null);
+  assert.equal(formatUptimeWindow("not-a-date", now), null);
 });
 
 test("never rounds an imperfect uptime up to 100%", () => {

--- a/test/status.test.mjs
+++ b/test/status.test.mjs
@@ -50,6 +50,43 @@ test("accepts the published feed shape", () => {
   });
 });
 
+test("the window is measured against the feed, not the viewer's clock", () => {
+  // The percentage was computed over uptime_since -> generated_at. Measuring the
+  // label against `now` instead lets it keep growing after the data stopped: a
+  // stale feed would claim "3 days" for a 19-hour measurement, which is the same
+  // defect this whole change removes, just smaller.
+  const generatedAt = new Date("2026-07-24T19:55:00Z");
+  const since = "2026-07-24T08:30:00Z";
+
+  assert.equal(formatUptimeWindow(since, generatedAt), "11 hours");
+  // Days later, the same frozen feed must still say 11 hours.
+  assert.equal(
+    formatUptimeWindow(since, new Date("2026-07-28T19:55:00Z")),
+    "4 days",
+    "sanity: a later as-of does change the answer, so the arg is load-bearing",
+  );
+});
+
+test("a timestamp without a UTC offset is refused rather than shifted", () => {
+  // Date.parse treats an offset-less date-time as local, so a naive value —
+  // exactly what Python's datetime.isoformat() emits without tzinfo — would
+  // silently shift the window by the viewer's offset.
+  const asOf = new Date("2026-07-25T12:00:00Z");
+
+  assert.equal(formatUptimeWindow("2026-07-25T00:00:00", asOf), null);
+  assert.equal(formatUptimeWindow("2026-07-25T00:00:00Z", asOf), "12 hours");
+  assert.equal(formatUptimeWindow("2026-07-25T00:00:00+00:00", asOf), "12 hours");
+  assert.equal(formatUptimeWindow("2026-07-25T02:00:00+02:00", asOf), "12 hours");
+});
+
+test("an absent or future window omits the line rather than guessing", () => {
+  const asOf = new Date("2026-07-25T12:00:00Z");
+
+  assert.equal(formatUptimeWindow(undefined, asOf), null);
+  assert.equal(formatUptimeWindow(null, asOf), null);
+  assert.equal(formatUptimeWindow("2026-07-26T00:00:00Z", asOf), null);
+});
+
 test("labels the uptime window from what was measured", () => {
   // The publisher sends the window it actually observed, so the page must never
   // assert "90 days" for a monitor that has only been running for hours.


### PR DESCRIPTION
Requires dynamical-org/dynamical.org-data#11, which publishes the new fields.

## Why

The page rendered **"100% uptime over the last 90 days"** from a figure computed over ~19 hours.

The publisher asks Sentry for `statsPeriod=90d`; Sentry answers with whatever exists. Both platform detectors were recreated during today's migration back to Sentry, so the real coverage is currently hours. Measured against the API:

```
7895687 (dynamical.org)  6h=72  8h=96  10h=120  12h=136 → flat   (5-min probes)
7896993 (STAC catalog)   6h=359 8h=451 10h=451         → flat   (1-min probes)
```

Both scale exactly with their probe interval below the ceiling, and the ceilings sit at *different* elapsed times — so it is detector age, not a result cap. It grows on its own.

The percentage was true. The window was asserted.

## What changed

- Read `uptime` + `uptime_since` instead of `uptime_90d`, and derive the label from the elapsed window: "over the last 19 hours" today, "over the last 90 days" once the data reaches back that far, with no code change in between.
- The Platform section subtitle drops its "trailing 90-day uptime" claim for the same reason.
- The uptime line is omitted entirely when the window is missing or hasn't elapsed, rather than guessing.

No backdating and no asserted spans. Uptime genuinely has been 100% over the last 90 days, but Sentry cannot substantiate the part of that window it never observed, and a backdated figure that looks measured is indistinguishable from a measured one later — which is exactly when it would matter.

## Fixture correction

The fixture carried 17 datasets including three contrib ones the publisher no longer emits, which made the one artifact documenting the feed shape misleading. Now 14, matching `stac.dynamical.org/catalog.json`. The `down` example moves to `ecmwf-ifs-ens-forecast-15-day-0-25-degree`, which is genuinely down in production.

## Validation

- `npm test` — 9 passed, including both the long-window and short-window label paths
- `npm run build` — clean
- Rendered against the fixture in a real browser: "99.982% uptime over the last 90 days" and "100% uptime over the last 19 hours" side by side, verified in dark mode
- Production build re-verified still unlisted: `noindex` present, absent from `sitemap.xml`, fixture not shipped

## Note

This is the third instance of one pattern in this feed, after rounding an imperfect figure up to 100% and the bar-strip depth question: asserting a window the data does not cover. Publishing the observed window instead of a hardcoded label addresses the class rather than the instance.