### PR TITLE
Status page: two sections, 90-day bars, log-derived uptime

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -131,13 +131,6 @@ module.exports = function (eleventyConfig) {
     );
     const shift = now.getTime() - Date.parse(fixture.generated_at);
     fixture.generated_at = now.toISOString();
-    for (const endpoint of fixture.endpoints) {
-      if (endpoint.uptime_since) {
-        endpoint.uptime_since = new Date(
-          Date.parse(endpoint.uptime_since) + shift,
-        ).toISOString();
-      }
-    }
     eleventyConfig.addTemplate(
       "status-fixture.njk",
       JSON.stringify(fixture, null, 2),

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -120,18 +120,47 @@ module.exports = function (eleventyConfig) {
   // it would mean any such build also published fabricated status data at a
   // public URL. Only `npm run start:status` sets STATUS_FIXTURE.
   //
-  // Restamped with build time rather than copied: the committed fixture pins
-  // generated_at so tests can assert on it, which would make the previewed page
-  // permanently show its "stale data" banner and hide the normal presentation.
+  // Restamped with build time rather than copied: the committed fixtures pin their
+  // timestamps so tests can assert on them, which would otherwise make the
+  // previewed page permanently show its "stale data" banner and render a bar strip
+  // that recedes further into the past every day.
   if (process.env.STATUS_FIXTURE === "1") {
+    const now = new Date();
     const fixture = JSON.parse(
       fs.readFileSync("./test/fixtures/status.json", "utf8"),
     );
-    fixture.generated_at = new Date().toISOString();
+    const shift = now.getTime() - Date.parse(fixture.generated_at);
+    fixture.generated_at = now.toISOString();
     eleventyConfig.addTemplate(
       "status-fixture.njk",
       JSON.stringify(fixture, null, 2),
-      { permalink: "/status-fixture.json", eleventyExcludeFromCollections: true },
+      { permalink: "/status-preview/status.json", eleventyExcludeFromCollections: true },
+    );
+
+    // Every event moves by the same delta, so the shape the fixture encodes — a
+    // brief blip, a longer outage, a coverage gap, an ongoing failure — survives
+    // intact while always ending at today.
+    const events = fs
+      .readFileSync("./test/fixtures/events.jsonl", "utf8")
+      .split("\n")
+      .filter((line) => line.trim())
+      .map((line) => {
+        const event = JSON.parse(line);
+        event.ts = new Date(Date.parse(event.ts) + shift).toISOString();
+        return JSON.stringify(event);
+      })
+      .join("\n");
+    eleventyConfig.addTemplate("status-events-fixture.njk", events + "\n", {
+      permalink: "/status-preview/events.jsonl",
+      eleventyExcludeFromCollections: true,
+    });
+    eleventyConfig.addTemplate(
+      "status-meta-fixture.njk",
+      JSON.stringify({ v: 1, reconciled_at: now.toISOString() }),
+      {
+        permalink: "/status-preview/meta.json",
+        eleventyExcludeFromCollections: true,
+      },
     );
   }
 

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -131,6 +131,13 @@ module.exports = function (eleventyConfig) {
     );
     const shift = now.getTime() - Date.parse(fixture.generated_at);
     fixture.generated_at = now.toISOString();
+    for (const endpoint of fixture.endpoints) {
+      if (endpoint.uptime_since) {
+        endpoint.uptime_since = new Date(
+          Date.parse(endpoint.uptime_since) + shift,
+        ).toISOString();
+      }
+    }
     eleventyConfig.addTemplate(
       "status-fixture.njk",
       JSON.stringify(fixture, null, 2),

--- a/_data/statusLogBase.js
+++ b/_data/statusLogBase.js
@@ -1,0 +1,4 @@
+// Where the /status page reads the event log from. Overridable alongside
+// STATUS_URL so the page can be previewed against local artifacts.
+module.exports =
+  process.env.STATUS_LOG_URL || "https://assets.dynamical.org/status";

--- a/content/status.njk
+++ b/content/status.njk
@@ -110,7 +110,7 @@ sitemap: false
     <section aria-labelledby="platform-heading">
       <header>
         <h2 id="platform-heading">Platform</h2>
-        <p>Public services · trailing 90-day uptime</p>
+        <p>Public services · measured uptime</p>
       </header>
       <ul class="index-list status-list" id="status-platform"></ul>
     </section>

--- a/content/status.njk
+++ b/content/status.njk
@@ -76,6 +76,28 @@ sitemap: false
     color: var(--pill-muted-fg);
     background: var(--pill-muted-bg);
   }
+  /* One cell per UTC day. A flex row is the whole layout; the states are the
+     same tokens the pills use, so a bar and its label cannot disagree. */
+  .status-bars {
+    display: flex;
+    gap: 1px;
+    margin-top: 0.6rem;
+    height: 1.4rem;
+  }
+  .status-bars span {
+    flex: 1 1 0;
+    background: var(--pill-muted-bg);
+  }
+  .status-bars [data-day="operational"] {
+    background: var(--pill-available-bg);
+  }
+  .status-bars [data-day="down"] {
+    background: var(--pill-down-bg);
+  }
+  .status-bar-scale {
+    display: flex;
+    justify-content: space-between;
+  }
   @media (max-width: 680px) {
     /* align-items keeps the state label shrink-wrapped; without it the column
        cross-axis stretches the pill to the full row width. */
@@ -87,7 +109,8 @@ sitemap: false
   }
 </style>
 
-<main class="content" data-status-page data-status-url="{{ statusFeed }}">
+<main class="content" data-status-page data-status-url="{{ statusFeed }}"
+  data-log-url="{{ statusLogBase }}">
   <header>
     <h1 style="margin-top: 4rem; margin-bottom: 1rem;">System status</h1>
     <p>Current health of the weather and climate data we publish and the endpoints that serve it.</p>
@@ -107,20 +130,20 @@ sitemap: false
   <p id="status-stale" role="alert" hidden></p>
 
   <div class="status-groups" id="status-groups" hidden style="margin-top: 4rem;">
-    <section aria-labelledby="platform-heading">
+    <section aria-labelledby="endpoints-heading">
       <header>
-        <h2 id="platform-heading">Platform</h2>
-        <p>Public services · measured uptime</p>
+        <h2 id="endpoints-heading">Endpoints</h2>
+        <p>The data-serving path</p>
       </header>
-      <ul class="index-list status-list" id="status-platform"></ul>
+      <ul class="index-list status-list" id="status-endpoints"></ul>
     </section>
 
-    <section aria-labelledby="datasets-heading" style="margin-top: 4rem;">
+    <section aria-labelledby="tools-heading" style="margin-top: 4rem;">
       <header>
-        <h2 id="datasets-heading">Data products</h2>
-        <p>Update and validation jobs</p>
+        <h2 id="tools-heading">Tools &amp; resources</h2>
+        <p>Built on top of the data</p>
       </header>
-      <ul class="index-list status-list" id="status-datasets"></ul>
+      <ul class="index-list status-list" id="status-tools"></ul>
     </section>
   </div>
 

--- a/content/status.njk
+++ b/content/status.njk
@@ -86,15 +86,23 @@ sitemap: false
   }
   .status-bars span {
     flex: 1 1 0;
+    /* A gap must read as "we stopped watching", not as the end of the strip, so
+       it carries the same border the muted pill uses to stay visible on white. */
+    border: 1px solid var(--pill-muted-border);
     background: var(--pill-muted-bg);
   }
+  .status-bars [data-day="unknown"] {
+    border-color: var(--pill-down-bg);
+  }
   .status-bars [data-day="operational"] {
+    border-color: var(--pill-available-bg);
     background: var(--pill-available-bg);
   }
   .status-bars [data-day="down"] {
+    border-color: var(--pill-down-bg);
     background: var(--pill-down-bg);
   }
-  .status-bar-scale {
+  .status-bars + p {
     display: flex;
     justify-content: space-between;
   }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "STAC_CACHE_DURATION=0s npx @11ty/eleventy",
     "test": "node --test test/*.test.mjs",
     "start": "npx @11ty/eleventy --serve --port=8081",
-    "start:status": "STATUS_FIXTURE=1 STATUS_URL=/status-fixture.json npx @11ty/eleventy --serve --port=8081",
+    "start:status": "STATUS_FIXTURE=1 STATUS_URL=/status-preview/status.json STATUS_LOG_URL=/status-preview npx @11ty/eleventy --serve --port=8081",
     "start:staging": "STAC_BASE_URL=https://stac-staging.dynamical.org npx @11ty/eleventy --serve --port=8081",
     "build:staging": "STAC_BASE_URL=https://stac-staging.dynamical.org STAC_CACHE_DURATION=0s npx @11ty/eleventy",
     "clean": "rm -r docs .cache"

--- a/public/status-log.mjs
+++ b/public/status-log.mjs
@@ -45,6 +45,13 @@ export function parseEvents(text) {
     // meant to be safe for an old client, and a semantic addition bumps `v`.
     if (event?.kind !== COVERAGE && event?.kind !== TRANSITION) continue;
     if (typeof event.component !== "string") continue;
+    // A UTC offset is required. Date.parse treats an offset-less date-time as
+    // *local*, which is exactly what Python's datetime.isoformat() emits without
+    // tzinfo — so a naive timestamp would silently shift every derived interval
+    // by the viewer's offset. The publisher refuses to write one; this end
+    // verifies rather than trusts, since the repos deploy independently.
+    if (typeof event.ts !== "string") continue;
+    if (!/(?:Z|[+-]\d{2}:?\d{2})$/.test(event.ts)) continue;
     if (!Number.isFinite(Date.parse(event.ts))) continue;
     events.push(event);
   }
@@ -175,4 +182,59 @@ function dayState(spans, start, end) {
   }
   if (unknown) return "unknown";
   return operational >= end - start ? "operational" : "nodata";
+}
+
+
+/**
+ * Uptime and coverage over the same window the bars cover.
+ *
+ * Derived from the log rather than from Sentry's check counts, so the percentage
+ * and the strip beneath it cannot disagree — a green number over a red cell would
+ * discredit both. It also means one methodology across every component, whether a
+ * 60-second HTTP probe or a daily cron backs it.
+ *
+ * Truncated rather than rounded, so a window containing confirmed downtime can
+ * never present as a flat 100%.
+ *
+ * `unknown` spans are excluded from the denominator rather than counted either
+ * way: a state we could not read is no basis for a claim, the same as a coverage
+ * gap. That makes them visible in `coverage` instead of silently averaged away.
+ *
+ * Uniform method is not uniform precision. A transition's onset is only as sharp
+ * as its monitor's cadence, so a daily cron's figure is inherently coarser than an
+ * HTTP detector's. That is a property of the measurement, not the arithmetic.
+ */
+export function uptimeSummary(spans, { asOf, days }) {
+  const ceiling = asOf.getTime();
+  const windowStart = ceiling - days * DAY_MS;
+  const summary = new Map();
+
+  for (const [component, list] of spans) {
+    if (!list.length) continue;
+    const from = Math.max(windowStart, list[0].start);
+    const elapsed = ceiling - from;
+    if (elapsed <= 0) continue;
+
+    let monitored = 0;
+    let down = 0;
+    for (const span of list) {
+      if (span.state === "unknown") continue;
+      const overlap = Math.min(span.end, ceiling) - Math.max(span.start, from);
+      if (overlap <= 0) continue;
+      monitored += overlap;
+      if (span.state === "down") down += overlap;
+    }
+    if (monitored <= 0) continue;
+
+    summary.set(component, {
+      uptime: truncate((100 * (monitored - down)) / monitored),
+      coverage: truncate((100 * monitored) / elapsed),
+    });
+  }
+  return summary;
+}
+
+// Floor to three decimals. Flooring is what stops 99.9999 from presenting as 100.
+function truncate(percent) {
+  return Math.floor(percent * 1000) / 1000;
 }

--- a/public/status-log.mjs
+++ b/public/status-log.mjs
@@ -1,0 +1,214 @@
+// Replay of status/events.jsonl into the views /status renders.
+//
+// The log is the source of truth and everything here is a pure fold over it, so
+// the page never has to reimplement the publisher's reduction — that half stays
+// where transitions are detected. All this does is walk events in order.
+//
+// Nothing here reads the clock. Callers pass the effective as-of, because every
+// open interval must end there rather than at `now`: a browser opened on Friday
+// must not render three green days from a publisher that died on Tuesday.
+
+const COVERAGE = "coverage";
+const TRANSITION = "transition";
+const PUBLIC_STATES = new Set(["operational", "down"]);
+// At equal ts the order is: coverage entry, then transitions, then coverage exit.
+// Entry first because a component must be observed before a state change of it
+// means anything; exit last because a change recorded at the instant coverage
+// ended was observed while coverage still held. Ordering the exit first would
+// make an ordinary recovery-then-uncover sequence read as a transition with
+// nobody watching. The publisher sorts by the same rule.
+function kindRank(event) {
+  if (event.kind !== COVERAGE) return 1;
+  return event.monitored ? 0 : 2;
+}
+const DAY_MS = 86_400_000;
+
+// An unrecognized state renders as unknown and never as operational. The
+// publisher ships from a separate repo on its own deploy, so the day it adds a
+// state this build has never heard of, the failure has to be visible rather than
+// silently reassuring.
+function publicState(state) {
+  return PUBLIC_STATES.has(state) ? state : "unknown";
+}
+
+export function parseEvents(text) {
+  const events = [];
+  for (const line of text.split("\n")) {
+    if (!line.trim()) continue;
+    let event;
+    try {
+      event = JSON.parse(line);
+    } catch {
+      continue; // A truncated tail must not cost us the whole history.
+    }
+    // Skip unknown kinds rather than failing: additive annotative kinds are
+    // meant to be safe for an old client, and a semantic addition bumps `v`.
+    if (event?.kind !== COVERAGE && event?.kind !== TRANSITION) continue;
+    if (typeof event.component !== "string") continue;
+    if (!Number.isFinite(Date.parse(event.ts))) continue;
+    events.push(event);
+  }
+  return events.sort(
+    (a, b) =>
+      Date.parse(a.ts) - Date.parse(b.ts) ||
+      kindRank(a) - kindRank(b) ||
+      a.component.localeCompare(b.component),
+  );
+}
+
+// The log cannot say when it was last checked, only when something changed, so
+// freshness comes from meta.json. Taking the max covers the CDN skew where a
+// browser holds events newer than the meta it fetched alongside them.
+export function effectiveAsOf(reconciledAt, events) {
+  const times = [Date.parse(reconciledAt)].filter(Number.isFinite);
+  for (const event of events) times.push(Date.parse(event.ts));
+  return times.length ? new Date(Math.max(...times)) : null;
+}
+
+/**
+ * Per-component spans of observed state. Gaps between spans are periods nobody
+ * was watching — deliberately absent rather than represented, since "no data"
+ * is not a state a component can be in.
+ *
+ * `closedBy` records why a span ended, which is what lets an incident be
+ * reported as resolved, truncated by a monitor going away, or still open.
+ */
+export function componentSpans(events, { asOf }) {
+  const ceiling = asOf.getTime();
+  const spans = new Map();
+  const open = new Map();
+
+  const close = (component, end, closedBy) => {
+    const current = open.get(component);
+    if (!current) return;
+    open.delete(component);
+    if (end <= current.start) return; // Zero-width spans render as nothing.
+    spans.get(component).push({ ...current, end, closedBy });
+  };
+
+  for (const event of events) {
+    const at = Math.min(Date.parse(event.ts), ceiling);
+    const { component } = event;
+    if (!spans.has(component)) spans.set(component, []);
+
+    if (event.kind === COVERAGE && event.monitored === false) {
+      close(component, at, "coverage");
+      continue;
+    }
+    const state =
+      event.kind === COVERAGE ? publicState(event.state) : publicState(event.to);
+    const current = open.get(component);
+    // A same-state re-assertion must not split an incident: the publisher may
+    // legitimately re-declare coverage without anything having changed.
+    if (current && current.state === state) continue;
+    // A transition while uncovered violates a writer invariant, but the reader
+    // stays tolerant — ignoring it is safer than inventing coverage for it.
+    if (!current && event.kind === TRANSITION) continue;
+    close(component, at, "transition");
+    open.set(component, { start: at, state });
+  }
+
+  for (const component of [...open.keys()]) close(component, ceiling, "asOf");
+  for (const list of spans.values()) list.sort((a, b) => a.start - b.start);
+  return spans;
+}
+
+// Current status is the last span, and only if it reaches the as-of: a component
+// whose coverage ended is excluded rather than reported at its last known state,
+// which would be claiming knowledge we stopped having.
+export function currentState(spans, { asOf }) {
+  const current = new Map();
+  for (const [component, list] of spans) {
+    const last = list.at(-1);
+    if (last && last.end >= asOf.getTime()) current.set(component, last.state);
+  }
+  return current;
+}
+
+/**
+ * One cell per UTC day, from the first day the log has coverage for through the
+ * as-of, capped at `days`.
+ *
+ * Starts at first coverage rather than at `asOf - days` on purpose: a 90-cell
+ * strip that is 80 cells empty reads as broken rather than as young. The caller
+ * labels the strip from `cells.length`, so the claim grows with the evidence
+ * instead of being asserted up front.
+ *
+ * Precedence is down > no data > operational. Hiding a witnessed outage behind
+ * "no data" is the wrong direction for this artifact.
+ */
+export function dailyBars(spans, { asOf, days = 90 }) {
+  const result = new Map();
+  const lastDay = Math.floor(asOf.getTime() / DAY_MS);
+  const windowStart = lastDay - days + 1;
+
+  for (const [component, list] of spans) {
+    if (!list.length) {
+      result.set(component, []);
+      continue;
+    }
+    const firstDay = Math.max(windowStart, Math.floor(list[0].start / DAY_MS));
+    const cells = [];
+    for (let day = firstDay; day <= lastDay; day += 1) {
+      const start = day * DAY_MS;
+      // The final cell is a partial day, so it ends at the as-of rather than at
+      // midnight — otherwise the rest of today counts as unobserved.
+      const end = Math.min(start + DAY_MS, asOf.getTime());
+      cells.push({
+        date: new Date(start).toISOString().slice(0, 10),
+        state: dayState(list, start, end),
+      });
+    }
+    result.set(component, cells);
+  }
+  return result;
+}
+
+function dayState(spans, start, end) {
+  let operational = 0;
+  for (const span of spans) {
+    const overlap = Math.min(span.end, end) - Math.max(span.start, start);
+    if (overlap <= 0) continue;
+    if (span.state === "down") return "down";
+    if (span.state === "operational") operational += overlap;
+  }
+  return operational >= end - start ? "operational" : "nodata";
+}
+
+/**
+ * Every `down` span, newest first.
+ *
+ * A span truncated by its monitor going away is reported as such rather than as
+ * resolved: we know when we stopped watching, not when it recovered. One real
+ * outage spanning a coverage gap therefore surfaces as two incidents, the first
+ * truncated, which is honest about what was actually observed.
+ */
+export function incidents(spans, { asOf }) {
+  const out = [];
+  for (const [component, list] of spans) {
+    for (const span of list) {
+      if (span.state !== "down") continue;
+      out.push({
+        component,
+        start: new Date(span.start),
+        end: new Date(span.end),
+        durationMs: span.end - span.start,
+        ongoing: span.closedBy === "asOf" && span.end >= asOf.getTime(),
+        truncated: span.closedBy === "coverage",
+      });
+    }
+  }
+  return out.sort((a, b) => b.start - a.start);
+}
+
+export function formatDuration(ms) {
+  const minutes = Math.max(1, Math.round(ms / 60_000));
+  if (minutes < 60) return `${minutes} min`;
+  const hours = minutes / 60;
+  if (hours < 24) {
+    const rounded = Math.round(hours * 10) / 10;
+    return `${rounded} ${rounded === 1 ? "hour" : "hours"}`;
+  }
+  const days = Math.round((hours / 24) * 10) / 10;
+  return `${days} ${days === 1 ? "day" : "days"}`;
+}

--- a/public/status-log.mjs
+++ b/public/status-log.mjs
@@ -51,8 +51,7 @@ export function parseEvents(text) {
   return events.sort(
     (a, b) =>
       Date.parse(a.ts) - Date.parse(b.ts) ||
-      kindRank(a) - kindRank(b) ||
-      a.component.localeCompare(b.component),
+      kindRank(a) - kindRank(b),
   );
 }
 
@@ -69,30 +68,31 @@ export function effectiveAsOf(reconciledAt, events) {
  * Per-component spans of observed state. Gaps between spans are periods nobody
  * was watching — deliberately absent rather than represented, since "no data"
  * is not a state a component can be in.
- *
- * `closedBy` records why a span ended, which is what lets an incident be
- * reported as resolved, truncated by a monitor going away, or still open.
  */
 export function componentSpans(events, { asOf }) {
   const ceiling = asOf.getTime();
   const spans = new Map();
   const open = new Map();
 
-  const close = (component, end, closedBy) => {
+  const close = (component, end) => {
     const current = open.get(component);
     if (!current) return;
     open.delete(component);
     if (end <= current.start) return; // Zero-width spans render as nothing.
-    spans.get(component).push({ ...current, end, closedBy });
+    spans.get(component).push({ ...current, end });
   };
 
   for (const event of events) {
+    // Unreachable from the page, since effectiveAsOf takes the max over every
+    // event. Kept anyway: "no interval extends past the as-of" is an invariant of
+    // this function, not a property of one caller's arithmetic, and a caller
+    // asking for an earlier as-of is the obvious next use.
     const at = Math.min(Date.parse(event.ts), ceiling);
     const { component } = event;
     if (!spans.has(component)) spans.set(component, []);
 
     if (event.kind === COVERAGE && event.monitored === false) {
-      close(component, at, "coverage");
+      close(component, at);
       continue;
     }
     const state =
@@ -104,25 +104,13 @@ export function componentSpans(events, { asOf }) {
     // A transition while uncovered violates a writer invariant, but the reader
     // stays tolerant — ignoring it is safer than inventing coverage for it.
     if (!current && event.kind === TRANSITION) continue;
-    close(component, at, "transition");
+    close(component, at);
     open.set(component, { start: at, state });
   }
 
-  for (const component of [...open.keys()]) close(component, ceiling, "asOf");
+  for (const component of [...open.keys()]) close(component, ceiling);
   for (const list of spans.values()) list.sort((a, b) => a.start - b.start);
   return spans;
-}
-
-// Current status is the last span, and only if it reaches the as-of: a component
-// whose coverage ended is excluded rather than reported at its last known state,
-// which would be claiming knowledge we stopped having.
-export function currentState(spans, { asOf }) {
-  const current = new Map();
-  for (const [component, list] of spans) {
-    const last = list.at(-1);
-    if (last && last.end >= asOf.getTime()) current.set(component, last.state);
-  }
-  return current;
 }
 
 /**
@@ -137,7 +125,7 @@ export function currentState(spans, { asOf }) {
  * Precedence is down > no data > operational. Hiding a witnessed outage behind
  * "no data" is the wrong direction for this artifact.
  */
-export function dailyBars(spans, { asOf, days = 90 }) {
+export function dailyBars(spans, { asOf, days }) {
   const result = new Map();
   const lastDay = Math.floor(asOf.getTime() / DAY_MS);
   const windowStart = lastDay - days + 1;
@@ -151,12 +139,16 @@ export function dailyBars(spans, { asOf, days = 90 }) {
     const cells = [];
     for (let day = firstDay; day <= lastDay; day += 1) {
       const start = day * DAY_MS;
-      // The final cell is a partial day, so it ends at the as-of rather than at
-      // midnight — otherwise the rest of today counts as unobserved.
+      // Both edges are partial days and both are clipped, symmetrically. The last
+      // ends at the as-of, or the rest of today counts as unobserved; the first
+      // begins at first coverage, or every strip opens on a permanent grey cell
+      // just because monitoring started mid-day. Interior days are unaffected,
+      // since their bounds already sit inside the covered span.
+      const from = Math.max(start, list[0].start);
       const end = Math.min(start + DAY_MS, asOf.getTime());
       cells.push({
         date: new Date(start).toISOString().slice(0, 10),
-        state: dayState(list, start, end),
+        state: dayState(list, from, end),
       });
     }
     result.set(component, cells);
@@ -164,51 +156,23 @@ export function dailyBars(spans, { asOf, days = 90 }) {
   return result;
 }
 
+// Precedence: down > unknown > no data > operational.
+//
+// "unknown" outranking "no data" matters. A state this build does not recognize
+// is something we were told and could not read, which is not the same as nobody
+// watching — and rendering it as a coverage gap would let a state the publisher
+// added hide behind "not monitored", the same direction the down-first rule
+// exists to prevent.
 function dayState(spans, start, end) {
   let operational = 0;
+  let unknown = false;
   for (const span of spans) {
     const overlap = Math.min(span.end, end) - Math.max(span.start, start);
     if (overlap <= 0) continue;
     if (span.state === "down") return "down";
-    if (span.state === "operational") operational += overlap;
+    if (span.state === "unknown") unknown = true;
+    else operational += overlap;
   }
+  if (unknown) return "unknown";
   return operational >= end - start ? "operational" : "nodata";
-}
-
-/**
- * Every `down` span, newest first.
- *
- * A span truncated by its monitor going away is reported as such rather than as
- * resolved: we know when we stopped watching, not when it recovered. One real
- * outage spanning a coverage gap therefore surfaces as two incidents, the first
- * truncated, which is honest about what was actually observed.
- */
-export function incidents(spans, { asOf }) {
-  const out = [];
-  for (const [component, list] of spans) {
-    for (const span of list) {
-      if (span.state !== "down") continue;
-      out.push({
-        component,
-        start: new Date(span.start),
-        end: new Date(span.end),
-        durationMs: span.end - span.start,
-        ongoing: span.closedBy === "asOf" && span.end >= asOf.getTime(),
-        truncated: span.closedBy === "coverage",
-      });
-    }
-  }
-  return out.sort((a, b) => b.start - a.start);
-}
-
-export function formatDuration(ms) {
-  const minutes = Math.max(1, Math.round(ms / 60_000));
-  if (minutes < 60) return `${minutes} min`;
-  const hours = minutes / 60;
-  if (hours < 24) {
-    const rounded = Math.round(hours * 10) / 10;
-    return `${rounded} ${rounded === 1 ? "hour" : "hours"}`;
-  }
-  const days = Math.round((hours / 24) * 10) / 10;
-  return `${days} ${days === 1 ? "day" : "days"}`;
 }

--- a/public/status.mjs
+++ b/public/status.mjs
@@ -93,8 +93,24 @@ function statusMark(status) {
 // uptime_since rather than a fixed "90 days". Both detectors were recreated
 // during the Sentry migration, so the real window is hours today and grows on
 // its own; hardcoding a period asserted coverage the data did not have.
-export function formatUptimeWindow(since, now = new Date()) {
-  const seconds = (now.getTime() - Date.parse(since)) / 1000;
+//
+// `asOf` must be the feed's generated_at, not the viewer's clock. The percentage
+// was computed over uptime_since → generated_at, so measuring the label against
+// `now` would let it keep growing after the data stopped — a stale feed would
+// claim "3 days" for a 19-hour measurement, which is the same defect this
+// function exists to remove, just smaller. It also makes the label immune to
+// viewer clock skew, which otherwise makes the line vanish on a slow clock.
+//
+// uptime_since must carry a UTC offset. Date.parse treats an offset-less
+// date-time as *local*, so a naive value — exactly what Python's
+// datetime.isoformat() produces without tzinfo — would silently shift the window
+// by the viewer's offset. The publisher's _utc_iso refuses naive timestamps, but
+// the two repos deploy independently, so this end verifies rather than trusts.
+export function formatUptimeWindow(since, asOf) {
+  if (typeof since !== "string" || !/(?:Z|[+-]\d{2}:?\d{2})$/.test(since)) {
+    return null;
+  }
+  const seconds = (asOf.getTime() - Date.parse(since)) / 1000;
   if (!Number.isFinite(seconds) || seconds <= 0) return null;
   const days = Math.floor(seconds / 86400);
   if (days >= 1) return `${days} day${days === 1 ? "" : "s"}`;
@@ -114,7 +130,7 @@ export function formatUptime(uptime) {
   return capped.replace(/\.?0+$/, "");
 }
 
-function renderGroup(list, entries, kind) {
+function renderGroup(list, entries, kind, asOf) {
   list.replaceChildren();
   for (const entry of entries) {
     const item = document.createElement("li");
@@ -146,12 +162,10 @@ function renderGroup(list, entries, kind) {
       item.append(detail);
     }
     if (kind === "endpoint" && Number.isFinite(entry.uptime)) {
-      const window = entry.uptime_since
-        ? formatUptimeWindow(entry.uptime_since)
-        : null;
-      if (window) {
+      const measured = formatUptimeWindow(entry.uptime_since, asOf);
+      if (measured) {
         const detail = document.createElement("p");
-        detail.textContent = `${formatUptime(entry.uptime)}% uptime over the last ${window}`;
+        detail.textContent = `${formatUptime(entry.uptime)}% uptime over the last ${measured}`;
         item.append(detail);
       }
     }
@@ -205,7 +219,12 @@ function renderStatus(root, data) {
       : null,
   );
   groups.hidden = false;
-  renderGroup(root.querySelector("#status-platform"), data.endpoints, "endpoint");
+  renderGroup(
+    root.querySelector("#status-platform"),
+    data.endpoints,
+    "endpoint",
+    new Date(data.generated_at),
+  );
   renderGroup(root.querySelector("#status-datasets"), data.datasets, "dataset");
 }
 

--- a/public/status.mjs
+++ b/public/status.mjs
@@ -89,10 +89,25 @@ function statusMark(status) {
   return { operational: "●", degraded: "▲", down: "×", unknown: "?" }[status];
 }
 
-// uptime_90d is not validated in validateStatusData at all; the load-bearing
-// guard is the Number.isFinite check at the call site in renderGroup, without
-// which a string value would throw here. Trims trailing zeros, and never lets
-// rounding promote an imperfect figure to a flat "100%".
+// The measured window the publisher actually observed, rendered from
+// uptime_since rather than a fixed "90 days". Both detectors were recreated
+// during the Sentry migration, so the real window is hours today and grows on
+// its own; hardcoding a period asserted coverage the data did not have.
+export function formatUptimeWindow(since, now = new Date()) {
+  const seconds = (now.getTime() - Date.parse(since)) / 1000;
+  if (!Number.isFinite(seconds) || seconds <= 0) return null;
+  const days = Math.floor(seconds / 86400);
+  if (days >= 1) return `${days} day${days === 1 ? "" : "s"}`;
+  const hours = Math.floor(seconds / 3600);
+  if (hours >= 1) return `${hours} hour${hours === 1 ? "" : "s"}`;
+  const minutes = Math.max(1, Math.floor(seconds / 60));
+  return `${minutes} minute${minutes === 1 ? "" : "s"}`;
+}
+
+// uptime is not validated in validateStatusData at all; the load-bearing guard
+// is the Number.isFinite check at the call site in renderGroup, without which a
+// string value would throw here. Trims trailing zeros, and never lets rounding
+// promote an imperfect figure to a flat "100%".
 export function formatUptime(uptime) {
   const rounded = uptime.toFixed(3);
   const capped = rounded === "100.000" && uptime < 100 ? "99.999" : rounded;
@@ -130,10 +145,15 @@ function renderGroup(list, entries, kind) {
       detail.append("Last successful update ", time);
       item.append(detail);
     }
-    if (kind === "endpoint" && Number.isFinite(entry.uptime_90d)) {
-      const detail = document.createElement("p");
-      detail.textContent = `${formatUptime(entry.uptime_90d)}% uptime over the last 90 days`;
-      item.append(detail);
+    if (kind === "endpoint" && Number.isFinite(entry.uptime)) {
+      const window = entry.uptime_since
+        ? formatUptimeWindow(entry.uptime_since)
+        : null;
+      if (window) {
+        const detail = document.createElement("p");
+        detail.textContent = `${formatUptime(entry.uptime)}% uptime over the last ${window}`;
+        item.append(detail);
+      }
     }
     list.append(item);
   }

--- a/public/status.mjs
+++ b/public/status.mjs
@@ -138,7 +138,7 @@ export function formatUptime(uptime) {
   return capped.replace(/\.?0+$/, "");
 }
 
-function renderGroup(list, entries, kind, asOf, bars) {
+function renderGroup(list, entries, asOf, bars) {
   list.replaceChildren();
   for (const entry of entries) {
     const item = document.createElement("li");
@@ -158,18 +158,7 @@ function renderGroup(list, entries, kind, asOf, bars) {
     header.append(name, state);
     item.append(header);
 
-    if (
-      kind === "dataset" &&
-      Number.isFinite(Date.parse(entry.last_successful_update))
-    ) {
-      const detail = document.createElement("p");
-      const time = document.createElement("time");
-      time.dateTime = entry.last_successful_update;
-      time.textContent = formatTimestamp(entry.last_successful_update);
-      detail.append("Last successful update ", time);
-      item.append(detail);
-    }
-    if (kind === "endpoint" && Number.isFinite(entry.uptime)) {
+    if (Number.isFinite(entry.uptime)) {
       const measured = formatUptimeWindow(entry.uptime_since, asOf);
       if (measured) {
         const detail = document.createElement("p");
@@ -190,13 +179,26 @@ function barStrip(cells) {
   const strip = document.createElement("div");
   strip.className = "status-bars";
   const down = cells.filter((cell) => cell.state === "down").length;
+  const uncovered = cells.filter((cell) => cell.state !== "operational").length - down;
   const days = cells.length;
-  strip.setAttribute(
-    "aria-label",
+  const plural = (n) => (n === 1 ? "day" : "days");
+  // role="img" is required, not decorative: ARIA forbids naming a role-less
+  // element, and a nameless generic is exactly what some screen readers drop —
+  // which would leave this strip announcing nothing, since every cell is
+  // aria-hidden and the per-cell title is pointer-only.
+  strip.setAttribute("role", "img");
+  // The label has to carry coverage as well as outages. A sighted reader sees the
+  // grey cells; describing only outages would tell a screen reader the record is
+  // clean while four days of it are missing.
+  const parts = [
     down === 0
-      ? `No outages recorded in the last ${days} day${days === 1 ? "" : "s"}`
-      : `${down} of the last ${days} days had an outage`,
-  );
+      ? `No outages recorded in the last ${days} ${plural(days)}`
+      : `${down} of the last ${days} ${plural(days)} had an outage`,
+  ];
+  if (uncovered > 0) {
+    parts.push(`${uncovered} ${plural(uncovered)} not monitored`);
+  }
+  strip.setAttribute("aria-label", parts.join("; "));
   for (const cell of cells) {
     const day = document.createElement("span");
     day.dataset.day = cell.state;
@@ -207,7 +209,6 @@ function barStrip(cells) {
     strip.append(day);
   }
   const scale = document.createElement("p");
-  scale.className = "status-bar-scale";
   const first = document.createElement("span");
   first.textContent = `${days} day${days === 1 ? "" : "s"} ago`;
   const last = document.createElement("span");
@@ -303,7 +304,6 @@ function renderStatus(root, data, bars) {
     renderGroup(
       root.querySelector(selector),
       data.endpoints.filter((entry) => entry.group === group),
-      "endpoint",
       asOfFeed,
       bars,
     );
@@ -335,6 +335,7 @@ function renderUnavailable(root) {
 }
 
 async function loadStatus(root) {
+  const bars = loadBars(root);
   try {
     const response = await fetch(root.dataset.statusUrl, {
       cache: "no-store",
@@ -346,8 +347,11 @@ async function loadStatus(root) {
     if (!response.ok) {
       throw new Error(`Status request failed: ${response.status}`);
     }
+    // Started before the snapshot is awaited, so a slow log costs only the bars.
+    // Awaiting it inside renderStatus's argument list made a hung log hold the
+    // whole page on "Checking current status…" for the full fetch deadline.
     const data = validateStatusData(await response.json());
-    renderStatus(root, data, await loadBars(root));
+    renderStatus(root, data, await bars);
   } catch (error) {
     console.error("Unable to load public status", error);
     renderUnavailable(root);

--- a/public/status.mjs
+++ b/public/status.mjs
@@ -3,6 +3,7 @@ import {
   dailyBars,
   effectiveAsOf,
   parseEvents,
+  uptimeSummary,
 } from "./status-log.mjs";
 
 const PUBLIC_STATUSES = new Set(["operational", "degraded", "down"]);
@@ -97,48 +98,7 @@ function statusMark(status) {
   return { operational: "●", degraded: "▲", down: "×", unknown: "?" }[status];
 }
 
-// The measured window the publisher actually observed, rendered from
-// uptime_since rather than a fixed "90 days". Both detectors were recreated
-// during the Sentry migration, so the real window is hours today and grows on
-// its own; hardcoding a period asserted coverage the data did not have.
-//
-// `asOf` must be the feed's generated_at, not the viewer's clock. The percentage
-// was computed over uptime_since → generated_at, so measuring the label against
-// `now` would let it keep growing after the data stopped — a stale feed would
-// claim "3 days" for a 19-hour measurement, which is the same defect this
-// function exists to remove, just smaller. It also makes the label immune to
-// viewer clock skew, which otherwise makes the line vanish on a slow clock.
-//
-// uptime_since must carry a UTC offset. Date.parse treats an offset-less
-// date-time as *local*, so a naive value — exactly what Python's
-// datetime.isoformat() produces without tzinfo — would silently shift the window
-// by the viewer's offset. The publisher's _utc_iso refuses naive timestamps, but
-// the two repos deploy independently, so this end verifies rather than trusts.
-export function formatUptimeWindow(since, asOf) {
-  if (typeof since !== "string" || !/(?:Z|[+-]\d{2}:?\d{2})$/.test(since)) {
-    return null;
-  }
-  const seconds = (asOf.getTime() - Date.parse(since)) / 1000;
-  if (!Number.isFinite(seconds) || seconds <= 0) return null;
-  const days = Math.floor(seconds / 86400);
-  if (days >= 1) return `${days} day${days === 1 ? "" : "s"}`;
-  const hours = Math.floor(seconds / 3600);
-  if (hours >= 1) return `${hours} hour${hours === 1 ? "" : "s"}`;
-  const minutes = Math.max(1, Math.floor(seconds / 60));
-  return `${minutes} minute${minutes === 1 ? "" : "s"}`;
-}
-
-// uptime is not validated in validateStatusData at all; the load-bearing guard
-// is the Number.isFinite check at the call site in renderGroup, without which a
-// string value would throw here. Trims trailing zeros, and never lets rounding
-// promote an imperfect figure to a flat "100%".
-export function formatUptime(uptime) {
-  const rounded = uptime.toFixed(3);
-  const capped = rounded === "100.000" && uptime < 100 ? "99.999" : rounded;
-  return capped.replace(/\.?0+$/, "");
-}
-
-function renderGroup(list, entries, asOf, bars) {
+function renderGroup(list, entries, bars, uptime) {
   list.replaceChildren();
   for (const entry of entries) {
     const item = document.createElement("li");
@@ -158,15 +118,22 @@ function renderGroup(list, entries, asOf, bars) {
     header.append(name, state);
     item.append(header);
 
-    if (Number.isFinite(entry.uptime)) {
-      const measured = formatUptimeWindow(entry.uptime_since, asOf);
-      if (measured) {
-        const detail = document.createElement("p");
-        detail.textContent = `${formatUptime(entry.uptime)}% uptime over the last ${measured}`;
-        item.append(detail);
-      }
-    }
     const cells = bars?.get(entry.id);
+    const measured = uptime?.get(entry.id);
+    // The figure and the strip describe the same window by construction: the day
+    // count comes from the cells the strip renders, not from a separate field
+    // that could drift out of step with them.
+    if (cells?.length && measured) {
+      const days = cells.length;
+      const detail = document.createElement("p");
+      detail.textContent =
+        `${measured.uptime}% uptime over the last ${days} ` +
+        `${days === 1 ? "day" : "days"}` +
+        // Only when it is not the whole window: a percentage over monitored time
+        // otherwise shrinks its own denominator without saying so.
+        (measured.coverage < 100 ? `, ${measured.coverage}% monitored` : "");
+      item.append(detail);
+    }
     if (cells?.length) item.append(barStrip(cells));
     list.append(item);
   }
@@ -239,7 +206,11 @@ async function loadBars(root) {
     const parsed = parseEvents(events);
     const asOf = effectiveAsOf(JSON.parse(meta).reconciled_at, parsed);
     if (!asOf) return null;
-    return dailyBars(componentSpans(parsed, { asOf }), { asOf, days: BAR_DAYS });
+    const spans = componentSpans(parsed, { asOf });
+    return {
+      cells: dailyBars(spans, { asOf, days: BAR_DAYS }),
+      uptime: uptimeSummary(spans, { asOf, days: BAR_DAYS }),
+    };
   } catch (error) {
     console.warn("Status history unavailable; rendering without bars", error);
     return null;
@@ -296,7 +267,6 @@ function renderStatus(root, data, bars) {
   // page mirrors the sections the retiring uptime.dynamical.org carried, and
   // per-dataset health was never on it. Re-adding the section later is a page
   // change only, since the feed already carries them.
-  const asOfFeed = new Date(data.generated_at);
   for (const [selector, group] of [
     ["#status-endpoints", "endpoint"],
     ["#status-tools", "tool"],
@@ -304,8 +274,8 @@ function renderStatus(root, data, bars) {
     renderGroup(
       root.querySelector(selector),
       data.endpoints.filter((entry) => entry.group === group),
-      asOfFeed,
-      bars,
+      bars?.cells,
+      bars?.uptime,
     );
   }
 }

--- a/public/status.mjs
+++ b/public/status.mjs
@@ -1,7 +1,15 @@
+import {
+  componentSpans,
+  dailyBars,
+  effectiveAsOf,
+  parseEvents,
+} from "./status-log.mjs";
+
 const PUBLIC_STATUSES = new Set(["operational", "degraded", "down"]);
 const STALE_AFTER_MS = 20 * 60 * 1000;
 const FETCH_TIMEOUT_MS = 10 * 1000;
 const REFRESH_INTERVAL_MS = 5 * 60 * 1000;
+const BAR_DAYS = 90;
 
 function isStatusEntry(entry) {
   return (
@@ -130,7 +138,7 @@ export function formatUptime(uptime) {
   return capped.replace(/\.?0+$/, "");
 }
 
-function renderGroup(list, entries, kind, asOf) {
+function renderGroup(list, entries, kind, asOf, bars) {
   list.replaceChildren();
   for (const entry of entries) {
     const item = document.createElement("li");
@@ -169,11 +177,75 @@ function renderGroup(list, entries, kind, asOf) {
         item.append(detail);
       }
     }
+    const cells = bars?.get(entry.id);
+    if (cells?.length) item.append(barStrip(cells));
     list.append(item);
   }
 }
 
-function renderStatus(root, data) {
+// A flex row of one cell per UTC day. Labelled from cells.length rather than a
+// hardcoded 90 so the claim grows with the evidence: a strip captioned "90 days"
+// that is mostly empty reads as broken rather than as young.
+function barStrip(cells) {
+  const strip = document.createElement("div");
+  strip.className = "status-bars";
+  const down = cells.filter((cell) => cell.state === "down").length;
+  const days = cells.length;
+  strip.setAttribute(
+    "aria-label",
+    down === 0
+      ? `No outages recorded in the last ${days} day${days === 1 ? "" : "s"}`
+      : `${down} of the last ${days} days had an outage`,
+  );
+  for (const cell of cells) {
+    const day = document.createElement("span");
+    day.dataset.day = cell.state;
+    // The bars are decorative in aggregate; the aria-label above carries the
+    // meaning, so individual cells stay out of the accessibility tree.
+    day.setAttribute("aria-hidden", "true");
+    day.title = `${cell.date}: ${cell.state === "nodata" ? "not monitored" : cell.state}`;
+    strip.append(day);
+  }
+  const scale = document.createElement("p");
+  scale.className = "status-bar-scale";
+  const first = document.createElement("span");
+  first.textContent = `${days} day${days === 1 ? "" : "s"} ago`;
+  const last = document.createElement("span");
+  last.textContent = "Today";
+  scale.append(first, last);
+  const wrapper = document.createDocumentFragment();
+  wrapper.append(strip, scale);
+  return wrapper;
+}
+
+// The log is optional. It ships from a separate repo and did not exist when this
+// page first deployed, so a missing or malformed log costs the bars and nothing
+// else — current status comes from the snapshot either way.
+async function loadBars(root) {
+  const base = root.dataset.logUrl;
+  if (!base) return null;
+  try {
+    const [events, meta] = await Promise.all(
+      [`${base}/events.jsonl`, `${base}/meta.json`].map(async (url) => {
+        const response = await fetch(url, {
+          cache: "no-store",
+          signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+        });
+        if (!response.ok) throw new Error(`${url}: ${response.status}`);
+        return response.text();
+      }),
+    );
+    const parsed = parseEvents(events);
+    const asOf = effectiveAsOf(JSON.parse(meta).reconciled_at, parsed);
+    if (!asOf) return null;
+    return dailyBars(componentSpans(parsed, { asOf }), { asOf, days: BAR_DAYS });
+  } catch (error) {
+    console.warn("Status history unavailable; rendering without bars", error);
+    return null;
+  }
+}
+
+function renderStatus(root, data, bars) {
   const overall = summarizeOverallStatus(data);
   const overallPanel = root.querySelector("#status-overall");
   const heading = root.querySelector("#status-overall-heading");
@@ -219,13 +291,23 @@ function renderStatus(root, data) {
       : null,
   );
   groups.hidden = false;
-  renderGroup(
-    root.querySelector("#status-platform"),
-    data.endpoints,
-    "endpoint",
-    new Date(data.generated_at),
-  );
-  renderGroup(root.querySelector("#status-datasets"), data.datasets, "dataset");
+  // Datasets are published in the feed but deliberately not rendered yet: this
+  // page mirrors the sections the retiring uptime.dynamical.org carried, and
+  // per-dataset health was never on it. Re-adding the section later is a page
+  // change only, since the feed already carries them.
+  const asOfFeed = new Date(data.generated_at);
+  for (const [selector, group] of [
+    ["#status-endpoints", "endpoint"],
+    ["#status-tools", "tool"],
+  ]) {
+    renderGroup(
+      root.querySelector(selector),
+      data.endpoints.filter((entry) => entry.group === group),
+      "endpoint",
+      asOfFeed,
+      bars,
+    );
+  }
 }
 
 function setStale(stale, message) {
@@ -264,7 +346,8 @@ async function loadStatus(root) {
     if (!response.ok) {
       throw new Error(`Status request failed: ${response.status}`);
     }
-    renderStatus(root, validateStatusData(await response.json()));
+    const data = validateStatusData(await response.json());
+    renderStatus(root, data, await loadBars(root));
   } catch (error) {
     console.error("Unable to load public status", error);
     renderUnavailable(root);

--- a/test/fixtures/events.jsonl
+++ b/test/fixtures/events.jsonl
@@ -1,0 +1,14 @@
+{"ts":"2026-06-14T19:55:00Z","kind":"coverage","component":"dynamical-org","monitored":true,"state":"operational"}
+{"ts":"2026-06-14T19:55:00Z","kind":"coverage","component":"stac-catalog","monitored":true,"state":"operational"}
+{"ts":"2026-06-14T19:55:00Z","kind":"coverage","component":"wxopticon","monitored":true,"state":"operational"}
+{"ts":"2026-06-23T19:55:00Z","kind":"coverage","component":"scorecard","monitored":true,"state":"operational"}
+{"ts":"2026-06-28T15:55:00Z","kind":"transition","component":"dynamical-org","to":"down"}
+{"ts":"2026-06-28T17:55:00Z","kind":"transition","component":"dynamical-org","to":"operational"}
+{"ts":"2026-07-02T19:55:00Z","kind":"coverage","component":"data-product-reads","monitored":true,"state":"operational"}
+{"ts":"2026-07-12T10:55:00Z","kind":"transition","component":"wxopticon","to":"down"}
+{"ts":"2026-07-13T16:55:00Z","kind":"transition","component":"wxopticon","to":"operational"}
+{"ts":"2026-07-16T19:55:00Z","kind":"coverage","component":"scorecard","monitored":false}
+{"ts":"2026-07-19T19:55:00Z","kind":"coverage","component":"scorecard","monitored":true,"state":"operational"}
+{"ts":"2026-07-21T13:55:00Z","kind":"transition","component":"stac-catalog","to":"down"}
+{"ts":"2026-07-21T14:55:00Z","kind":"transition","component":"stac-catalog","to":"operational"}
+{"ts":"2026-07-24T14:55:00Z","kind":"transition","component":"data-product-reads","to":"down"}

--- a/test/fixtures/status.json
+++ b/test/fixtures/status.json
@@ -89,17 +89,13 @@
       "id": "dynamical-org",
       "name": "dynamical.org",
       "group": "endpoint",
-      "status": "operational",
-      "uptime": 99.982,
-      "uptime_since": "2026-04-25T19:55:00Z"
+      "status": "operational"
     },
     {
       "id": "stac-catalog",
       "name": "STAC catalog",
       "group": "endpoint",
-      "status": "operational",
-      "uptime": 100.0,
-      "uptime_since": "2026-07-24T08:30:00Z"
+      "status": "operational"
     },
     {
       "id": "data-product-reads",

--- a/test/fixtures/status.json
+++ b/test/fixtures/status.json
@@ -45,8 +45,7 @@
     {
       "id": "ecmwf-ifs-ens-forecast-15-day-0-25-degree",
       "name": "ECMWF IFS ENS forecast, 15 day, 0.25 degree",
-      "status": "operational",
-      "last_successful_update": "2026-07-24T14:20:00Z"
+      "status": "down"
     },
     {
       "id": "noaa-gefs-forecast-35-day",
@@ -79,27 +78,10 @@
       "last_successful_update": "2026-07-24T18:30:00Z"
     },
     {
-      "id": "nasa-smap-level3-36km-v9",
-      "name": "NASA SMAP Level 3, 36 km, v9",
-      "status": "down"
-    },
-    {
       "id": "noaa-gfs-forecast",
       "name": "NOAA GFS forecast",
       "status": "operational",
       "last_successful_update": "2026-07-24T18:00:00Z"
-    },
-    {
-      "id": "noaa-ndvi-cdr-analysis",
-      "name": "NOAA NDVI CDR analysis",
-      "status": "operational",
-      "last_successful_update": "2026-07-23T22:10:00Z"
-    },
-    {
-      "id": "u-arizona-swann-analysis",
-      "name": "University of Arizona SWANN analysis",
-      "status": "operational",
-      "last_successful_update": "2026-07-24T06:00:00Z"
     }
   ],
   "endpoints": [
@@ -107,13 +89,15 @@
       "id": "dynamical-org",
       "name": "dynamical.org",
       "status": "operational",
-      "uptime_90d": 99.982
+      "uptime": 99.982,
+      "uptime_since": "2026-04-25T19:55:00Z"
     },
     {
       "id": "stac-catalog",
       "name": "STAC catalog",
       "status": "operational",
-      "uptime_90d": 100.0
+      "uptime": 100.0,
+      "uptime_since": "2026-07-24T08:30:00Z"
     }
   ]
 }

--- a/test/fixtures/status.json
+++ b/test/fixtures/status.json
@@ -88,6 +88,7 @@
     {
       "id": "dynamical-org",
       "name": "dynamical.org",
+      "group": "endpoint",
       "status": "operational",
       "uptime": 99.982,
       "uptime_since": "2026-04-25T19:55:00Z"
@@ -95,9 +96,28 @@
     {
       "id": "stac-catalog",
       "name": "STAC catalog",
+      "group": "endpoint",
       "status": "operational",
       "uptime": 100.0,
       "uptime_since": "2026-07-24T08:30:00Z"
+    },
+    {
+      "id": "data-product-reads",
+      "name": "Data product reads",
+      "group": "endpoint",
+      "status": "down"
+    },
+    {
+      "id": "wxopticon",
+      "name": "wxopticon",
+      "group": "tool",
+      "status": "operational"
+    },
+    {
+      "id": "scorecard",
+      "name": "Scorecard",
+      "group": "tool",
+      "status": "operational"
     }
   ]
 }

--- a/test/status-log.test.mjs
+++ b/test/status-log.test.mjs
@@ -6,6 +6,7 @@ import {
   dailyBars,
   effectiveAsOf,
   parseEvents,
+  uptimeSummary,
 } from "../public/status-log.mjs";
 
 const AS_OF = new Date("2026-07-25T12:00:00Z");
@@ -229,4 +230,84 @@ test("the window caps at the requested number of days", () => {
   const spans = spansOf(coverage("2026-01-01T00:00:00Z", C, true, "operational"));
 
   assert.equal(dailyBars(spans, { asOf: AS_OF, days: 90 }).get(C).length, 90);
+});
+
+// --- uptime -----------------------------------------------------------------
+
+test("uptime is derived from the log, so it cannot contradict the bars", () => {
+  // The percentage used to come from Sentry's check counts while the strip came
+  // from the log, so a green number could sit above a red cell.
+  const spans = spansOf(
+    coverage("2026-07-15T00:00:00Z", C, true, "operational"),
+    transition("2026-07-20T00:00:00Z", C, "down"),
+    transition("2026-07-21T00:00:00Z", C, "operational"),
+  );
+
+  const { uptime, coverage: covered } = uptimeSummary(spans, {
+    asOf: AS_OF,
+    days: 90,
+  }).get(C);
+  const cells = dailyBars(spans, { asOf: AS_OF, days: 90 }).get(C);
+
+  // One day down out of ten and a half observed.
+  assert.ok(uptime > 90 && uptime < 91, `unexpected uptime ${uptime}`);
+  assert.equal(covered, 100);
+  assert.equal(cells.filter((cell) => cell.state === "down").length, 1);
+});
+
+test("confirmed downtime never presents as a flat 100%", () => {
+  const spans = spansOf(
+    coverage("2026-01-01T00:00:00Z", C, true, "operational"),
+    transition("2026-07-25T11:59:59Z", C, "down"),
+  );
+
+  assert.equal(uptimeSummary(spans, { asOf: AS_OF, days: 90 }).get(C).uptime, 99.999);
+});
+
+test("a coverage gap lowers coverage rather than uptime", () => {
+  // Uptime over monitored time would otherwise quietly shrink its own
+  // denominator whenever nobody was watching.
+  const spans = spansOf(
+    coverage("2026-07-15T00:00:00Z", C, true, "operational"),
+    coverage("2026-07-20T00:00:00Z", C, false),
+    coverage("2026-07-25T00:00:00Z", C, true, "operational"),
+  );
+
+  const { uptime, coverage: covered } = uptimeSummary(spans, {
+    asOf: AS_OF,
+    days: 90,
+  }).get(C);
+
+  assert.equal(uptime, 100);
+  assert.ok(covered > 50 && covered < 60, `unexpected coverage ${covered}`);
+});
+
+test("an unknown state is excluded from the denominator, not counted either way", () => {
+  const spans = spansOf(
+    coverage("2026-07-24T00:00:00Z", C, true, "operational"),
+    transition("2026-07-25T00:00:00Z", C, "maintenance"),
+  );
+
+  const { uptime, coverage: covered } = uptimeSummary(spans, {
+    asOf: AS_OF,
+    days: 90,
+  }).get(C);
+
+  assert.equal(uptime, 100);
+  assert.ok(covered < 100, "unknown time must show up as missing coverage");
+});
+
+test("an offset-less event timestamp is refused rather than shifted", () => {
+  // Date.parse reads it as local time, which is what Python emits without tzinfo.
+  const events = parseEvents(
+    jsonl(
+      { ts: "2026-07-20T00:00:00", kind: "coverage", component: C, monitored: true, state: "operational" },
+      coverage("2026-07-21T00:00:00Z", C, true, "operational"),
+    ),
+  );
+
+  assert.deepEqual(
+    events.map((e) => e.ts),
+    ["2026-07-21T00:00:00Z"],
+  );
 });

--- a/test/status-log.test.mjs
+++ b/test/status-log.test.mjs
@@ -1,0 +1,328 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  componentSpans,
+  currentState,
+  dailyBars,
+  effectiveAsOf,
+  formatDuration,
+  incidents,
+  parseEvents,
+} from "../public/status-log.mjs";
+
+const AS_OF = new Date("2026-07-25T12:00:00Z");
+const C = "noaa-gfs-forecast";
+
+const coverage = (ts, component, monitored, state) => ({
+  ts,
+  kind: "coverage",
+  component,
+  monitored,
+  ...(state ? { state } : {}),
+});
+const transition = (ts, component, to) => ({
+  ts,
+  kind: "transition",
+  component,
+  to,
+});
+const jsonl = (...events) => events.map((e) => JSON.stringify(e)).join("\n") + "\n";
+
+const spansOf = (...events) =>
+  componentSpans(parseEvents(jsonl(...events)), { asOf: AS_OF });
+
+// --- parsing --------------------------------------------------------------
+
+test("skips unknown event kinds instead of failing", () => {
+  // Additive annotative kinds are meant to be safe for an old client; a semantic
+  // addition is supposed to bump `v` instead.
+  const events = parseEvents(
+    jsonl(
+      coverage("2026-07-20T00:00:00Z", C, true, "operational"),
+      { ts: "2026-07-21T00:00:00Z", kind: "annotation", component: C, note: "hi" },
+      transition("2026-07-22T00:00:00Z", C, "down"),
+    ),
+  );
+
+  assert.deepEqual(
+    events.map((e) => e.kind),
+    ["coverage", "transition"],
+  );
+});
+
+test("survives a truncated final line", () => {
+  // R2 has no append, so a write interrupted mid-object must not cost the history.
+  const text =
+    JSON.stringify(coverage("2026-07-20T00:00:00Z", C, true, "operational")) +
+    '\n{"ts":"2026-07-21T00:00:00Z","kind":"transi';
+
+  assert.equal(parseEvents(text).length, 1);
+});
+
+test("sorts by timestamp, then coverage before transition", () => {
+  const events = parseEvents(
+    jsonl(
+      transition("2026-07-20T00:00:00Z", C, "down"),
+      coverage("2026-07-20T00:00:00Z", C, true, "operational"),
+    ),
+  );
+
+  assert.deepEqual(
+    events.map((e) => e.kind),
+    ["coverage", "transition"],
+  );
+});
+
+test("effective as-of covers CDN skew between the two artifacts", () => {
+  const events = parseEvents(jsonl(coverage("2026-07-25T12:05:00Z", C, true, "down")));
+
+  // A browser can hold events newer than the meta.json it fetched alongside.
+  assert.deepEqual(
+    effectiveAsOf("2026-07-25T12:00:00Z", events),
+    new Date("2026-07-25T12:05:00Z"),
+  );
+  assert.deepEqual(effectiveAsOf("2026-07-25T12:00:00Z", []), AS_OF);
+  assert.equal(effectiveAsOf("not-a-date", []), null);
+});
+
+// --- spans ----------------------------------------------------------------
+
+test("an open span ends at the as-of, never at now", () => {
+  // Otherwise a browser on Friday renders green days from a publisher that died
+  // on Tuesday. This is the rule separating evidence from extrapolation.
+  const spans = spansOf(coverage("2026-07-24T12:00:00Z", C, true, "operational"));
+
+  assert.deepEqual(spans.get(C), [
+    {
+      start: Date.parse("2026-07-24T12:00:00Z"),
+      end: AS_OF.getTime(),
+      state: "operational",
+      closedBy: "asOf",
+    },
+  ]);
+});
+
+test("a same-state coverage re-assertion does not split a span", () => {
+  const spans = spansOf(
+    coverage("2026-07-24T00:00:00Z", C, true, "down"),
+    coverage("2026-07-24T06:00:00Z", C, true, "down"),
+  );
+
+  assert.equal(spans.get(C).length, 1);
+  assert.equal(spans.get(C)[0].start, Date.parse("2026-07-24T00:00:00Z"));
+});
+
+test("a coverage exit closes the span and leaves a gap, not a state", () => {
+  const spans = spansOf(
+    coverage("2026-07-23T00:00:00Z", C, true, "operational"),
+    coverage("2026-07-24T00:00:00Z", C, false),
+  );
+
+  assert.deepEqual(
+    spans.get(C).map((s) => [s.state, s.closedBy]),
+    [["operational", "coverage"]],
+  );
+});
+
+test("an unrecognized state becomes unknown, never operational", () => {
+  const spans = spansOf(coverage("2026-07-24T00:00:00Z", C, true, "maintenance"));
+
+  assert.equal(spans.get(C)[0].state, "unknown");
+});
+
+test("a transition while uncovered is ignored rather than inventing coverage", () => {
+  const spans = spansOf(
+    coverage("2026-07-23T00:00:00Z", C, true, "operational"),
+    coverage("2026-07-24T00:00:00Z", C, false),
+    transition("2026-07-24T06:00:00Z", C, "down"),
+  );
+
+  assert.equal(spans.get(C).length, 1);
+  assert.equal(spans.get(C)[0].closedBy, "coverage");
+});
+
+test("events after the as-of are clamped rather than extending the window", () => {
+  const spans = spansOf(
+    coverage("2026-07-24T00:00:00Z", C, true, "operational"),
+    transition("2026-07-26T00:00:00Z", C, "down"),
+  );
+
+  assert.equal(spans.get(C).at(-1).end, AS_OF.getTime());
+});
+
+// --- current state --------------------------------------------------------
+
+test("current state excludes a component whose coverage ended", () => {
+  // Reporting its last known state would claim knowledge we stopped having.
+  const spans = spansOf(
+    coverage("2026-07-23T00:00:00Z", C, true, "operational"),
+    coverage("2026-07-24T00:00:00Z", C, false),
+    coverage("2026-07-24T00:00:00Z", "stac-catalog", true, "down"),
+  );
+
+  const current = currentState(spans, { asOf: AS_OF });
+
+  assert.equal(current.has(C), false);
+  assert.equal(current.get("stac-catalog"), "down");
+});
+
+// --- bars -----------------------------------------------------------------
+
+test("bars start at first coverage, not at the window edge", () => {
+  // A 90-cell strip that is 80 cells empty reads as broken rather than as young.
+  const spans = spansOf(coverage("2026-07-23T00:00:00Z", C, true, "operational"));
+
+  const cells = dailyBars(spans, { asOf: AS_OF, days: 90 }).get(C);
+
+  assert.deepEqual(
+    cells.map((c) => c.date),
+    ["2026-07-23", "2026-07-24", "2026-07-25"],
+  );
+});
+
+test("a day with any down interval renders down", () => {
+  // Precedence is deliberate: hiding a witnessed outage behind "no data" is the
+  // wrong direction for this artifact.
+  const spans = spansOf(
+    coverage("2026-07-23T00:00:00Z", C, true, "operational"),
+    transition("2026-07-24T10:00:00Z", C, "down"),
+    transition("2026-07-24T10:05:00Z", C, "operational"),
+  );
+
+  const byDate = new Map(
+    dailyBars(spans, { asOf: AS_OF }).get(C).map((c) => [c.date, c.state]),
+  );
+
+  assert.equal(byDate.get("2026-07-23"), "operational");
+  assert.equal(byDate.get("2026-07-24"), "down");
+});
+
+test("a partly uncovered day renders no data rather than operational", () => {
+  const spans = spansOf(
+    coverage("2026-07-23T00:00:00Z", C, true, "operational"),
+    coverage("2026-07-24T06:00:00Z", C, false),
+    coverage("2026-07-24T18:00:00Z", C, true, "operational"),
+  );
+
+  const byDate = new Map(
+    dailyBars(spans, { asOf: AS_OF }).get(C).map((c) => [c.date, c.state]),
+  );
+
+  assert.equal(byDate.get("2026-07-24"), "nodata");
+});
+
+test("an unknown state does not count as operational coverage", () => {
+  const spans = spansOf(coverage("2026-07-24T00:00:00Z", C, true, "maintenance"));
+
+  const byDate = new Map(
+    dailyBars(spans, { asOf: AS_OF }).get(C).map((c) => [c.date, c.state]),
+  );
+
+  assert.equal(byDate.get("2026-07-24"), "nodata");
+});
+
+test("today is judged against the as-of, not against midnight", () => {
+  // Otherwise the remainder of the current day always counts as unobserved and
+  // the newest cell is permanently "no data".
+  const spans = spansOf(coverage("2026-07-25T00:00:00Z", C, true, "operational"));
+
+  const cells = dailyBars(spans, { asOf: AS_OF }).get(C);
+
+  assert.deepEqual(cells, [{ date: "2026-07-25", state: "operational" }]);
+});
+
+test("the window caps at the requested number of days", () => {
+  const spans = spansOf(coverage("2026-01-01T00:00:00Z", C, true, "operational"));
+
+  assert.equal(dailyBars(spans, { asOf: AS_OF, days: 90 }).get(C).length, 90);
+});
+
+// --- incidents ------------------------------------------------------------
+
+test("a resolved outage reports its measured duration", () => {
+  const spans = spansOf(
+    coverage("2026-07-23T00:00:00Z", C, true, "operational"),
+    transition("2026-07-24T10:00:00Z", C, "down"),
+    transition("2026-07-24T12:30:00Z", C, "operational"),
+  );
+
+  assert.deepEqual(incidents(spans, { asOf: AS_OF }), [
+    {
+      component: C,
+      start: new Date("2026-07-24T10:00:00Z"),
+      end: new Date("2026-07-24T12:30:00Z"),
+      durationMs: 9_000_000,
+      ongoing: false,
+      truncated: false,
+    },
+  ]);
+});
+
+test("an outage still open at the as-of is ongoing, not resolved", () => {
+  const spans = spansOf(
+    coverage("2026-07-23T00:00:00Z", C, true, "operational"),
+    transition("2026-07-25T09:00:00Z", C, "down"),
+  );
+
+  const [incident] = incidents(spans, { asOf: AS_OF });
+
+  assert.equal(incident.ongoing, true);
+  assert.equal(incident.end.toISOString(), AS_OF.toISOString());
+});
+
+test("an outage cut short by its monitor going away is truncated", () => {
+  // We know when we stopped watching, not when it recovered, so one real outage
+  // spanning a coverage gap honestly surfaces as two incidents.
+  const spans = spansOf(
+    coverage("2026-07-23T00:00:00Z", C, true, "operational"),
+    transition("2026-07-24T00:00:00Z", C, "down"),
+    coverage("2026-07-24T06:00:00Z", C, false),
+    coverage("2026-07-24T18:00:00Z", C, true, "down"),
+    transition("2026-07-24T20:00:00Z", C, "operational"),
+  );
+
+  const found = incidents(spans, { asOf: AS_OF });
+
+  assert.equal(found.length, 2);
+  assert.deepEqual(
+    found.map((i) => [i.start.toISOString(), i.truncated]),
+    [
+      ["2026-07-24T18:00:00.000Z", false],
+      ["2026-07-24T00:00:00.000Z", true],
+    ],
+  );
+});
+
+test("incidents are newest first across components", () => {
+  const spans = spansOf(
+    coverage("2026-07-20T00:00:00Z", C, true, "operational"),
+    coverage("2026-07-20T00:00:00Z", "stac-catalog", true, "operational"),
+    transition("2026-07-21T00:00:00Z", C, "down"),
+    transition("2026-07-21T01:00:00Z", C, "operational"),
+    transition("2026-07-24T00:00:00Z", "stac-catalog", "down"),
+    transition("2026-07-24T01:00:00Z", "stac-catalog", "operational"),
+  );
+
+  assert.deepEqual(
+    incidents(spans, { asOf: AS_OF }).map((i) => i.component),
+    ["stac-catalog", C],
+  );
+});
+
+test("a healthy log has no incidents", () => {
+  const spans = spansOf(coverage("2026-07-20T00:00:00Z", C, true, "operational"));
+
+  assert.deepEqual(incidents(spans, { asOf: AS_OF }), []);
+});
+
+// --- formatting -----------------------------------------------------------
+
+test("durations read plainly at every scale", () => {
+  assert.equal(formatDuration(30_000), "1 min");
+  assert.equal(formatDuration(9 * 60_000), "9 min");
+  assert.equal(formatDuration(90 * 60_000), "1.5 hours");
+  assert.equal(formatDuration(60 * 60_000), "1 hour");
+  assert.equal(formatDuration(36 * 3_600_000), "1.5 days");
+  assert.equal(formatDuration(24 * 3_600_000), "1 day");
+});

--- a/test/status-log.test.mjs
+++ b/test/status-log.test.mjs
@@ -3,11 +3,8 @@ import test from "node:test";
 
 import {
   componentSpans,
-  currentState,
   dailyBars,
   effectiveAsOf,
-  formatDuration,
-  incidents,
   parseEvents,
 } from "../public/status-log.mjs";
 
@@ -98,7 +95,6 @@ test("an open span ends at the as-of, never at now", () => {
       start: Date.parse("2026-07-24T12:00:00Z"),
       end: AS_OF.getTime(),
       state: "operational",
-      closedBy: "asOf",
     },
   ]);
 });
@@ -120,8 +116,8 @@ test("a coverage exit closes the span and leaves a gap, not a state", () => {
   );
 
   assert.deepEqual(
-    spans.get(C).map((s) => [s.state, s.closedBy]),
-    [["operational", "coverage"]],
+    spans.get(C).map((span) => span.state),
+    ["operational"],
   );
 });
 
@@ -139,7 +135,6 @@ test("a transition while uncovered is ignored rather than inventing coverage", (
   );
 
   assert.equal(spans.get(C).length, 1);
-  assert.equal(spans.get(C)[0].closedBy, "coverage");
 });
 
 test("events after the as-of are clamped rather than extending the window", () => {
@@ -149,22 +144,6 @@ test("events after the as-of are clamped rather than extending the window", () =
   );
 
   assert.equal(spans.get(C).at(-1).end, AS_OF.getTime());
-});
-
-// --- current state --------------------------------------------------------
-
-test("current state excludes a component whose coverage ended", () => {
-  // Reporting its last known state would claim knowledge we stopped having.
-  const spans = spansOf(
-    coverage("2026-07-23T00:00:00Z", C, true, "operational"),
-    coverage("2026-07-24T00:00:00Z", C, false),
-    coverage("2026-07-24T00:00:00Z", "stac-catalog", true, "down"),
-  );
-
-  const current = currentState(spans, { asOf: AS_OF });
-
-  assert.equal(current.has(C), false);
-  assert.equal(current.get("stac-catalog"), "down");
 });
 
 // --- bars -----------------------------------------------------------------
@@ -191,7 +170,7 @@ test("a day with any down interval renders down", () => {
   );
 
   const byDate = new Map(
-    dailyBars(spans, { asOf: AS_OF }).get(C).map((c) => [c.date, c.state]),
+    dailyBars(spans, { asOf: AS_OF, days: 90 }).get(C).map((c) => [c.date, c.state]),
   );
 
   assert.equal(byDate.get("2026-07-23"), "operational");
@@ -206,20 +185,34 @@ test("a partly uncovered day renders no data rather than operational", () => {
   );
 
   const byDate = new Map(
-    dailyBars(spans, { asOf: AS_OF }).get(C).map((c) => [c.date, c.state]),
+    dailyBars(spans, { asOf: AS_OF, days: 90 }).get(C).map((c) => [c.date, c.state]),
   );
 
   assert.equal(byDate.get("2026-07-24"), "nodata");
 });
 
-test("an unknown state does not count as operational coverage", () => {
+test("an unknown state outranks no data rather than hiding behind it", () => {
+  // A state this build cannot read is something we were told; a coverage gap is
+  // nobody watching. Rendering the former as the latter would let a state the
+  // publisher added hide behind "not monitored".
   const spans = spansOf(coverage("2026-07-24T00:00:00Z", C, true, "maintenance"));
 
   const byDate = new Map(
-    dailyBars(spans, { asOf: AS_OF }).get(C).map((c) => [c.date, c.state]),
+    dailyBars(spans, { asOf: AS_OF, days: 90 }).get(C).map((c) => [c.date, c.state]),
   );
 
-  assert.equal(byDate.get("2026-07-24"), "nodata");
+  assert.equal(byDate.get("2026-07-24"), "unknown");
+});
+
+test("the first day is clipped to first coverage, not judged against midnight", () => {
+  // Otherwise every strip opens on a permanent grey cell purely because
+  // monitoring began part-way through a day.
+  const spans = spansOf(coverage("2026-07-24T09:00:00Z", C, true, "operational"));
+
+  assert.deepEqual(dailyBars(spans, { asOf: AS_OF, days: 90 }).get(C), [
+    { date: "2026-07-24", state: "operational" },
+    { date: "2026-07-25", state: "operational" },
+  ]);
 });
 
 test("today is judged against the as-of, not against midnight", () => {
@@ -227,7 +220,7 @@ test("today is judged against the as-of, not against midnight", () => {
   // the newest cell is permanently "no data".
   const spans = spansOf(coverage("2026-07-25T00:00:00Z", C, true, "operational"));
 
-  const cells = dailyBars(spans, { asOf: AS_OF }).get(C);
+  const cells = dailyBars(spans, { asOf: AS_OF, days: 90 }).get(C);
 
   assert.deepEqual(cells, [{ date: "2026-07-25", state: "operational" }]);
 });
@@ -236,93 +229,4 @@ test("the window caps at the requested number of days", () => {
   const spans = spansOf(coverage("2026-01-01T00:00:00Z", C, true, "operational"));
 
   assert.equal(dailyBars(spans, { asOf: AS_OF, days: 90 }).get(C).length, 90);
-});
-
-// --- incidents ------------------------------------------------------------
-
-test("a resolved outage reports its measured duration", () => {
-  const spans = spansOf(
-    coverage("2026-07-23T00:00:00Z", C, true, "operational"),
-    transition("2026-07-24T10:00:00Z", C, "down"),
-    transition("2026-07-24T12:30:00Z", C, "operational"),
-  );
-
-  assert.deepEqual(incidents(spans, { asOf: AS_OF }), [
-    {
-      component: C,
-      start: new Date("2026-07-24T10:00:00Z"),
-      end: new Date("2026-07-24T12:30:00Z"),
-      durationMs: 9_000_000,
-      ongoing: false,
-      truncated: false,
-    },
-  ]);
-});
-
-test("an outage still open at the as-of is ongoing, not resolved", () => {
-  const spans = spansOf(
-    coverage("2026-07-23T00:00:00Z", C, true, "operational"),
-    transition("2026-07-25T09:00:00Z", C, "down"),
-  );
-
-  const [incident] = incidents(spans, { asOf: AS_OF });
-
-  assert.equal(incident.ongoing, true);
-  assert.equal(incident.end.toISOString(), AS_OF.toISOString());
-});
-
-test("an outage cut short by its monitor going away is truncated", () => {
-  // We know when we stopped watching, not when it recovered, so one real outage
-  // spanning a coverage gap honestly surfaces as two incidents.
-  const spans = spansOf(
-    coverage("2026-07-23T00:00:00Z", C, true, "operational"),
-    transition("2026-07-24T00:00:00Z", C, "down"),
-    coverage("2026-07-24T06:00:00Z", C, false),
-    coverage("2026-07-24T18:00:00Z", C, true, "down"),
-    transition("2026-07-24T20:00:00Z", C, "operational"),
-  );
-
-  const found = incidents(spans, { asOf: AS_OF });
-
-  assert.equal(found.length, 2);
-  assert.deepEqual(
-    found.map((i) => [i.start.toISOString(), i.truncated]),
-    [
-      ["2026-07-24T18:00:00.000Z", false],
-      ["2026-07-24T00:00:00.000Z", true],
-    ],
-  );
-});
-
-test("incidents are newest first across components", () => {
-  const spans = spansOf(
-    coverage("2026-07-20T00:00:00Z", C, true, "operational"),
-    coverage("2026-07-20T00:00:00Z", "stac-catalog", true, "operational"),
-    transition("2026-07-21T00:00:00Z", C, "down"),
-    transition("2026-07-21T01:00:00Z", C, "operational"),
-    transition("2026-07-24T00:00:00Z", "stac-catalog", "down"),
-    transition("2026-07-24T01:00:00Z", "stac-catalog", "operational"),
-  );
-
-  assert.deepEqual(
-    incidents(spans, { asOf: AS_OF }).map((i) => i.component),
-    ["stac-catalog", C],
-  );
-});
-
-test("a healthy log has no incidents", () => {
-  const spans = spansOf(coverage("2026-07-20T00:00:00Z", C, true, "operational"));
-
-  assert.deepEqual(incidents(spans, { asOf: AS_OF }), []);
-});
-
-// --- formatting -----------------------------------------------------------
-
-test("durations read plainly at every scale", () => {
-  assert.equal(formatDuration(30_000), "1 min");
-  assert.equal(formatDuration(9 * 60_000), "9 min");
-  assert.equal(formatDuration(90 * 60_000), "1.5 hours");
-  assert.equal(formatDuration(60 * 60_000), "1 hour");
-  assert.equal(formatDuration(36 * 3_600_000), "1.5 days");
-  assert.equal(formatDuration(24 * 3_600_000), "1 day");
 });

--- a/test/status.test.mjs
+++ b/test/status.test.mjs
@@ -4,6 +4,7 @@ import test from "node:test";
 
 import {
   formatUptime,
+  formatUptimeWindow,
   isStatusDataStale,
   summarizeOverallStatus,
   validateStatusData,
@@ -28,7 +29,8 @@ const operationalData = {
       id: "dynamical-org",
       name: "dynamical.org",
       status: "operational",
-      uptime_90d: 99.9,
+      uptime: 99.9,
+      uptime_since: "2026-04-26T19:55:00Z",
     },
   ],
 };
@@ -36,14 +38,31 @@ const operationalData = {
 test("accepts the published feed shape", () => {
   // Returns a normalized copy, not the same reference, so compare by value.
   assert.deepEqual(validateStatusData(fixture), fixture);
-  assert.equal(fixture.datasets.length, 17);
+  // 14, matching the collections in stac.dynamical.org/catalog.json — the
+  // publisher deliberately excludes contrib datasets and source archivers.
+  assert.equal(fixture.datasets.length, 14);
   assert.deepEqual(summarizeOverallStatus(fixture), {
     status: "down",
     incidents: [
       { name: "NOAA HRRR forecast, 48 hour", status: "degraded" },
-      { name: "NASA SMAP Level 3, 36 km, v9", status: "down" },
+      { name: "ECMWF IFS ENS forecast, 15 day, 0.25 degree", status: "down" },
     ],
   });
+});
+
+test("labels the uptime window from what was measured", () => {
+  // The publisher sends the window it actually observed, so the page must never
+  // assert "90 days" for a monitor that has only been running for hours.
+  const now = new Date("2026-07-25T00:00:00Z");
+
+  assert.equal(formatUptimeWindow("2026-04-26T00:00:00Z", now), "90 days");
+  assert.equal(formatUptimeWindow("2026-07-24T00:00:00Z", now), "1 day");
+  assert.equal(formatUptimeWindow("2026-07-24T12:36:00Z", now), "11 hours");
+  assert.equal(formatUptimeWindow("2026-07-24T23:00:00Z", now), "1 hour");
+  assert.equal(formatUptimeWindow("2026-07-24T23:58:00Z", now), "2 minutes");
+  // A window that has not elapsed, or is unparseable, has nothing to claim.
+  assert.equal(formatUptimeWindow("2026-07-25T00:00:00Z", now), null);
+  assert.equal(formatUptimeWindow("not-a-date", now), null);
 });
 
 test("never rounds an imperfect uptime up to 100%", () => {

--- a/test/status.test.mjs
+++ b/test/status.test.mjs
@@ -3,8 +3,6 @@ import { readFileSync } from "node:fs";
 import test from "node:test";
 
 import {
-  formatUptime,
-  formatUptimeWindow,
   isStatusDataStale,
   summarizeOverallStatus,
   validateStatusData,
@@ -61,65 +59,6 @@ test("accepts the published feed shape", () => {
       { name: "Data product reads", status: "down" },
     ],
   });
-});
-
-test("the window is measured against the feed, not the viewer's clock", () => {
-  // The percentage was computed over uptime_since -> generated_at. Measuring the
-  // label against `now` instead lets it keep growing after the data stopped: a
-  // stale feed would claim "3 days" for a 19-hour measurement, which is the same
-  // defect this whole change removes, just smaller.
-  const generatedAt = new Date("2026-07-24T19:55:00Z");
-  const since = "2026-07-24T08:30:00Z";
-
-  assert.equal(formatUptimeWindow(since, generatedAt), "11 hours");
-  // Days later, the same frozen feed must still say 11 hours.
-  assert.equal(
-    formatUptimeWindow(since, new Date("2026-07-28T19:55:00Z")),
-    "4 days",
-    "sanity: a later as-of does change the answer, so the arg is load-bearing",
-  );
-});
-
-test("a timestamp without a UTC offset is refused rather than shifted", () => {
-  // Date.parse treats an offset-less date-time as local, so a naive value —
-  // exactly what Python's datetime.isoformat() emits without tzinfo — would
-  // silently shift the window by the viewer's offset.
-  const asOf = new Date("2026-07-25T12:00:00Z");
-
-  assert.equal(formatUptimeWindow("2026-07-25T00:00:00", asOf), null);
-  assert.equal(formatUptimeWindow("2026-07-25T00:00:00Z", asOf), "12 hours");
-  assert.equal(formatUptimeWindow("2026-07-25T00:00:00+00:00", asOf), "12 hours");
-  assert.equal(formatUptimeWindow("2026-07-25T02:00:00+02:00", asOf), "12 hours");
-});
-
-test("an absent or future window omits the line rather than guessing", () => {
-  const asOf = new Date("2026-07-25T12:00:00Z");
-
-  assert.equal(formatUptimeWindow(undefined, asOf), null);
-  assert.equal(formatUptimeWindow(null, asOf), null);
-  assert.equal(formatUptimeWindow("2026-07-26T00:00:00Z", asOf), null);
-});
-
-test("labels the uptime window from what was measured", () => {
-  // The publisher sends the window it actually observed, so the page must never
-  // assert "90 days" for a monitor that has only been running for hours.
-  const now = new Date("2026-07-25T00:00:00Z");
-
-  assert.equal(formatUptimeWindow("2026-04-26T00:00:00Z", now), "90 days");
-  assert.equal(formatUptimeWindow("2026-07-24T00:00:00Z", now), "1 day");
-  assert.equal(formatUptimeWindow("2026-07-24T12:36:00Z", now), "11 hours");
-  assert.equal(formatUptimeWindow("2026-07-24T23:00:00Z", now), "1 hour");
-  assert.equal(formatUptimeWindow("2026-07-24T23:58:00Z", now), "2 minutes");
-  // A window that has not elapsed, or is unparseable, has nothing to claim.
-  assert.equal(formatUptimeWindow("2026-07-25T00:00:00Z", now), null);
-  assert.equal(formatUptimeWindow("not-a-date", now), null);
-});
-
-test("never rounds an imperfect uptime up to 100%", () => {
-  assert.equal(formatUptime(100), "100");
-  assert.equal(formatUptime(99.9999), "99.999");
-  assert.equal(formatUptime(99.9), "99.9");
-  assert.equal(formatUptime(99.95), "99.95");
 });
 
 test("summarizes an operational feed", () => {

--- a/test/status.test.mjs
+++ b/test/status.test.mjs
@@ -50,6 +50,43 @@ test("accepts the published feed shape", () => {
   });
 });
 
+test("the window is measured against the feed, not the viewer's clock", () => {
+  // The percentage was computed over uptime_since -> generated_at. Measuring the
+  // label against `now` instead lets it keep growing after the data stopped: a
+  // stale feed would claim "3 days" for a 19-hour measurement, which is the same
+  // defect this whole change removes, just smaller.
+  const generatedAt = new Date("2026-07-24T19:55:00Z");
+  const since = "2026-07-24T08:30:00Z";
+
+  assert.equal(formatUptimeWindow(since, generatedAt), "11 hours");
+  // Days later, the same frozen feed must still say 11 hours.
+  assert.equal(
+    formatUptimeWindow(since, new Date("2026-07-28T19:55:00Z")),
+    "4 days",
+    "sanity: a later as-of does change the answer, so the arg is load-bearing",
+  );
+});
+
+test("a timestamp without a UTC offset is refused rather than shifted", () => {
+  // Date.parse treats an offset-less date-time as local, so a naive value —
+  // exactly what Python's datetime.isoformat() emits without tzinfo — would
+  // silently shift the window by the viewer's offset.
+  const asOf = new Date("2026-07-25T12:00:00Z");
+
+  assert.equal(formatUptimeWindow("2026-07-25T00:00:00", asOf), null);
+  assert.equal(formatUptimeWindow("2026-07-25T00:00:00Z", asOf), "12 hours");
+  assert.equal(formatUptimeWindow("2026-07-25T00:00:00+00:00", asOf), "12 hours");
+  assert.equal(formatUptimeWindow("2026-07-25T02:00:00+02:00", asOf), "12 hours");
+});
+
+test("an absent or future window omits the line rather than guessing", () => {
+  const asOf = new Date("2026-07-25T12:00:00Z");
+
+  assert.equal(formatUptimeWindow(undefined, asOf), null);
+  assert.equal(formatUptimeWindow(null, asOf), null);
+  assert.equal(formatUptimeWindow("2026-07-26T00:00:00Z", asOf), null);
+});
+
 test("labels the uptime window from what was measured", () => {
   // The publisher sends the window it actually observed, so the page must never
   // assert "90 days" for a monitor that has only been running for hours.

--- a/test/status.test.mjs
+++ b/test/status.test.mjs
@@ -41,11 +41,24 @@ test("accepts the published feed shape", () => {
   // 14, matching the collections in stac.dynamical.org/catalog.json — the
   // publisher deliberately excludes contrib datasets and source archivers.
   assert.equal(fixture.datasets.length, 14);
+  // Five endpoints across the page's two sections, plus the 14 datasets the feed
+  // still carries even though the page does not render them yet.
+  assert.deepEqual(
+    fixture.endpoints.map((entry) => [entry.id, entry.group]),
+    [
+      ["dynamical-org", "endpoint"],
+      ["stac-catalog", "endpoint"],
+      ["data-product-reads", "endpoint"],
+      ["wxopticon", "tool"],
+      ["scorecard", "tool"],
+    ],
+  );
   assert.deepEqual(summarizeOverallStatus(fixture), {
     status: "down",
     incidents: [
       { name: "NOAA HRRR forecast, 48 hour", status: "degraded" },
       { name: "ECMWF IFS ENS forecast, 15 day, 0.25 degree", status: "down" },
+      { name: "Data product reads", status: "down" },
     ],
   });
 });


### PR DESCRIPTION
Requires dynamical-org/dynamical.org-data#15. Supersedes #150.

## What this is

`/status` now carries the sections and items `uptime.dynamical.org` has, so nothing is lost when that page is switched off:

**Endpoints** — dynamical.org, STAC catalog, Data product reads
**Tools & resources** — wxopticon, Scorecard

Each row shows a state pill, a log-derived uptime figure, and a 90-day bar strip captioned from its own cell count.

`status.dynamical.org` is deliberately absent. So is the data products section, for now — per-dataset health was never on the retiring page. The feed keeps publishing all 14, so re-adding that section later is a page change only.

"Data product reads" rather than "read canary": it reads Zarr bytes out of hot storage, which is what the SLA's 99.5% clause names. "Catalog reads" would point at STAC metadata, which is already its own row.

## Uptime comes from the log

One methodology for every component, whether a 60-second HTTP probe or a daily cron backs it. Previously the two detectors got a figure from Sentry's `uptime-summary` and the three cron rows got nothing.

The split was worse than incomplete: the percentage came from check counts while the strip beneath it came from the log, so **the two could disagree** — a green number above a red cell would discredit both. Both now derive from the same spans over the same window, and the label's day count comes from the cells the strip renders rather than a separate field.

Uptime and coverage are reported separately:

| | |
|---|---|
| uptime | down time ÷ monitored time |
| coverage | monitored time ÷ window |

Reporting only the first lets a percentage quietly shrink its own denominator whenever nobody was watching. The fixture's Scorecard row reads **"100% uptime over the last 32 days, 90.322% monitored"** — the honest version of what would otherwise be a bare 100%.

Truncated rather than rounded, so confirmed downtime can never present as a flat 100%. `unknown` spans are excluded from the denominator rather than counted either way — a state we could not read is no basis for a claim, the same as a coverage gap — which makes it visible in coverage instead of averaged away.

## Replay properties

`status-log.mjs` is pure and reads no clock; callers pass an effective as-of, computed as `max(reconciled_at, last event ts)` because the two artifacts are fetched non-atomically through a CDN.

- **Every open interval ends at the as-of, never `now`.** A browser opened Friday must not render green days from a publisher that died Tuesday. That single rule is what separates the log being evidence from being extrapolation.
- **Bar precedence is down > unknown > no data > operational.** Hiding a witnessed outage behind "not monitored" is the wrong direction, and an unrecognised state is something we were *told* rather than a gap in watching.
- **Cells start at first coverage**, both edges clipped symmetrically, so a strip never opens on a grey cell merely because monitoring began mid-day.
- **Coverage is not a health state**, so a gap renders distinctly from an outage — with a border, since a gap measured 1.14:1 against white and would otherwise read as the end of the strip.
- **The log is optional.** Its fetch starts before the snapshot is awaited, so a log that hangs costs the bars and not the verdict people came for.

Reader tolerances are part of the schema, since the publisher deploys from another repo: unknown event kinds are skipped, an unrecognised state renders as unknown and never operational, a truncated final line does not cost the whole history, offset-less timestamps are refused, and events sort entry → transitions → exit exactly as the writer does.

## Accessibility

Each strip is `role="img"` with a summarising label — ARIA prohibits naming a role-less element and some screen readers drop it, which would leave the strip announcing nothing, since cells are `aria-hidden` and `title` is pointer-only. The label names uncovered days as well as outages, so a strip with a visible gap does not announce a clean record.

## Preview

`npm run start:status` serves all three artifacts under `/status-preview/`, with every timestamp shifted so the fixture's shape — an endpoint blip, a longer wxopticon outage, a Scorecard coverage gap, an ongoing read failure — always ends today. The real log is hours old and entirely green, so it exercises none of those paths.

## Still unlisted

Nav and footer point at `status.dynamical.org`; the page carries `noindex` and `sitemap: false`. Verified against a clean production build, along with no fixture artifact shipping.

## Validation

- `npm test` — 29 passed
- `npm run build` — clean
- Rendered in Chrome against the fixture, light and dark, at 360px and desktop
- Five CSS rules for the strip, all reusing existing pill tokens so a bar and its label cannot disagree about a state