### PR TITLE
Make status history claims match the evidence

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -156,7 +156,11 @@ module.exports = function (eleventyConfig) {
     });
     eleventyConfig.addTemplate(
       "status-meta-fixture.njk",
-      JSON.stringify({ v: 1, reconciled_at: now.toISOString() }),
+      JSON.stringify({
+        v: 1,
+        reconciled_at: now.toISOString(),
+        events_count: events.split("\n").length,
+      }),
       {
         permalink: "/status-preview/meta.json",
         eleventyExcludeFromCollections: true,

--- a/_data/statusIncidentFeed.js
+++ b/_data/statusIncidentFeed.js
@@ -1,0 +1,3 @@
+module.exports =
+  process.env.STATUS_INCIDENT_FEED_URL ||
+  "https://assets.dynamical.org/status/incidents.xml";

--- a/_includes/base.njk
+++ b/_includes/base.njk
@@ -51,6 +51,8 @@
     <link rel="apple-touch-icon" href="https://assets.dynamical.org/identity/logo/favicon/apple-touch-icon.png"/>
     <link rel="alternate" href="/feed/feed.xml" type="application/atom+xml" title="{{ metadata.title }}"/>
     <link rel="alternate" href="/feed/feed.json" type="application/json" title="{{ metadata.title }}"/>
+    {% if statusIncidentFeedEnabled %}<link rel="alternate" href="{{ statusIncidentFeed }}" type="application/rss+xml" title="dynamical.org status incidents"/>
+    {% endif %}
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",

--- a/_includes/base.njk
+++ b/_includes/base.njk
@@ -185,7 +185,7 @@
       {% set contentIcon = "🎙️" %}
       {% set contentUrl = latestPodcast.url %}
     {% endif %}
-    {% if latestContent %}
+    {% if latestContent and not hideLatestPopup %}
       <div id="latest-popup">
         <div class="popup-header">
           <span class="popup-type">{{ contentIcon }} {{ contentType }}</span>

--- a/content/status.njk
+++ b/content/status.njk
@@ -1,7 +1,7 @@
 ---
 layout: base.njk
 title: status
-description: Current health of dynamical.org datasets and public endpoints.
+description: Current health of dynamical.org public endpoints and tools.
 permalink: /status/
 # Unlisted for the first iteration: reachable by direct URL, but absent from the
 # nav, the footer, sitemap.xml, and llms.txt. Deliberately not disallowed in
@@ -9,6 +9,7 @@ permalink: /status/
 # very URL this is keeping quiet. noindex covers the crawler case.
 noindex: true
 sitemap: false
+hideLatestPopup: true
 ---
 
 <style>
@@ -121,7 +122,7 @@ sitemap: false
   data-log-url="{{ statusLogBase }}">
   <header>
     <h1 style="margin-top: 4rem; margin-bottom: 1rem;">System status</h1>
-    <p>Current health of the weather and climate data we publish and the endpoints that serve it.</p>
+    <p>Current health of dynamical.org public endpoints, tools, and resources.</p>
     <p id="status-as-of"><strong>As of —</strong></p>
   </header>
 
@@ -136,6 +137,7 @@ sitemap: false
   {# Left empty on purpose — status.mjs writes the text, so the live region
      announces a content change rather than merely becoming visible. #}
   <p id="status-stale" role="alert" hidden></p>
+  <p id="status-history" role="status" hidden></p>
 
   <div class="status-groups" id="status-groups" hidden style="margin-top: 4rem;">
     <section aria-labelledby="endpoints-heading">

--- a/content/status.njk
+++ b/content/status.njk
@@ -87,10 +87,8 @@ hideLatestPopup: true
   }
   .status-bars span {
     flex: 1 1 0;
-    /* A gap must read as "we stopped watching", not as the end of the strip, so
-       it carries the same border the muted pill uses to stay visible on white. */
     border: 1px solid var(--pill-muted-border);
-    background: var(--pill-muted-bg);
+    background: transparent;
   }
   .status-bars [data-day="unknown"] {
     border-color: var(--pill-down-bg);

--- a/content/status.njk
+++ b/content/status.njk
@@ -10,12 +10,30 @@ permalink: /status/
 noindex: true
 sitemap: false
 hideLatestPopup: true
+statusIncidentFeedEnabled: true
 ---
 
 <style>
-  /* The one piece of at-a-glance signal on the page: a state-colored rule above
-     the summary. Neutral until the feed resolves. */
+  .status-page-heading {
+    display: flex;
+    align-items: baseline;
+    flex-wrap: wrap;
+    gap: 0.5rem 2rem;
+    margin-top: 4rem;
+  }
+  .status-page-heading h1,
+  .status-page-heading p {
+    margin: 0;
+  }
+  #status-as-of {
+    margin-left: auto;
+    text-align: right;
+  }
+  #status-as-of.status-stale {
+    color: var(--pill-degraded-fg);
+  }
   .status-overall {
+    margin-top: 1rem;
     padding-top: 1.6rem;
     border-top: 0.6rem solid var(--muted-text);
   }
@@ -37,7 +55,6 @@ hideLatestPopup: true
   .status-list {
     --index-row-padding: 1rem;
   }
-  /* Name left, state right; the state must not shrink or wrap mid-label. */
   .status-list header {
     display: flex;
     gap: 1.2rem;
@@ -51,8 +68,6 @@ hideLatestPopup: true
     color: var(--muted-text);
     font-size: 1.2rem;
   }
-  /* One pill shape for every state, so severity is carried by color while the
-     text label stays the thing that actually conveys it. */
   .status-label {
     flex: 0 0 auto;
     padding: 0.1rem 0.5rem;
@@ -71,24 +86,24 @@ hideLatestPopup: true
     color: var(--pill-down-fg);
     background: var(--pill-down-bg);
   }
-  /* A state the publisher added that this page does not know yet. */
   .status-list [data-status="unknown"] .status-label {
     border: 1px solid var(--pill-muted-border);
     color: var(--pill-muted-fg);
     background: var(--pill-muted-bg);
   }
-  /* One cell per UTC day. A flex row is the whole layout; the states are the
-     same tokens the pills use, so a bar and its label cannot disagree. */
   .status-bars {
     display: flex;
     gap: 1px;
     margin-top: 0.6rem;
     height: 1.4rem;
   }
-  .status-bars span {
+  .status-bars > * {
     flex: 1 1 0;
     border: 1px solid var(--pill-muted-border);
     background: transparent;
+  }
+  .status-bars > a {
+    text-decoration: none;
   }
   .status-bars [data-day="unknown"] {
     border-color: var(--pill-down-bg);
@@ -105,9 +120,39 @@ hideLatestPopup: true
     display: flex;
     justify-content: space-between;
   }
+  .status-incident-heading,
+  .status-incident header {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 1rem;
+  }
+  .status-incident-log {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
+  .status-incident {
+    scroll-margin-top: 1rem;
+    padding: 1rem 0;
+    border-bottom: 1px solid var(--border-color);
+  }
+  .status-incident:target {
+    background: var(--pill-muted-bg);
+    outline: 0.4rem solid var(--pill-muted-bg);
+  }
+  .status-incident h3,
+  .status-incident p {
+    margin: 0;
+  }
+  .status-incident p {
+    margin-top: 0.4rem;
+    color: var(--muted-text);
+  }
   @media (max-width: 680px) {
-    /* align-items keeps the state label shrink-wrapped; without it the column
-       cross-axis stretches the pill to the full row width. */
+    #status-as-of {
+      flex-basis: 100%;
+    }
     .status-list header {
       flex-direction: column;
       align-items: start;
@@ -118,23 +163,17 @@ hideLatestPopup: true
 
 <main class="content" data-status-page data-status-url="{{ statusFeed }}"
   data-log-url="{{ statusLogBase }}">
-  <header>
-    <h1 style="margin-top: 4rem; margin-bottom: 1rem;">System status</h1>
-    <p>Current health of dynamical.org public endpoints, tools, and resources.</p>
-    <p id="status-as-of"><strong>As of —</strong></p>
+  <header class="status-page-heading">
+    <h1>dynamical.org status</h1>
+    <p id="status-as-of" role="status"><strong>As of —</strong></p>
   </header>
 
-  {# aria-live belongs on the verdict, not the timestamp: the heading is what
-     changes from "Checking current status…" to the actual result. #}
   <section class="status-overall" id="status-overall" aria-labelledby="status-overall-heading" aria-live="polite">
     <h2 id="status-overall-heading">Checking current status…</h2>
     <p id="status-summary">Loading the latest monitor results.</p>
     <ul id="status-incidents" hidden></ul>
   </section>
 
-  {# Left empty on purpose — status.mjs writes the text, so the live region
-     announces a content change rather than merely becoming visible. #}
-  <p id="status-stale" role="alert" hidden></p>
   <p id="status-history" role="status" hidden></p>
 
   <div class="status-groups" id="status-groups" hidden style="margin-top: 4rem;">
@@ -159,6 +198,15 @@ hideLatestPopup: true
     For per-model run timing and upstream source arrival history, see the
     <a href="https://status.dynamical.org">detailed data arrival status</a>.
   </p>
+
+  <section aria-labelledby="status-incident-heading" style="margin-top: 4rem;">
+    <header class="status-incident-heading">
+      <h2 id="status-incident-heading">Incident history</h2>
+      <a href="{{ statusIncidentFeed }}">RSS</a>
+    </header>
+    <p id="status-incident-empty">Loading incident history…</p>
+    <ol class="status-incident-log" id="status-incident-log"></ol>
+  </section>
 
   <noscript>
     <p>Status temporarily unavailable because JavaScript is disabled.</p>

--- a/public/status-log.mjs
+++ b/public/status-log.mjs
@@ -124,6 +124,60 @@ export function componentSpans(events, { asOf }) {
   return spans;
 }
 
+export function incidentId(component, start) {
+  return `incident-${component}-${Math.floor(start / 1000)}`;
+}
+
+export function incidentLog(events) {
+  const coverage = new Map();
+  const open = new Map();
+  const result = [];
+
+  const close = (component, end, ending) => {
+    const current = open.get(component);
+    open.delete(component);
+    if (!current || end <= current.start) return;
+    result.push({ ...current, end, ending });
+  };
+
+  for (const event of events) {
+    const at = Date.parse(event.ts);
+    const { component } = event;
+    const current = coverage.get(component) ?? {
+      monitored: false,
+      state: null,
+    };
+
+    if (event.kind === COVERAGE && event.monitored === false) {
+      if (current.monitored && current.state === "down") {
+        close(component, at, "observation-ended");
+      }
+      coverage.set(component, { monitored: false, state: null });
+      continue;
+    }
+    if (event.kind === TRANSITION && !current.monitored) continue;
+
+    const state =
+      event.kind === COVERAGE ? publicState(event.state) : publicState(event.to);
+    if (current.monitored && current.state === "down" && state !== "down") {
+      close(component, at, "resolved");
+    }
+    if ((!current.monitored || current.state !== "down") && state === "down") {
+      open.set(component, {
+        id: incidentId(component, at),
+        component,
+        start: at,
+      });
+    }
+    coverage.set(component, { monitored: true, state });
+  }
+
+  for (const current of open.values()) {
+    result.push({ ...current, end: null, ending: null });
+  }
+  return result.sort((a, b) => a.start - b.start);
+}
+
 /**
  * One cell per UTC day in the rolling window.
  *
@@ -140,9 +194,21 @@ export function dailyBars(spans, { asOf, days }) {
     for (let day = windowStart; day <= lastDay; day += 1) {
       const start = day * DAY_MS;
       const end = Math.min(start + DAY_MS, asOf.getTime());
+      const state = dayState(list, start, end);
+      const incidentIds =
+        state === "down"
+          ? list
+              .filter(
+                (span) =>
+                  span.state === "down" &&
+                  Math.min(span.end, end) - Math.max(span.start, start) > 0,
+              )
+              .map((span) => incidentId(component, span.start))
+          : [];
       cells.push({
         date: new Date(start).toISOString().slice(0, 10),
-        state: dayState(list, start, end),
+        state,
+        ...(incidentIds.length ? { incidentIds } : {}),
       });
     }
     result.set(component, cells);

--- a/public/status-log.mjs
+++ b/public/status-log.mjs
@@ -35,8 +35,9 @@ function publicState(state) {
   return PUBLIC_STATES.has(state) ? state : "unknown";
 }
 
-export function parseEvents(text) {
+export function parseEventLog(text) {
   const events = [];
+  let recordCount = 0;
   for (const line of text.split("\n")) {
     if (!line.trim()) continue;
     let event;
@@ -45,8 +46,9 @@ export function parseEvents(text) {
     } catch {
       continue; // A truncated tail must not cost us the whole history.
     }
-    // Skip unknown kinds rather than failing: additive annotative kinds are
-    // meant to be safe for an old client, and a semantic addition bumps `v`.
+    recordCount += 1;
+    // Skip unknown kinds so additive records remain safe for an old client.
+    // A state-bearing semantic addition bumps `v`.
     if (event?.kind !== COVERAGE && event?.kind !== TRANSITION) continue;
     if (typeof event.component !== "string") continue;
     // A UTC offset is required. Date.parse treats an offset-less date-time as
@@ -59,11 +61,15 @@ export function parseEvents(text) {
     if (!Number.isFinite(Date.parse(event.ts))) continue;
     events.push(event);
   }
-  return events.sort(
+  events.sort(
     (a, b) =>
-      Date.parse(a.ts) - Date.parse(b.ts) ||
-      kindRank(a) - kindRank(b),
+      Date.parse(a.ts) - Date.parse(b.ts) || kindRank(a) - kindRank(b),
   );
+  return { events, recordCount };
+}
+
+export function parseEvents(text) {
+  return parseEventLog(text).events;
 }
 
 // The log cannot say when it was last checked, only when something changed, so

--- a/public/status-log.mjs
+++ b/public/status-log.mjs
@@ -125,16 +125,10 @@ export function componentSpans(events, { asOf }) {
 }
 
 /**
- * One cell per UTC day, from the first day the log has coverage for through the
- * as-of, capped at `days`.
+ * One cell per UTC day in the rolling window.
  *
- * Starts at first coverage rather than at `asOf - days` on purpose: a 90-cell
- * strip that is 80 cells empty reads as broken rather than as young. The caller
- * labels the strip from `cells.length`, so the claim grows with the evidence
- * instead of being asserted up front.
- *
- * Precedence is down > no data > operational. Hiding a witnessed outage behind
- * "no data" is the wrong direction for this artifact.
+ * Precedence is down > unknown > operational > no data. Any observation fills
+ * the day; the separate coverage percentage carries partial-day completeness.
  */
 export function dailyBars(spans, { asOf, days }) {
   const result = new Map();
@@ -142,24 +136,13 @@ export function dailyBars(spans, { asOf, days }) {
   const windowStart = utcDayWindowStart(asOf, days) / DAY_MS;
 
   for (const [component, list] of spans) {
-    if (!list.length) {
-      result.set(component, []);
-      continue;
-    }
-    const firstDay = Math.max(windowStart, Math.floor(list[0].start / DAY_MS));
     const cells = [];
-    for (let day = firstDay; day <= lastDay; day += 1) {
+    for (let day = windowStart; day <= lastDay; day += 1) {
       const start = day * DAY_MS;
-      // Both edges are partial days and both are clipped, symmetrically. The last
-      // ends at the as-of, or the rest of today counts as unobserved; the first
-      // begins at first coverage, or every strip opens on a permanent grey cell
-      // just because monitoring started mid-day. Interior days are unaffected,
-      // since their bounds already sit inside the covered span.
-      const from = Math.max(start, list[0].start);
       const end = Math.min(start + DAY_MS, asOf.getTime());
       cells.push({
         date: new Date(start).toISOString().slice(0, 10),
-        state: dayState(list, from, end),
+        state: dayState(list, start, end),
       });
     }
     result.set(component, cells);
@@ -167,7 +150,7 @@ export function dailyBars(spans, { asOf, days }) {
   return result;
 }
 
-// Precedence: down > unknown > no data > operational.
+// Precedence: down > unknown > operational > no data.
 //
 // "unknown" outranking "no data" matters. A state this build does not recognize
 // is something we were told and could not read, which is not the same as nobody
@@ -185,7 +168,7 @@ function dayState(spans, start, end) {
     else operational += overlap;
   }
   if (unknown) return "unknown";
-  return operational >= end - start ? "operational" : "nodata";
+  return operational > 0 ? "operational" : "nodata";
 }
 
 
@@ -215,7 +198,7 @@ export function uptimeSummary(spans, { asOf, days }) {
 
   for (const [component, list] of spans) {
     if (!list.length) continue;
-    const from = Math.max(windowStart, list[0].start);
+    const from = windowStart;
     const elapsed = ceiling - from;
     if (elapsed <= 0) continue;
 

--- a/public/status-log.mjs
+++ b/public/status-log.mjs
@@ -23,6 +23,10 @@ function kindRank(event) {
 }
 const DAY_MS = 86_400_000;
 
+function utcDayWindowStart(asOf, days) {
+  return (Math.floor(asOf.getTime() / DAY_MS) - days + 1) * DAY_MS;
+}
+
 // An unrecognized state renders as unknown and never as operational. The
 // publisher ships from a separate repo on its own deploy, so the day it adds a
 // state this build has never heard of, the failure has to be visible rather than
@@ -135,7 +139,7 @@ export function componentSpans(events, { asOf }) {
 export function dailyBars(spans, { asOf, days }) {
   const result = new Map();
   const lastDay = Math.floor(asOf.getTime() / DAY_MS);
-  const windowStart = lastDay - days + 1;
+  const windowStart = utcDayWindowStart(asOf, days) / DAY_MS;
 
   for (const [component, list] of spans) {
     if (!list.length) {
@@ -206,7 +210,7 @@ function dayState(spans, start, end) {
  */
 export function uptimeSummary(spans, { asOf, days }) {
   const ceiling = asOf.getTime();
-  const windowStart = ceiling - days * DAY_MS;
+  const windowStart = utcDayWindowStart(asOf, days);
   const summary = new Map();
 
   for (const [component, list] of spans) {

--- a/public/status.mjs
+++ b/public/status.mjs
@@ -3,7 +3,7 @@ import {
   dailyBars,
   effectiveAsOf,
   incidentLog,
-  parseEvents,
+  parseEventLog,
   uptimeSummary,
 } from "./status-log.mjs";
 
@@ -206,13 +206,13 @@ function barStrip(cells) {
 }
 
 export function buildHistory(eventsText, metaText) {
-  const events = parseEvents(eventsText);
+  const { events, recordCount } = parseEventLog(eventsText);
   const meta = JSON.parse(metaText);
   if (
     "events_count" in meta &&
     (!Number.isInteger(meta.events_count) ||
       meta.events_count < 0 ||
-      meta.events_count !== events.length)
+      meta.events_count !== recordCount)
   ) {
     throw new TypeError("Mismatched event-log revision");
   }

--- a/public/status.mjs
+++ b/public/status.mjs
@@ -103,11 +103,9 @@ function statusMark(status) {
 }
 
 export function uptimeDescription(measured, days) {
-  return (
-    `${measured.uptime}% uptime over the last ${days} ` +
-    `${days === 1 ? "day" : "days"}` +
-    (measured.coverage < 100 ? `, ${measured.coverage}% monitored` : "")
-  );
+  return `${measured.uptime}% uptime over the last ${days} ${
+    days === 1 ? "day" : "days"
+  }`;
 }
 
 function renderGroup(list, entries, bars, uptime, emptyCells) {

--- a/public/status.mjs
+++ b/public/status.mjs
@@ -7,6 +7,7 @@ import {
 } from "./status-log.mjs";
 
 const PUBLIC_STATUSES = new Set(["operational", "degraded", "down"]);
+const PUBLIC_GROUPS = new Set(["endpoint", "tool"]);
 const STALE_AFTER_MS = 20 * 60 * 1000;
 const FETCH_TIMEOUT_MS = 10 * 1000;
 const REFRESH_INTERVAL_MS = 5 * 60 * 1000;
@@ -18,10 +19,15 @@ function isStatusEntry(entry) {
   );
 }
 
-// An unrecognized state is never treated as healthy. The publisher ships from a
-// separate repo on its own deploy, so the day it adds a fourth state this page
-// must keep working — showing that one row as unknown, not blacking out the
-// other sixteen that are fine.
+function hasUtcOffset(timestamp) {
+  return (
+    typeof timestamp === "string" &&
+    /(?:Z|[+-]\d{2}:?\d{2})$/.test(timestamp) &&
+    Number.isFinite(Date.parse(timestamp))
+  );
+}
+
+// Preserve the rest of the page when a separately deployed publisher adds a state.
 function normalizeEntry(entry) {
   return PUBLIC_STATUSES.has(entry.status)
     ? entry
@@ -31,21 +37,21 @@ function normalizeEntry(entry) {
 export function validateStatusData(data) {
   if (
     !data ||
-    typeof data.generated_at !== "string" ||
-    !Number.isFinite(Date.parse(data.generated_at)) ||
+    !hasUtcOffset(data.generated_at) ||
     !Array.isArray(data.datasets) ||
     !Array.isArray(data.endpoints)
   ) {
     throw new TypeError("Invalid status document");
   }
-  // A contentless-but-well-formed document must not read as "all clear". If the
-  // publisher's enumeration comes back empty during an outage, that is the one
-  // direction this page must never fail in.
-  if (data.datasets.length === 0 || data.endpoints.length === 0) {
+  // A contentless document must not read as "all clear".
+  if (data.endpoints.length === 0) {
     throw new TypeError("Invalid status document: no components");
   }
   if (![...data.datasets, ...data.endpoints].every(isStatusEntry)) {
     throw new TypeError("Invalid status entry");
+  }
+  if (!data.endpoints.every((entry) => PUBLIC_GROUPS.has(entry.group))) {
+    throw new TypeError("Invalid status entry group");
   }
   return {
     ...data,
@@ -60,12 +66,10 @@ export function isStatusDataStale(generatedAt, now = new Date()) {
 }
 
 export function summarizeOverallStatus(data) {
-  const incidents = [...data.datasets, ...data.endpoints]
+  const incidents = data.endpoints
     .filter((entry) => entry.status !== "operational")
     .map(({ name, status }) => ({ name, status }));
   const statuses = new Set(incidents.map(({ status }) => status));
-  // "unknown" counts as not-operational so the headline can never claim all
-  // clear while a component's state is unreadable.
   const status = statuses.has("down")
     ? "down"
     : statuses.has("degraded") || statuses.has("unknown")
@@ -120,17 +124,13 @@ function renderGroup(list, entries, bars, uptime) {
 
     const cells = bars?.get(entry.id);
     const measured = uptime?.get(entry.id);
-    // The figure and the strip describe the same window by construction: the day
-    // count comes from the cells the strip renders, not from a separate field
-    // that could drift out of step with them.
     if (cells?.length && measured) {
       const days = cells.length;
       const detail = document.createElement("p");
       detail.textContent =
         `${measured.uptime}% uptime over the last ${days} ` +
         `${days === 1 ? "day" : "days"}` +
-        // Only when it is not the whole window: a percentage over monitored time
-        // otherwise shrinks its own denominator without saying so.
+        // State a reduced denominator only when coverage is incomplete.
         (measured.coverage < 100 ? `, ${measured.coverage}% monitored` : "");
       item.append(detail);
     }
@@ -139,38 +139,32 @@ function renderGroup(list, entries, bars, uptime) {
   }
 }
 
-// A flex row of one cell per UTC day. Labelled from cells.length rather than a
-// hardcoded 90 so the claim grows with the evidence: a strip captioned "90 days"
-// that is mostly empty reads as broken rather than as young.
-function barStrip(cells) {
-  const strip = document.createElement("div");
-  strip.className = "status-bars";
+export function barDescription(cells) {
   const down = cells.filter((cell) => cell.state === "down").length;
-  const uncovered = cells.filter((cell) => cell.state !== "operational").length - down;
+  const unknown = cells.filter((cell) => cell.state === "unknown").length;
+  const uncovered = cells.filter((cell) => cell.state === "nodata").length;
   const days = cells.length;
   const plural = (n) => (n === 1 ? "day" : "days");
-  // role="img" is required, not decorative: ARIA forbids naming a role-less
-  // element, and a nameless generic is exactly what some screen readers drop —
-  // which would leave this strip announcing nothing, since every cell is
-  // aria-hidden and the per-cell title is pointer-only.
-  strip.setAttribute("role", "img");
-  // The label has to carry coverage as well as outages. A sighted reader sees the
-  // grey cells; describing only outages would tell a screen reader the record is
-  // clean while four days of it are missing.
   const parts = [
     down === 0
       ? `No outages recorded in the last ${days} ${plural(days)}`
       : `${down} of the last ${days} ${plural(days)} had an outage`,
   ];
-  if (uncovered > 0) {
-    parts.push(`${uncovered} ${plural(uncovered)} not monitored`);
-  }
-  strip.setAttribute("aria-label", parts.join("; "));
+  if (unknown > 0) parts.push(`${unknown} ${plural(unknown)} had an unknown state`);
+  if (uncovered > 0) parts.push(`${uncovered} ${plural(uncovered)} not monitored`);
+  return parts.join("; ");
+}
+
+function barStrip(cells) {
+  const strip = document.createElement("div");
+  strip.className = "status-bars";
+  const days = cells.length;
+  strip.setAttribute("role", "img");
+  strip.setAttribute("aria-label", barDescription(cells));
   for (const cell of cells) {
     const day = document.createElement("span");
     day.dataset.day = cell.state;
-    // The bars are decorative in aggregate; the aria-label above carries the
-    // meaning, so individual cells stay out of the accessibility tree.
+    // The aggregate label carries the meaning; cells are decorative.
     day.setAttribute("aria-hidden", "true");
     day.title = `${cell.date}: ${cell.state === "nodata" ? "not monitored" : cell.state}`;
     strip.append(day);
@@ -186,10 +180,37 @@ function barStrip(cells) {
   return wrapper;
 }
 
-// The log is optional. It ships from a separate repo and did not exist when this
-// page first deployed, so a missing or malformed log costs the bars and nothing
-// else — current status comes from the snapshot either way.
-async function loadBars(root) {
+export function buildHistory(eventsText, metaText) {
+  const events = parseEvents(eventsText);
+  const meta = JSON.parse(metaText);
+  if (
+    !Number.isInteger(meta.events_count) ||
+    meta.events_count < 0 ||
+    meta.events_count !== events.length
+  ) {
+    throw new TypeError("Mismatched event-log revision");
+  }
+  const asOf = effectiveAsOf(meta.reconciled_at, events);
+  if (!asOf) throw new TypeError("Invalid status history metadata");
+  const spans = componentSpans(events, { asOf });
+  return {
+    asOf,
+    cells: dailyBars(spans, { asOf, days: BAR_DAYS }),
+    uptime: uptimeSummary(spans, { asOf, days: BAR_DAYS }),
+  };
+}
+
+export function isHistoryCurrent(asOf, generatedAt) {
+  const snapshot = Date.parse(generatedAt);
+  return (
+    asOf instanceof Date &&
+    Number.isFinite(asOf.getTime()) &&
+    Number.isFinite(snapshot) &&
+    Math.abs(snapshot - asOf.getTime()) <= STALE_AFTER_MS
+  );
+}
+
+async function loadHistory(root) {
   const base = root.dataset.logUrl;
   if (!base) return null;
   try {
@@ -203,21 +224,14 @@ async function loadBars(root) {
         return response.text();
       }),
     );
-    const parsed = parseEvents(events);
-    const asOf = effectiveAsOf(JSON.parse(meta).reconciled_at, parsed);
-    if (!asOf) return null;
-    const spans = componentSpans(parsed, { asOf });
-    return {
-      cells: dailyBars(spans, { asOf, days: BAR_DAYS }),
-      uptime: uptimeSummary(spans, { asOf, days: BAR_DAYS }),
-    };
+    return buildHistory(events, meta);
   } catch (error) {
     console.warn("Status history unavailable; rendering without bars", error);
     return null;
   }
 }
 
-function renderStatus(root, data, bars) {
+function renderStatus(root, data, loadedHistory) {
   const overall = summarizeOverallStatus(data);
   const overallPanel = root.querySelector("#status-overall");
   const heading = root.querySelector("#status-overall-heading");
@@ -225,6 +239,7 @@ function renderStatus(root, data, bars) {
   const incidents = root.querySelector("#status-incidents");
   const asOf = root.querySelector("#status-as-of");
   const stale = root.querySelector("#status-stale");
+  const historyNotice = root.querySelector("#status-history");
   const groups = root.querySelector("#status-groups");
 
   overallPanel.className = `status-overall status-${overall.status}`;
@@ -235,7 +250,7 @@ function renderStatus(root, data, bars) {
   }[overall.status];
   summary.textContent =
     overall.status === "operational"
-      ? "All monitored datasets and public endpoints are reporting normally."
+      ? "All monitored public endpoints and tools are reporting normally."
       : "The affected components are listed below.";
 
   incidents.replaceChildren();
@@ -253,20 +268,26 @@ function renderStatus(root, data, bars) {
   asOfLabel.append("As of ", generatedTime);
   asOf.replaceChildren(asOfLabel);
 
-  // Write the text rather than only un-hiding it: screen readers announce a
-  // live region on content change, and handling of "already-populated region
-  // becomes visible" is inconsistent across NVDA/JAWS/VoiceOver.
   setStale(
     stale,
     isStatusDataStale(data.generated_at)
       ? "The publisher has not refreshed this page in more than 20 minutes."
       : null,
   );
+  const history =
+    loadedHistory && isHistoryCurrent(loadedHistory.asOf, data.generated_at)
+      ? loadedHistory
+      : null;
+  setHistoryNotice(
+    historyNotice,
+    history
+      ? null
+      : loadedHistory
+        ? "Uptime history is stale and has been hidden."
+        : "Uptime history is temporarily unavailable.",
+  );
   groups.hidden = false;
-  // Datasets are published in the feed but deliberately not rendered yet: this
-  // page mirrors the sections the retiring uptime.dynamical.org carried, and
-  // per-dataset health was never on it. Re-adding the section later is a page
-  // change only, since the feed already carries them.
+  // Datasets remain in the feed for a later page-side section.
   for (const [selector, group] of [
     ["#status-endpoints", "endpoint"],
     ["#status-tools", "tool"],
@@ -274,10 +295,15 @@ function renderStatus(root, data, bars) {
     renderGroup(
       root.querySelector(selector),
       data.endpoints.filter((entry) => entry.group === group),
-      bars?.cells,
-      bars?.uptime,
+      history?.cells,
+      history?.uptime,
     );
   }
+}
+
+function setHistoryNotice(element, message) {
+  element.hidden = message === null;
+  element.textContent = message ?? "";
 }
 
 function setStale(stale, message) {
@@ -298,6 +324,7 @@ function renderUnavailable(root) {
     "The status feed could not be loaded. Try again shortly.";
   root.querySelector("#status-incidents").hidden = true;
   setStale(root.querySelector("#status-stale"), null);
+  setHistoryNotice(root.querySelector("#status-history"), null);
   root.querySelector("#status-groups").hidden = true;
   const asOfLabel = document.createElement("strong");
   asOfLabel.textContent = "As of —";
@@ -305,23 +332,18 @@ function renderUnavailable(root) {
 }
 
 async function loadStatus(root) {
-  const bars = loadBars(root);
+  const history = loadHistory(root);
   try {
     const response = await fetch(root.dataset.statusUrl, {
       cache: "no-store",
       headers: { Accept: "application/json" },
-      // Without a deadline a hung CDN connection leaves the page stuck on
-      // "Checking current status…" forever instead of the unavailable state.
       signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
     });
     if (!response.ok) {
       throw new Error(`Status request failed: ${response.status}`);
     }
-    // Started before the snapshot is awaited, so a slow log costs only the bars.
-    // Awaiting it inside renderStatus's argument list made a hung log hold the
-    // whole page on "Checking current status…" for the full fetch deadline.
     const data = validateStatusData(await response.json());
-    renderStatus(root, data, await bars);
+    renderStatus(root, data, await history);
   } catch (error) {
     console.error("Unable to load public status", error);
     renderUnavailable(root);
@@ -332,9 +354,6 @@ if (typeof document !== "undefined") {
   const root = document.querySelector("[data-status-page]");
   if (root) {
     loadStatus(root);
-    // Matches the publisher's cadence and the feed's max-age, so a tab left
-    // open on a wall display keeps current instead of showing one frozen
-    // timestamp forever — which would also stop the stale banner ever firing.
     setInterval(() => loadStatus(root), REFRESH_INTERVAL_MS);
   }
 }

--- a/public/status.mjs
+++ b/public/status.mjs
@@ -2,6 +2,7 @@ import {
   componentSpans,
   dailyBars,
   effectiveAsOf,
+  incidentLog,
   parseEvents,
   uptimeSummary,
 } from "./status-log.mjs";
@@ -12,6 +13,7 @@ const STALE_AFTER_MS = 20 * 60 * 1000;
 const FETCH_TIMEOUT_MS = 10 * 1000;
 const REFRESH_INTERVAL_MS = 5 * 60 * 1000;
 const BAR_DAYS = 90;
+export const STALE_MESSAGE = "Stale: status page experiencing delayed updates";
 
 function isStatusEntry(entry) {
   return (
@@ -98,6 +100,20 @@ function formatTimestamp(timestamp) {
   }).format(new Date(timestamp));
 }
 
+function formatDuration(start, end) {
+  const minutes = Math.floor((end - start) / 60_000);
+  if (minutes < 1) return "less than a minute";
+  if (minutes < 60) return `${minutes} minute${minutes === 1 ? "" : "s"}`;
+  const hours = Math.floor(minutes / 60);
+  const remainder = minutes % 60;
+  if (hours < 24) {
+    return `${hours}h${remainder ? ` ${remainder}m` : ""}`;
+  }
+  const days = Math.floor(hours / 24);
+  const remainingHours = hours % 24;
+  return `${days}d${remainingHours ? ` ${remainingHours}h` : ""}`;
+}
+
 function statusMark(status) {
   return { operational: "●", degraded: "▲", down: "×", unknown: "?" }[status];
 }
@@ -160,14 +176,22 @@ function barStrip(cells) {
   const strip = document.createElement("div");
   strip.className = "status-bars";
   const days = cells.length;
-  strip.setAttribute("role", "img");
+  strip.setAttribute("role", "group");
   strip.setAttribute("aria-label", barDescription(cells));
   for (const cell of cells) {
-    const day = document.createElement("span");
+    const incident = cell.incidentIds?.[0];
+    const day = document.createElement(incident ? "a" : "span");
     day.dataset.day = cell.state;
-    // The aggregate label carries the meaning; cells are decorative.
-    day.setAttribute("aria-hidden", "true");
     day.title = `${cell.date}: ${cell.state === "nodata" ? "not monitored" : cell.state}`;
+    if (incident) {
+      day.href = `#${incident}`;
+      day.setAttribute(
+        "aria-label",
+        `${cell.date}: outage; view incident details`,
+      );
+    } else {
+      day.setAttribute("aria-hidden", "true");
+    }
     strip.append(day);
   }
   const scale = document.createElement("p");
@@ -198,6 +222,7 @@ export function buildHistory(eventsText, metaText) {
   return {
     asOf,
     cells: dailyBars(spans, { asOf, days: BAR_DAYS }),
+    incidents: incidentLog(events),
     uptime: uptimeSummary(spans, { asOf, days: BAR_DAYS }),
   };
 }
@@ -240,7 +265,6 @@ function renderStatus(root, data, loadedHistory) {
   const summary = root.querySelector("#status-summary");
   const incidents = root.querySelector("#status-incidents");
   const asOf = root.querySelector("#status-as-of");
-  const stale = root.querySelector("#status-stale");
   const historyNotice = root.querySelector("#status-history");
   const groups = root.querySelector("#status-groups");
 
@@ -263,19 +287,28 @@ function renderStatus(root, data, loadedHistory) {
     incidents.append(item);
   }
 
-  const generatedTime = document.createElement("time");
-  generatedTime.dateTime = data.generated_at;
-  generatedTime.textContent = formatTimestamp(data.generated_at);
-  const asOfLabel = document.createElement("strong");
-  asOfLabel.append("As of ", generatedTime);
-  asOf.replaceChildren(asOfLabel);
-
-  setStale(
-    stale,
-    isStatusDataStale(data.generated_at)
-      ? "The publisher has not refreshed this page in more than 20 minutes."
-      : null,
-  );
+  const stale = isStatusDataStale(data.generated_at);
+  asOf.classList.toggle("status-stale", stale);
+  if (stale) {
+    const icon = document.createElement("span");
+    icon.setAttribute("aria-hidden", "true");
+    icon.textContent = "⚠";
+    const label = document.createElement("strong");
+    label.textContent = "Stale:";
+    asOf.replaceChildren(
+      icon,
+      " ",
+      label,
+      STALE_MESSAGE.slice("Stale:".length),
+    );
+  } else {
+    const generatedTime = document.createElement("time");
+    generatedTime.dateTime = data.generated_at;
+    generatedTime.textContent = formatTimestamp(data.generated_at);
+    const asOfLabel = document.createElement("strong");
+    asOfLabel.append("As of ", generatedTime);
+    asOf.replaceChildren(asOfLabel);
+  }
   const history =
     loadedHistory && isHistoryCurrent(loadedHistory.asOf, data.generated_at)
       ? loadedHistory
@@ -306,6 +339,7 @@ function renderStatus(root, data, loadedHistory) {
       emptyCells,
     );
   }
+  renderIncidentLog(root, history, data);
 }
 
 function setHistoryNotice(element, message) {
@@ -313,13 +347,56 @@ function setHistoryNotice(element, message) {
   element.textContent = message ?? "";
 }
 
-function setStale(stale, message) {
-  stale.replaceChildren();
-  stale.hidden = message === null;
-  if (message === null) return;
-  const label = document.createElement("strong");
-  label.textContent = "Status data is stale.";
-  stale.append(label, ` ${message}`);
+function renderIncidentLog(root, history, data) {
+  const list = root.querySelector("#status-incident-log");
+  const empty = root.querySelector("#status-incident-empty");
+  list.replaceChildren();
+  if (!history) {
+    empty.textContent = "Incident history is temporarily unavailable.";
+    empty.hidden = false;
+    return;
+  }
+
+  const names = new Map(data.endpoints.map(({ id, name }) => [id, name]));
+  const visible = history.incidents
+    .filter((incident) => names.has(incident.component))
+    .reverse();
+  empty.textContent = "No incidents recorded.";
+  empty.hidden = visible.length > 0;
+
+  for (const incident of visible) {
+    const item = document.createElement("li");
+    const header = document.createElement("header");
+    const name = document.createElement("h3");
+    const state = document.createElement("strong");
+    const timing = document.createElement("p");
+    const end = incident.end ?? history.asOf.getTime();
+
+    item.id = incident.id;
+    item.className = "status-incident";
+    name.textContent = names.get(incident.component);
+    state.textContent =
+      incident.ending === "resolved"
+        ? "Resolved"
+        : incident.ending === "observation-ended"
+          ? "Observation ended"
+          : "Ongoing";
+    timing.textContent =
+      incident.ending === "observation-ended"
+        ? `${formatTimestamp(incident.start)} – ${formatTimestamp(incident.end)} · ${formatDuration(incident.start, end)}. Recovery was not witnessed.`
+        : `${formatTimestamp(incident.start)} – ${
+            incident.end ? formatTimestamp(incident.end) : "ongoing"
+          } · ${formatDuration(incident.start, end)}.`;
+    header.append(name, state);
+    item.append(header, timing);
+    list.append(item);
+  }
+  if (typeof location !== "undefined" && location.hash) {
+    const target = document.getElementById(
+      decodeURIComponent(location.hash.slice(1)),
+    );
+    if (target) requestAnimationFrame(() => target.scrollIntoView());
+  }
 }
 
 function renderUnavailable(root) {
@@ -330,12 +407,14 @@ function renderUnavailable(root) {
   root.querySelector("#status-summary").textContent =
     "The status feed could not be loaded. Try again shortly.";
   root.querySelector("#status-incidents").hidden = true;
-  setStale(root.querySelector("#status-stale"), null);
   setHistoryNotice(root.querySelector("#status-history"), null);
   root.querySelector("#status-groups").hidden = true;
+  renderIncidentLog(root, null, { endpoints: [] });
   const asOfLabel = document.createElement("strong");
   asOfLabel.textContent = "As of —";
-  root.querySelector("#status-as-of").replaceChildren(asOfLabel);
+  const asOf = root.querySelector("#status-as-of");
+  asOf.classList.remove("status-stale");
+  asOf.replaceChildren(asOfLabel);
 }
 
 async function loadStatus(root) {

--- a/public/status.mjs
+++ b/public/status.mjs
@@ -102,7 +102,15 @@ function statusMark(status) {
   return { operational: "●", degraded: "▲", down: "×", unknown: "?" }[status];
 }
 
-function renderGroup(list, entries, bars, uptime) {
+export function uptimeDescription(measured, days) {
+  return (
+    `${measured.uptime}% uptime over the last ${days} ` +
+    `${days === 1 ? "day" : "days"}` +
+    (measured.coverage < 100 ? `, ${measured.coverage}% monitored` : "")
+  );
+}
+
+function renderGroup(list, entries, bars, uptime, emptyCells) {
   list.replaceChildren();
   for (const entry of entries) {
     const item = document.createElement("li");
@@ -122,16 +130,11 @@ function renderGroup(list, entries, bars, uptime) {
     header.append(name, state);
     item.append(header);
 
-    const cells = bars?.get(entry.id);
+    const cells = bars?.get(entry.id) ?? emptyCells;
     const measured = uptime?.get(entry.id);
     if (cells?.length && measured) {
-      const days = cells.length;
       const detail = document.createElement("p");
-      detail.textContent =
-        `${measured.uptime}% uptime over the last ${days} ` +
-        `${days === 1 ? "day" : "days"}` +
-        // State a reduced denominator only when coverage is incomplete.
-        (measured.coverage < 100 ? `, ${measured.coverage}% monitored` : "");
+      detail.textContent = uptimeDescription(measured, cells.length);
       item.append(detail);
     }
     if (cells?.length) item.append(barStrip(cells));
@@ -184,9 +187,10 @@ export function buildHistory(eventsText, metaText) {
   const events = parseEvents(eventsText);
   const meta = JSON.parse(metaText);
   if (
-    !Number.isInteger(meta.events_count) ||
-    meta.events_count < 0 ||
-    meta.events_count !== events.length
+    "events_count" in meta &&
+    (!Number.isInteger(meta.events_count) ||
+      meta.events_count < 0 ||
+      meta.events_count !== events.length)
   ) {
     throw new TypeError("Mismatched event-log revision");
   }
@@ -278,6 +282,10 @@ function renderStatus(root, data, loadedHistory) {
     loadedHistory && isHistoryCurrent(loadedHistory.asOf, data.generated_at)
       ? loadedHistory
       : null;
+  const emptyCells = dailyBars(new Map([["", []]]), {
+    asOf: history?.asOf ?? new Date(data.generated_at),
+    days: BAR_DAYS,
+  }).get("");
   setHistoryNotice(
     historyNotice,
     history
@@ -297,6 +305,7 @@ function renderStatus(root, data, loadedHistory) {
       data.endpoints.filter((entry) => entry.group === group),
       history?.cells,
       history?.uptime,
+      emptyCells,
     );
   }
 }

--- a/test/fixtures/status.json
+++ b/test/fixtures/status.json
@@ -87,7 +87,7 @@
   "endpoints": [
     {
       "id": "dynamical-org",
-      "name": "dynamical.org",
+      "name": "dynamical.org website",
       "group": "endpoint",
       "status": "operational"
     },
@@ -111,7 +111,7 @@
     },
     {
       "id": "scorecard",
-      "name": "Scorecard",
+      "name": "scorecard",
       "group": "tool",
       "status": "operational"
     }

--- a/test/status-log.test.mjs
+++ b/test/status-log.test.mjs
@@ -5,6 +5,7 @@ import {
   componentSpans,
   dailyBars,
   effectiveAsOf,
+  incidentLog,
   parseEvents,
   uptimeSummary,
 } from "../public/status-log.mjs";
@@ -147,6 +148,44 @@ test("events after the as-of are clamped rather than extending the window", () =
   assert.equal(spans.get(C).at(-1).end, AS_OF.getTime());
 });
 
+test("incidents distinguish resolution from observation ending", () => {
+  const events = parseEvents(
+    jsonl(
+      coverage("2026-07-24T00:00:00Z", C, true, "operational"),
+      transition("2026-07-24T01:00:00Z", C, "down"),
+      transition("2026-07-24T02:00:00Z", C, "operational"),
+      transition("2026-07-24T03:00:00Z", C, "down"),
+      coverage("2026-07-24T04:00:00Z", C, false),
+      coverage("2026-07-24T05:00:00Z", C, true, "down"),
+    ),
+  );
+
+  assert.deepEqual(
+    incidentLog(events).map(({ start, end, ending }) => ({
+      start,
+      end,
+      ending,
+    })),
+    [
+      {
+        start: Date.parse("2026-07-24T01:00:00Z"),
+        end: Date.parse("2026-07-24T02:00:00Z"),
+        ending: "resolved",
+      },
+      {
+        start: Date.parse("2026-07-24T03:00:00Z"),
+        end: Date.parse("2026-07-24T04:00:00Z"),
+        ending: "observation-ended",
+      },
+      {
+        start: Date.parse("2026-07-24T05:00:00Z"),
+        end: null,
+        ending: null,
+      },
+    ],
+  );
+});
+
 // --- bars -----------------------------------------------------------------
 
 test("bars always cover the full rolling window", () => {
@@ -189,6 +228,12 @@ test("a day with any down interval renders down", () => {
 
   assert.equal(byDate.get("2026-07-23"), "operational");
   assert.equal(byDate.get("2026-07-24"), "down");
+  assert.deepEqual(
+    dailyBars(spans, { asOf: AS_OF, days: 90 })
+      .get(C)
+      .find((cell) => cell.date === "2026-07-24").incidentIds,
+    [`incident-${C}-${Date.parse("2026-07-24T10:00:00Z") / 1000}`],
+  );
 });
 
 test("a partly observed day is filled while coverage records the gap", () => {

--- a/test/status-log.test.mjs
+++ b/test/status-log.test.mjs
@@ -149,16 +149,29 @@ test("events after the as-of are clamped rather than extending the window", () =
 
 // --- bars -----------------------------------------------------------------
 
-test("bars start at first coverage, not at the window edge", () => {
-  // A 90-cell strip that is 80 cells empty reads as broken rather than as young.
+test("bars always cover the full rolling window", () => {
   const spans = spansOf(coverage("2026-07-23T00:00:00Z", C, true, "operational"));
 
   const cells = dailyBars(spans, { asOf: AS_OF, days: 90 }).get(C);
 
-  assert.deepEqual(
-    cells.map((c) => c.date),
-    ["2026-07-23", "2026-07-24", "2026-07-25"],
-  );
+  assert.equal(cells.length, 90);
+  assert.equal(cells[0].date, "2026-04-27");
+  assert.equal(cells[0].state, "nodata");
+  assert.deepEqual(cells.slice(-3).map((cell) => cell.state), [
+    "operational",
+    "operational",
+    "operational",
+  ]);
+});
+
+test("an entirely unobserved component gets 90 blank bars", () => {
+  const cells = dailyBars(new Map([[C, []]]), {
+    asOf: AS_OF,
+    days: 90,
+  }).get(C);
+
+  assert.equal(cells.length, 90);
+  assert.ok(cells.every((cell) => cell.state === "nodata"));
 });
 
 test("a day with any down interval renders down", () => {
@@ -178,7 +191,7 @@ test("a day with any down interval renders down", () => {
   assert.equal(byDate.get("2026-07-24"), "down");
 });
 
-test("a partly uncovered day renders no data rather than operational", () => {
+test("a partly observed day is filled while coverage records the gap", () => {
   const spans = spansOf(
     coverage("2026-07-23T00:00:00Z", C, true, "operational"),
     coverage("2026-07-24T06:00:00Z", C, false),
@@ -189,7 +202,7 @@ test("a partly uncovered day renders no data rather than operational", () => {
     dailyBars(spans, { asOf: AS_OF, days: 90 }).get(C).map((c) => [c.date, c.state]),
   );
 
-  assert.equal(byDate.get("2026-07-24"), "nodata");
+  assert.equal(byDate.get("2026-07-24"), "operational");
 });
 
 test("an unknown state outranks no data rather than hiding behind it", () => {
@@ -205,12 +218,12 @@ test("an unknown state outranks no data rather than hiding behind it", () => {
   assert.equal(byDate.get("2026-07-24"), "unknown");
 });
 
-test("the first day is clipped to first coverage, not judged against midnight", () => {
-  // Otherwise every strip opens on a permanent grey cell purely because
-  // monitoring began part-way through a day.
+test("partial first coverage day is filled from observed status", () => {
   const spans = spansOf(coverage("2026-07-24T09:00:00Z", C, true, "operational"));
+  const cells = dailyBars(spans, { asOf: AS_OF, days: 90 }).get(C);
 
-  assert.deepEqual(dailyBars(spans, { asOf: AS_OF, days: 90 }).get(C), [
+  assert.equal(cells.length, 90);
+  assert.deepEqual(cells.slice(-2), [
     { date: "2026-07-24", state: "operational" },
     { date: "2026-07-25", state: "operational" },
   ]);
@@ -223,7 +236,12 @@ test("today is judged against the as-of, not against midnight", () => {
 
   const cells = dailyBars(spans, { asOf: AS_OF, days: 90 }).get(C);
 
-  assert.deepEqual(cells, [{ date: "2026-07-25", state: "operational" }]);
+  assert.equal(cells.length, 90);
+  assert.equal(cells.at(-2).state, "nodata");
+  assert.deepEqual(cells.at(-1), {
+    date: "2026-07-25",
+    state: "operational",
+  });
 });
 
 test("the window caps at the requested number of days", () => {
@@ -249,9 +267,9 @@ test("uptime is derived from the log, so it cannot contradict the bars", () => {
   }).get(C);
   const cells = dailyBars(spans, { asOf: AS_OF, days: 90 }).get(C);
 
-  // One day down out of ten and a half observed.
+  // One day down out of ten and a half observed within the 90-day window.
   assert.ok(uptime > 90 && uptime < 91, `unexpected uptime ${uptime}`);
-  assert.equal(covered, 100);
+  assert.ok(covered > 11 && covered < 12, `unexpected coverage ${covered}`);
   assert.equal(cells.filter((cell) => cell.state === "down").length, 1);
 });
 
@@ -294,7 +312,7 @@ test("a coverage gap lowers coverage rather than uptime", () => {
   }).get(C);
 
   assert.equal(uptime, 100);
-  assert.ok(covered > 50 && covered < 60, `unexpected coverage ${covered}`);
+  assert.ok(covered > 6 && covered < 7, `unexpected coverage ${covered}`);
 });
 
 test("an unknown state is excluded from the denominator, not counted either way", () => {

--- a/test/status-log.test.mjs
+++ b/test/status-log.test.mjs
@@ -255,6 +255,21 @@ test("uptime is derived from the log, so it cannot contradict the bars", () => {
   assert.equal(cells.filter((cell) => cell.state === "down").length, 1);
 });
 
+test("uptime excludes time before the first displayed UTC day", () => {
+  const spans = spansOf(
+    coverage("2026-01-01T00:00:00Z", C, true, "operational"),
+    transition("2026-04-26T18:00:00Z", C, "down"),
+    transition("2026-04-27T00:00:00Z", C, "operational"),
+  );
+
+  const cells = dailyBars(spans, { asOf: AS_OF, days: 90 }).get(C);
+  const summary = uptimeSummary(spans, { asOf: AS_OF, days: 90 }).get(C);
+
+  assert.equal(cells[0].date, "2026-04-27");
+  assert.equal(cells.filter((cell) => cell.state === "down").length, 0);
+  assert.equal(summary.uptime, 100);
+});
+
 test("confirmed downtime never presents as a flat 100%", () => {
   const spans = spansOf(
     coverage("2026-01-01T00:00:00Z", C, true, "operational"),

--- a/test/status-log.test.mjs
+++ b/test/status-log.test.mjs
@@ -34,12 +34,10 @@ const spansOf = (...events) =>
 // --- parsing --------------------------------------------------------------
 
 test("skips unknown event kinds instead of failing", () => {
-  // Additive annotative kinds are meant to be safe for an old client; a semantic
-  // addition is supposed to bump `v` instead.
   const events = parseEvents(
     jsonl(
       coverage("2026-07-20T00:00:00Z", C, true, "operational"),
-      { ts: "2026-07-21T00:00:00Z", kind: "annotation", component: C, note: "hi" },
+      { ts: "2026-07-21T00:00:00Z", kind: "future-metadata", component: C },
       transition("2026-07-22T00:00:00Z", C, "down"),
     ),
   );

--- a/test/status.test.mjs
+++ b/test/status.test.mjs
@@ -3,6 +3,9 @@ import { readFileSync } from "node:fs";
 import test from "node:test";
 
 import {
+  barDescription,
+  buildHistory,
+  isHistoryCurrent,
   isStatusDataStale,
   summarizeOverallStatus,
   validateStatusData,
@@ -26,6 +29,7 @@ const operationalData = {
     {
       id: "dynamical-org",
       name: "dynamical.org",
+      group: "endpoint",
       status: "operational",
       uptime: 99.9,
       uptime_since: "2026-04-26T19:55:00Z",
@@ -53,11 +57,7 @@ test("accepts the published feed shape", () => {
   );
   assert.deepEqual(summarizeOverallStatus(fixture), {
     status: "down",
-    incidents: [
-      { name: "NOAA HRRR forecast, 48 hour", status: "degraded" },
-      { name: "ECMWF IFS ENS forecast, 15 day, 0.25 degree", status: "down" },
-      { name: "Data product reads", status: "down" },
-    ],
+    incidents: [{ name: "Data product reads", status: "down" }],
   });
 });
 
@@ -68,17 +68,14 @@ test("summarizes an operational feed", () => {
   });
 });
 
-test("lists degraded and down components with the worst overall state", () => {
+test("summarizes only the components this page renders", () => {
   const data = structuredClone(operationalData);
   data.datasets[0].status = "degraded";
   data.endpoints[0].status = "down";
 
   assert.deepEqual(summarizeOverallStatus(data), {
     status: "down",
-    incidents: [
-      { name: "NOAA GFS forecast", status: "degraded" },
-      { name: "dynamical.org", status: "down" },
-    ],
+    incidents: [{ name: "dynamical.org", status: "down" }],
   });
 });
 
@@ -105,6 +102,14 @@ test("rejects a malformed envelope", () => {
     () => validateStatusData({ ...operationalData, datasets: [{ id: 1 }] }),
     /invalid status entry/i,
   );
+  assert.throws(
+    () =>
+      validateStatusData({
+        ...operationalData,
+        generated_at: "2026-07-24T19:55:00",
+      }),
+    /invalid status document/i,
+  );
 });
 
 test("refuses a contentless document instead of reporting all clear", () => {
@@ -120,21 +125,61 @@ test("refuses a contentless document instead of reporting all clear", () => {
   );
 });
 
-test("keeps rendering when the publisher adds an unrecognized state", () => {
+test("keeps rendering when a visible component has an unrecognized state", () => {
   // The publisher deploys from a separate repo; a fourth state must degrade one
   // row to Unknown, not black out the whole page.
   const data = structuredClone(operationalData);
-  data.datasets.push({
-    id: "nasa-smap-level3-36km-v9",
-    name: "NASA SMAP Level 3, 36 km, v9",
+  data.endpoints.push({
+    id: "future-tool",
+    name: "Future tool",
+    group: "tool",
     status: "maintenance",
   });
 
   const validated = validateStatusData(data);
 
-  assert.equal(validated.datasets[1].status, "unknown");
+  assert.equal(validated.endpoints[1].status, "unknown");
   assert.deepEqual(summarizeOverallStatus(validated), {
     status: "degraded",
-    incidents: [{ name: "NASA SMAP Level 3, 36 km, v9", status: "unknown" }],
+    incidents: [{ name: "Future tool", status: "unknown" }],
   });
+});
+
+test("rejects a mismatched event-log revision", () => {
+  const events = `${JSON.stringify({
+    ts: "2026-07-24T19:00:00Z",
+    kind: "coverage",
+    component: "dynamical-org",
+    monitored: true,
+    state: "operational",
+  })}\n`;
+  const meta = JSON.stringify({
+    v: 1,
+    reconciled_at: "2026-07-24T20:00:00Z",
+    events_count: 2,
+  });
+
+  assert.throws(() => buildHistory(events, meta), /event-log revision/i);
+});
+
+test("history must be close to the current snapshot", () => {
+  assert.equal(
+    isHistoryCurrent(
+      new Date("2026-07-24T19:40:00Z"),
+      "2026-07-24T20:00:00Z",
+    ),
+    true,
+  );
+  assert.equal(
+    isHistoryCurrent(
+      new Date("2026-07-24T19:39:59.999Z"),
+      "2026-07-24T20:00:00Z",
+    ),
+    false,
+  );
+});
+
+test("bar descriptions distinguish unknown state from missing coverage", () => {
+  assert.match(barDescription([{ state: "unknown" }]), /unknown state/i);
+  assert.doesNotMatch(barDescription([{ state: "unknown" }]), /not monitored/i);
 });

--- a/test/status.test.mjs
+++ b/test/status.test.mjs
@@ -170,6 +170,54 @@ test("rejects a mismatched event-log revision", () => {
   assert.throws(() => buildHistory(events, meta), /event-log revision/i);
 });
 
+test("revision count includes additive records old clients skip", () => {
+  const events = [
+    {
+      ts: "2026-07-24T19:00:00Z",
+      kind: "coverage",
+      component: "dynamical-org",
+      monitored: true,
+      state: "operational",
+    },
+    {
+      ts: "2026-07-24T19:30:00Z",
+      kind: "future-metadata",
+      component: "dynamical-org",
+    },
+  ]
+    .map(JSON.stringify)
+    .join("\n");
+  const meta = JSON.stringify({
+    v: 1,
+    reconciled_at: "2026-07-24T20:00:00Z",
+    events_count: 2,
+  });
+
+  const history = buildHistory(events, meta);
+
+  assert.equal(history.incidents.length, 0);
+  assert.equal(history.uptime.has("dynamical-org"), true);
+  assert.equal(history.asOf.toISOString(), "2026-07-24T20:00:00.000Z");
+});
+
+test("revision metadata rejects a truncated record", () => {
+  const events =
+    `${JSON.stringify({
+      ts: "2026-07-24T19:00:00Z",
+      kind: "coverage",
+      component: "dynamical-org",
+      monitored: true,
+      state: "operational",
+    })}\n` + '{"ts":"2026-07-24T19:30:00Z","kind":"transi';
+  const meta = JSON.stringify({
+    v: 1,
+    reconciled_at: "2026-07-24T20:00:00Z",
+    events_count: 2,
+  });
+
+  assert.throws(() => buildHistory(events, meta), /event-log revision/i);
+});
+
 test("accepts legacy history metadata during publisher rollout", () => {
   const events = `${JSON.stringify({
     ts: "2026-07-24T19:00:00Z",

--- a/test/status.test.mjs
+++ b/test/status.test.mjs
@@ -125,6 +125,12 @@ test("refuses a contentless document instead of reporting all clear", () => {
   );
 });
 
+test("does not require the deferred dataset section", () => {
+  assert.doesNotThrow(() =>
+    validateStatusData({ ...operationalData, datasets: [] }),
+  );
+});
+
 test("keeps rendering when a visible component has an unrecognized state", () => {
   // The publisher deploys from a separate repo; a fourth state must degrade one
   // row to Unknown, not black out the whole page.
@@ -160,6 +166,14 @@ test("rejects a mismatched event-log revision", () => {
   });
 
   assert.throws(() => buildHistory(events, meta), /event-log revision/i);
+  assert.throws(
+    () =>
+      buildHistory(
+        events,
+        JSON.stringify({ v: 1, reconciled_at: "2026-07-24T20:00:00Z" }),
+      ),
+    /event-log revision/i,
+  );
 });
 
 test("history must be close to the current snapshot", () => {
@@ -173,6 +187,13 @@ test("history must be close to the current snapshot", () => {
   assert.equal(
     isHistoryCurrent(
       new Date("2026-07-24T19:39:59.999Z"),
+      "2026-07-24T20:00:00Z",
+    ),
+    false,
+  );
+  assert.equal(
+    isHistoryCurrent(
+      new Date("2026-07-24T20:20:00.001Z"),
       "2026-07-24T20:00:00Z",
     ),
     false,

--- a/test/status.test.mjs
+++ b/test/status.test.mjs
@@ -214,9 +214,9 @@ test("bar descriptions distinguish unknown state from missing coverage", () => {
   assert.doesNotMatch(barDescription([{ state: "unknown" }]), /not monitored/i);
 });
 
-test("uptime description states the fixed window and observed coverage", () => {
+test("uptime description states the fixed window without a coverage suffix", () => {
   assert.equal(
     uptimeDescription({ uptime: 100, coverage: 1.5 }, 90),
-    "100% uptime over the last 90 days, 1.5% monitored",
+    "100% uptime over the last 90 days",
   );
 });

--- a/test/status.test.mjs
+++ b/test/status.test.mjs
@@ -7,6 +7,7 @@ import {
   buildHistory,
   isHistoryCurrent,
   isStatusDataStale,
+  STALE_MESSAGE,
   summarizeOverallStatus,
   uptimeDescription,
   validateStatusData,
@@ -29,7 +30,7 @@ const operationalData = {
   endpoints: [
     {
       id: "dynamical-org",
-      name: "dynamical.org",
+      name: "dynamical.org website",
       group: "endpoint",
       status: "operational",
       uptime: 99.9,
@@ -76,7 +77,7 @@ test("summarizes only the components this page renders", () => {
 
   assert.deepEqual(summarizeOverallStatus(data), {
     status: "down",
-    incidents: [{ name: "dynamical.org", status: "down" }],
+    incidents: [{ name: "dynamical.org website", status: "down" }],
   });
 });
 
@@ -218,5 +219,22 @@ test("uptime description states the fixed window without a coverage suffix", () 
   assert.equal(
     uptimeDescription({ uptime: 100, coverage: 1.5 }, 90),
     "100% uptime over the last 90 days",
+  );
+});
+
+test("status page uses the requested heading and replaces stale as-of copy", () => {
+  const template = readFileSync(
+    new URL("../content/status.njk", import.meta.url),
+    "utf8",
+  );
+
+  assert.match(template, />dynamical\.org status</);
+  assert.doesNotMatch(
+    template,
+    /Current health of dynamical\.org public endpoints, tools, and resources\./,
+  );
+  assert.equal(
+    STALE_MESSAGE,
+    "Stale: status page experiencing delayed updates",
   );
 });

--- a/test/status.test.mjs
+++ b/test/status.test.mjs
@@ -8,6 +8,7 @@ import {
   isHistoryCurrent,
   isStatusDataStale,
   summarizeOverallStatus,
+  uptimeDescription,
   validateStatusData,
 } from "../public/status.mjs";
 
@@ -166,14 +167,22 @@ test("rejects a mismatched event-log revision", () => {
   });
 
   assert.throws(() => buildHistory(events, meta), /event-log revision/i);
-  assert.throws(
-    () =>
-      buildHistory(
-        events,
-        JSON.stringify({ v: 1, reconciled_at: "2026-07-24T20:00:00Z" }),
-      ),
-    /event-log revision/i,
+});
+
+test("accepts legacy history metadata during publisher rollout", () => {
+  const events = `${JSON.stringify({
+    ts: "2026-07-24T19:00:00Z",
+    kind: "coverage",
+    component: "dynamical-org",
+    monitored: true,
+    state: "operational",
+  })}\n`;
+  const history = buildHistory(
+    events,
+    JSON.stringify({ v: 1, reconciled_at: "2026-07-24T20:00:00Z" }),
   );
+
+  assert.equal(history.asOf.toISOString(), "2026-07-24T20:00:00.000Z");
 });
 
 test("history must be close to the current snapshot", () => {
@@ -203,4 +212,11 @@ test("history must be close to the current snapshot", () => {
 test("bar descriptions distinguish unknown state from missing coverage", () => {
   assert.match(barDescription([{ state: "unknown" }]), /unknown state/i);
   assert.doesNotMatch(barDescription([{ state: "unknown" }]), /not monitored/i);
+});
+
+test("uptime description states the fixed window and observed coverage", () => {
+  assert.equal(
+    uptimeDescription({ uptime: 100, coverage: 1.5 }, 90),
+    "100% uptime over the last 90 days, 1.5% monitored",
+  );
 });


### PR DESCRIPTION
# Status page correctness

## Success criteria

- [x] Uptime uses the exact clipped UTC-day window represented by the bar strip.
- [x] Every component always renders a rolling 90-cell strip; unobserved days are blank.
- [x] Deferred datasets do not affect a page that renders only endpoints and tools.
- [x] Valid legacy history remains visible during the publisher rollout.
- [x] Revision-bearing stale, failed, or mismatched history is never rendered as current.
- [x] Snapshot timestamps require an explicit UTC offset.
- [x] The global latest-content popup does not cover status rows.
- [x] Local fixture mode demonstrates active, recovered, and coverage-gap failures.
- [x] Render a chronological incident log from witnessed down intervals.
- [x] Link red day cells to stable incident anchors and expose incident RSS.
- [x] Distinguish resolved, ongoing, and observation-ended incidents.
- [x] Apply the requested heading, timestamp, stale-warning, and component-name copy.
- [x] Preserve an accessible bar summary while making outage cells keyboard-accessible.
- [x] Run the full JavaScript suite, production build, and browser verification.

## Work log

### 2026-07-25 — Review findings

The page has a sound pure-replay core, but its uptime and bar windows diverge
after 90 days, deferred datasets still drive the headline, and historical
freshness is not checked against the current snapshot.

### 2026-07-25 — Implementation

Bars and uptime now share one UTC-day window. The headline and incident list use
only rendered endpoints and tools. Revision-bearing history is checked for
artifact mismatch and must be within 20 minutes of the snapshot.

### 2026-07-25 — PR feedback

The page accepts otherwise-valid legacy metadata during the publisher rollout.
Every component now gets 90 rolling cells: days with no evidence are unfilled,
any observed operational interval fills its day, and a witnessed outage wins.
The coverage calculation remains internal rather than appearing beside uptime.

### 2026-07-26 — Incident history feedback

The page reconstructs incident start, end, duration, and resolution evidence
from the same replay that powers its bars. Red day cells are keyboard-accessible
links to stable incident anchors. The publisher-owned RSS feed is discoverable
in the page head and beside the incident log.

The heading and freshness row use the requested copy and responsive alignment.
A stale feed replaces the timestamp with the warning instead of adding a second
line. Public names now read `dynamical.org website` and `scorecard`.

### 2026-07-26 — Retro

The stable incident key made the page, RSS, and a future prose-update stream
composable without adding identity to source transitions. Keeping the bar
summary as an accessible group preserved its aggregate meaning while exposing
outage cells as real links.

Validation: 39 tests passed; the production Eleventy build wrote 2,799 files.
Headless-browser verification covered desktop layout, requested labels, stale
replacement, and matching bar links and incident targets.

### 2026-07-26 — Code review

Review found and fixed one forward-compatibility defect: revision validation
compared `events_count` only with health events understood by the current
client. A future additive record would therefore have made an older client
hide the entire 90-day history. Validation now counts every valid JSONL record
while replay still consumes only recognized health events. A second regression
test confirms revision-bearing truncated records remain rejected.

Post-review validation: 41 tests passed; the production build wrote 2,799 files.
