### PR TITLE
Move the pipeline dashboard into the static status site

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -168,6 +168,60 @@ module.exports = function (eleventyConfig) {
     );
   }
 
+  if (process.env.PIPELINE_FIXTURE === "1") {
+    const source = JSON.parse(
+      fs.readFileSync("./test/fixtures/pipeline-dashboard.json", "utf8"),
+    );
+    const shiftFixture = (target) => {
+      const shift = target.getTime() - Date.parse(source.generated_at);
+      return JSON.parse(
+        JSON.stringify(source, (_key, value) => {
+          if (
+            typeof value === "string" &&
+            /(?:Z|[+-]\d{2}:?\d{2})$/.test(value) &&
+            Number.isFinite(Date.parse(value))
+          ) {
+            return new Date(Date.parse(value) + shift).toISOString();
+          }
+          return value;
+        }),
+      );
+    };
+    const now = new Date();
+    const snapshotTime = new Date(now.getTime() - 30 * 60 * 1000);
+    const historyKey = (date) =>
+      date
+        .toISOString()
+        .replace(/\.\d{3}Z$/, "Z")
+        .replaceAll(":", "-");
+    const snapshotKey = historyKey(snapshotTime);
+
+    eleventyConfig.addTemplate(
+      "pipeline-dashboard-fixture.njk",
+      JSON.stringify(shiftFixture(now)),
+      {
+        permalink: "/pipeline-preview/dashboard.json",
+        eleventyExcludeFromCollections: true,
+      },
+    );
+    eleventyConfig.addTemplate(
+      "pipeline-history-index-fixture.njk",
+      JSON.stringify([historyKey(now), snapshotKey]),
+      {
+        permalink: "/pipeline-preview/history/index.json",
+        eleventyExcludeFromCollections: true,
+      },
+    );
+    eleventyConfig.addTemplate(
+      "pipeline-history-snapshot-fixture.njk",
+      JSON.stringify(shiftFixture(snapshotTime)),
+      {
+        permalink: `/pipeline-preview/history/${snapshotKey}.json`,
+        eleventyExcludeFromCollections: true,
+      },
+    );
+  }
+
   // The includes/layouts dir (`../_includes`) lives outside the `content` input
   // dir, so `--serve` doesn't watch it by default — edits to base.njk and other
   // layouts wouldn't trigger a rebuild. Watch it explicitly.

--- a/_data/pipelineAssetsBase.js
+++ b/_data/pipelineAssetsBase.js
@@ -1,0 +1,3 @@
+module.exports =
+  process.env.PIPELINE_ASSETS_BASE ||
+  "https://assets.dynamical.org/wxopticon";

--- a/_includes/base.njk
+++ b/_includes/base.njk
@@ -42,6 +42,8 @@
     <meta name="twitter:image" content="{{ ogImage }}"/>
     <meta name="twitter:image:alt" content="{{ ogImageAlt }}"/>
     <link rel="stylesheet" type="text/css" href="/main.css?v={{ assets.mainCss }}"/>
+    {% if pageStylesheet %}<link rel="stylesheet" type="text/css" href="{{ pageStylesheet }}"/>
+    {% endif %}
     <link rel="preconnect" href="https://fonts.googleapis.com"/>
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
     <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;700&display=swap" rel="stylesheet"/>

--- a/_includes/status-subnav.njk
+++ b/_includes/status-subnav.njk
@@ -1,0 +1,5 @@
+<nav class="status-subnav" aria-label="Status">
+  <a href="/status/pipeline/"{% if statusSection == "pipeline" %} aria-current="page"{% endif %}>pipeline</a>
+  <span aria-hidden="true">|</span>
+  <a href="https://status.dynamical.org/webhooks">webhooks</a>
+</nav>

--- a/content/status-pipeline.njk
+++ b/content/status-pipeline.njk
@@ -1,0 +1,72 @@
+---
+layout: base.njk
+title: data product pipeline status
+description: Per-model production status and upstream forecast arrival timing.
+permalink: /status/pipeline/
+noindex: true
+sitemap: false
+hideLatestPopup: true
+statusSection: pipeline
+pageStylesheet: /pipeline.css
+---
+
+<main class="content pipeline-page" id="pipeline-app"
+  data-assets-base="{{ pipelineAssetsBase }}">
+  <header class="status-page-heading">
+    <h1>dynamical.org status</h1>
+    <p class="pipeline-updated">Updated <span data-slot="generated-at">—</span></p>
+  </header>
+  {% include "status-subnav.njk" %}
+
+  <h2>Data product pipeline</h2>
+  <p>Forecast-run arrival timing from the upstream sources we use.</p>
+
+  <div class="pipeline-ribbon" data-slot="ribbon" hidden>
+    Pipeline data is more than 10 minutes old — it may be stalled.
+  </div>
+  <div data-slot="banners" aria-live="polite"></div>
+
+  <div class="pipeline-controls">
+    <div class="pipeline-controls-primary">
+      <span class="pipeline-agencies" data-slot="agency-status" role="status"
+        title="NOAA, ECMWF, and DWD dissemination advisories">
+        <span class="pipeline-agency-dot" aria-hidden="true"></span>
+        weather agencies <strong>checking…</strong>
+      </span>
+      <label>
+        <span class="visually-hidden">Time zone</span>
+        <select id="pipeline-time-toggle">
+          <option value="utc">Coordinated Universal Time (UTC)</option>
+          <option value="local">Local time</option>
+        </select>
+      </label>
+    </div>
+    <button type="button" id="pipeline-history-toggle" aria-expanded="false"
+      aria-controls="pipeline-history-panel">history</button>
+  </div>
+
+  <div id="pipeline-history-panel" hidden>
+    <span data-slot="scrub-label" aria-hidden="true">—</span>
+    <input type="range" id="pipeline-history-range" min="0" max="0" value="0"
+      step="1" aria-label="Pipeline history" aria-valuetext="live" disabled>
+    <p data-slot="scrub-error" hidden></p>
+    <button type="button" data-slot="return-live" hidden>return to live</button>
+  </div>
+
+  <div data-slot="advisories"></div>
+  <div data-slot="groups" aria-live="polite">
+    <p data-slot="loading">Loading pipeline status…</p>
+  </div>
+
+  <footer class="pipeline-footer">
+    <span><span data-slot="window-days">—</span>-day rolling window · polls every 15s</span>
+    <span>
+      <a href="https://status.dynamical.org/webhooks">webhooks</a> ·
+      <a href="/research/when-the-forecast-is-ready/">integration guide</a>
+    </span>
+  </footer>
+
+  <noscript><p>Pipeline status requires JavaScript.</p></noscript>
+</main>
+
+<script type="module" src="/pipeline.mjs"></script>

--- a/content/status.njk
+++ b/content/status.njk
@@ -30,7 +30,7 @@ statusIncidentFeedEnabled: true
     text-align: right;
   }
   #status-as-of.status-stale {
-    color: var(--pill-degraded-fg);
+    color: var(--pill-degraded-bg);
   }
   .status-overall {
     margin-top: 1rem;
@@ -167,6 +167,7 @@ statusIncidentFeedEnabled: true
     <h1>dynamical.org status</h1>
     <p id="status-as-of" role="status"><strong>As of —</strong></p>
   </header>
+  {% include "status-subnav.njk" %}
 
   <section class="status-overall" id="status-overall" aria-labelledby="status-overall-heading" aria-live="polite">
     <h2 id="status-overall-heading">Checking current status…</h2>
@@ -196,7 +197,7 @@ statusIncidentFeedEnabled: true
 
   <p style="margin-top: 4rem;">
     For per-model run timing and upstream source arrival history, see the
-    <a href="https://status.dynamical.org">detailed data arrival status</a>.
+    <a href="/status/pipeline/">data product pipeline</a>.
   </p>
 
   <section aria-labelledby="status-incident-heading" style="margin-top: 4rem;">

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "STAC_CACHE_DURATION=0s npx @11ty/eleventy",
     "test": "node --test test/*.test.mjs",
     "start": "npx @11ty/eleventy --serve --port=8081",
+    "start:pipeline": "PIPELINE_FIXTURE=1 PIPELINE_ASSETS_BASE=/pipeline-preview npx @11ty/eleventy --serve --port=8081",
     "start:status": "STATUS_FIXTURE=1 STATUS_URL=/status-preview/status.json STATUS_LOG_URL=/status-preview npx @11ty/eleventy --serve --port=8081",
     "start:staging": "STAC_BASE_URL=https://stac-staging.dynamical.org npx @11ty/eleventy --serve --port=8081",
     "build:staging": "STAC_BASE_URL=https://stac-staging.dynamical.org STAC_CACHE_DURATION=0s npx @11ty/eleventy",

--- a/public/main.css
+++ b/public/main.css
@@ -145,6 +145,19 @@ a:visited {
   color: var(--link-visited-color);
 }
 
+.status-subnav {
+  display: flex;
+  gap: 0.8rem;
+  margin: 0.6rem 0 3rem;
+  font-size: 1.2rem;
+}
+
+.status-subnav [aria-current="page"] {
+  color: var(--text-color);
+  font-weight: 700;
+  text-decoration: none;
+}
+
 /* Prevent visited-link styling from recoloring interactive SVG maps (e.g. scorecard). */
 #map-container svg a:link,
 #map-container svg a:visited,

--- a/public/pipeline.css
+++ b/public/pipeline.css
@@ -1,0 +1,373 @@
+.pipeline-page {
+  --pipeline-ok: #5bc54a;
+  --pipeline-progress: #f4b942;
+  --pipeline-failed: #c5221f;
+  --pipeline-unobserved: #a8a8ad;
+}
+
+.pipeline-page .status-page-heading {
+  display: flex;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: 0.5rem 2rem;
+  margin-top: 4rem;
+}
+
+.pipeline-page .status-page-heading h1,
+.pipeline-page .status-page-heading p {
+  margin: 0;
+}
+
+.pipeline-updated {
+  margin-left: auto !important;
+  text-align: right;
+}
+
+.pipeline-controls,
+.pipeline-controls-primary {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 1.2rem;
+}
+
+.pipeline-controls {
+  justify-content: space-between;
+  margin: 3rem 0 2rem;
+}
+
+.pipeline-controls-primary {
+  justify-content: flex-start;
+}
+
+.pipeline-agencies {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  white-space: nowrap;
+}
+
+.pipeline-agency-dot {
+  width: 0.9rem;
+  height: 0.9rem;
+  border-radius: 50%;
+  background: var(--pipeline-unobserved);
+}
+
+.pipeline-agencies[data-state="nominal"] .pipeline-agency-dot {
+  background: var(--pipeline-ok);
+}
+
+.pipeline-agencies[data-state="advisory"] {
+  color: var(--pill-degraded-fg);
+  background: var(--pill-degraded-bg);
+  padding: 0.2rem 0.5rem;
+}
+
+.pipeline-agencies[data-state="advisory"] .pipeline-agency-dot {
+  background: currentColor;
+}
+
+.pipeline-controls button,
+.pipeline-footer,
+.pipeline-updated {
+  font-size: 1.2rem;
+}
+
+.pipeline-ribbon:not([hidden]),
+.pipeline-banner {
+  margin-bottom: 1.5rem;
+  padding: 0.8rem 1.2rem;
+  border: 1px solid var(--pipeline-progress);
+}
+
+.pipeline-banner--error {
+  border-color: var(--pipeline-failed);
+}
+
+#pipeline-history-panel {
+  position: relative;
+  margin: 2rem 0;
+  padding-top: 2.4rem;
+}
+
+#pipeline-history-panel > span {
+  position: absolute;
+  top: 0;
+  left: var(--thumb-pct, 50%);
+  transform: translateX(-50%);
+  font-size: 1.2rem;
+  white-space: nowrap;
+}
+
+#pipeline-history-range {
+  width: 100%;
+}
+
+#pipeline-history-panel [data-slot="return-live"] {
+  float: right;
+}
+
+.pipeline-advisories {
+  margin: 1.5rem 0;
+  font-size: 1.2rem;
+}
+
+.pipeline-advisories p {
+  margin: 0.4rem 0;
+}
+
+.pipeline-group {
+  border-top: 1px solid var(--border-muted-color);
+}
+
+.pipeline-group:first-child {
+  border-top: 0;
+}
+
+.pipeline-group > h3 {
+  margin: 1.6rem 0 0.4rem;
+  font-size: 1.5rem;
+}
+
+.pipeline-row {
+  display: grid;
+  grid-template-columns: 19rem minmax(0, 1fr) 16rem;
+  align-items: start;
+  gap: 2rem;
+  padding: 1.6rem 0;
+}
+
+.pipeline-source-meta {
+  overflow-wrap: anywhere;
+  color: var(--muted-text);
+  font-size: 1.2rem;
+}
+
+.pipeline-row-advisory {
+  color: var(--pill-degraded-bg);
+  font-weight: 700;
+}
+
+.pipeline-row-body {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.6rem;
+  min-width: 0;
+}
+
+.pipeline-lead-labels {
+  position: relative;
+  flex: none;
+  width: 2.6rem;
+  height: 13rem;
+  color: var(--muted-text);
+  font-size: 1rem;
+  line-height: 1;
+}
+
+.pipeline-lead-labels span {
+  position: absolute;
+  right: 0;
+  transform: translateY(50%);
+  white-space: nowrap;
+}
+
+.pipeline-grid {
+  display: grid;
+  grid-template-columns: repeat(10, minmax(0, 1fr));
+  flex: 1;
+  gap: 0.6rem;
+  min-width: 0;
+}
+
+.pipeline-bar {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.pipeline-bar-track {
+  position: relative;
+  width: 100%;
+  height: 13rem;
+  overflow: hidden;
+  border: 1px solid var(--text-color);
+}
+
+.pipeline-bar-fill,
+.pipeline-bar-segment,
+.pipeline-bar-segment-fill {
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  left: 0;
+}
+
+.pipeline-bar-fill {
+  height: var(--fill, 0%);
+}
+
+.pipeline-bar-segment {
+  bottom: var(--band-bottom, 0%);
+  height: var(--band-height, 0%);
+}
+
+.pipeline-bar-segment + .pipeline-bar-segment:not(:last-child) {
+  border-top: 1px solid var(--text-color);
+}
+
+.pipeline-bar-segment-fill {
+  height: var(--fill, 0%);
+}
+
+.pipeline-bar[data-status="complete"] .pipeline-bar-fill,
+.pipeline-bar-segment.g-complete .pipeline-bar-segment-fill {
+  background: var(--pipeline-ok);
+}
+
+.pipeline-bar[data-status="complete"][data-timing="delayed"] .pipeline-bar-fill,
+.pipeline-bar[data-status="in_flight"] .pipeline-bar-fill,
+.pipeline-bar-segment.g-complete[data-timing="delayed"] .pipeline-bar-segment-fill,
+.pipeline-bar-segment.g-in_flight .pipeline-bar-segment-fill {
+  background: var(--pipeline-progress);
+}
+
+.pipeline-bar[data-status="in_flight"][data-timing="on_time"] .pipeline-bar-fill,
+.pipeline-bar-segment.g-in_flight[data-timing="on_time"] .pipeline-bar-segment-fill {
+  background: var(--pipeline-ok);
+}
+
+.pipeline-bar[data-status="failed"] .pipeline-bar-fill,
+.pipeline-bar-segment.g-failed .pipeline-bar-segment-fill {
+  height: 100%;
+  background: var(--pipeline-failed);
+}
+
+.pipeline-bar[data-status="unobserved"] .pipeline-bar-track,
+.pipeline-bar-segment.g-pending {
+  border-style: dotted;
+  border-color: var(--pipeline-unobserved);
+}
+
+.pipeline-bar[data-status="unobserved"] .pipeline-bar-fill,
+.pipeline-bar[data-status="unobserved"] .pipeline-bar-segment,
+.pipeline-bar-segment.g-pending .pipeline-bar-segment-fill,
+.pipeline-bar-segment.g-unobserved .pipeline-bar-segment-fill {
+  display: none;
+}
+
+.pipeline-bar-label {
+  min-height: 2.4em;
+  color: var(--muted-text);
+  font-size: 1rem;
+  line-height: 1.2;
+  text-align: center;
+}
+
+.pipeline-bar-label strong {
+  display: block;
+  color: var(--text-color);
+}
+
+.pipeline-stats {
+  color: var(--muted-text);
+  font-size: 1.2rem;
+  text-align: right;
+}
+
+.pipeline-stats strong,
+.pipeline-stats span {
+  display: block;
+}
+
+.pipeline-stats strong {
+  color: var(--text-color);
+}
+
+.pipeline-stats [data-timing="on_time"] {
+  color: var(--pipeline-ok);
+}
+
+.pipeline-stats [data-timing="delayed"] {
+  color: var(--pipeline-progress);
+}
+
+.pipeline-details-button {
+  margin-top: 0.8rem;
+  padding: 0;
+  border: 0;
+  color: var(--link-color);
+  background: none;
+  font: inherit;
+  text-decoration: underline;
+  cursor: pointer;
+}
+
+.pipeline-row-details {
+  grid-column: 1 / -1;
+  max-width: 100%;
+  overflow-x: auto;
+}
+
+.pipeline-row-details table {
+  width: 100%;
+  min-width: 64rem;
+  border-collapse: collapse;
+  font-size: 1.2rem;
+}
+
+.pipeline-row-details th,
+.pipeline-row-details td {
+  padding: 0.4rem 1.2rem;
+  border: 1px dotted var(--border-muted-color);
+  text-align: right;
+  white-space: nowrap;
+}
+
+.pipeline-row-details th:first-child,
+.pipeline-row-details td:first-child {
+  text-align: left;
+}
+
+.pipeline-footer {
+  display: flex;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 1.2rem;
+  margin-top: 2rem;
+  padding-top: 1rem;
+  border-top: 1px solid var(--border-muted-color);
+  color: var(--muted-text);
+}
+
+.pipeline-time-local .pipeline-time-utc,
+body:not(.pipeline-time-local) .pipeline-time-local-only {
+  display: none;
+}
+
+@media (max-width: 900px) {
+  .pipeline-row {
+    grid-template-columns: 1fr;
+  }
+
+  .pipeline-stats {
+    text-align: left;
+  }
+}
+
+@media (max-width: 680px) {
+  .pipeline-updated {
+    flex-basis: 100%;
+    text-align: left;
+  }
+
+  .pipeline-grid {
+    gap: 0.3rem;
+  }
+
+  .pipeline-bar-label {
+    font-size: 0.8rem;
+  }
+}

--- a/public/pipeline.mjs
+++ b/public/pipeline.mjs
@@ -1,0 +1,682 @@
+const POLL_INTERVAL_MS = 15_000;
+const STALE_AFTER_MS = 10 * 60 * 1000;
+const FETCH_TIMEOUT_MS = 10_000;
+const TIME_MODE_KEY = "wxopticon:time-mode";
+const DASHBOARD_VERSION = 1;
+
+function hasTimestamp(value) {
+  return (
+    typeof value === "string" &&
+    /(?:Z|[+-]\d{2}:?\d{2})$/.test(value) &&
+    Number.isFinite(Date.parse(value))
+  );
+}
+
+export function validateDashboard(data) {
+  if (
+    !data ||
+    data.v !== DASHBOARD_VERSION ||
+    !hasTimestamp(data.generated_at) ||
+    !Array.isArray(data.groups) ||
+    data.groups.length === 0 ||
+    !Array.isArray(data.advisories)
+  ) {
+    throw new TypeError("Invalid pipeline dashboard");
+  }
+  for (const group of data.groups) {
+    if (
+      typeof group.id !== "string" ||
+      typeof group.label !== "string" ||
+      !Array.isArray(group.products) ||
+      group.products.length === 0
+    ) {
+      throw new TypeError("Invalid pipeline group");
+    }
+    for (const product of group.products) {
+      if (
+        typeof product.id !== "string" ||
+        typeof product.row_label !== "string" ||
+        !Array.isArray(product.recent_inits) ||
+        product.recent_inits.length > 10
+      ) {
+        throw new TypeError("Invalid pipeline product");
+      }
+    }
+  }
+  return data;
+}
+
+export function agencySummary(advisories) {
+  const active = advisories ?? [];
+  if (active.length === 0) {
+    return { state: "nominal", label: "nominal" };
+  }
+  const agencies = [...new Set(active.map(({ agency }) => agency.toUpperCase()))];
+  return {
+    state: "advisory",
+    label: `${agencies.join(", ")} advisor${active.length === 1 ? "y" : "ies"}`,
+  };
+}
+
+function productsOf(snapshot) {
+  if (Array.isArray(snapshot.products)) return snapshot.products;
+  return (snapshot.groups ?? []).flatMap((group) => group.products ?? []);
+}
+
+function element(tag, attrs, children) {
+  const node = document.createElement(tag);
+  for (const [name, value] of Object.entries(attrs ?? {})) {
+    if (value == null) continue;
+    if (name === "class") node.className = value;
+    else node.setAttribute(name, value);
+  }
+  for (const child of [].concat(children ?? [])) {
+    if (child == null || child === false) continue;
+    node.append(
+      typeof child === "string" || typeof child === "number"
+        ? document.createTextNode(String(child))
+        : child,
+    );
+  }
+  return node;
+}
+
+function formatLatency(seconds) {
+  if (seconds == null || !Number.isFinite(seconds)) return "—";
+  if (seconds < 60) return `${Math.round(seconds)}s`;
+  if (seconds < 3600) return `${Math.round(seconds / 60)}m`;
+  const hours = Math.floor(seconds / 3600);
+  const minutes = Math.round((seconds % 3600) / 60);
+  return minutes ? `${hours}h ${minutes}m` : `${hours}h`;
+}
+
+function formatDuration(seconds) {
+  if (seconds >= 3600) {
+    const hours = Math.floor(seconds / 3600);
+    const minutes = Math.floor((seconds % 3600) / 60);
+    return `${hours}h ${minutes}m`;
+  }
+  return `${Math.floor(seconds / 60)}m ${seconds % 60}s`;
+}
+
+function initShort(timestamp) {
+  const date = new Date(timestamp);
+  const month = String(date.getUTCMonth() + 1).padStart(2, "0");
+  const day = String(date.getUTCDate()).padStart(2, "0");
+  const hour = String(date.getUTCHours()).padStart(2, "0");
+  return `${month}-${day} ${hour}z`;
+}
+
+function initLabel(timestamp) {
+  const [date, hour] = initShort(timestamp).split(" ");
+  return element("span", null, [element("strong", null, date), hour]);
+}
+
+function formatTime(timestamp, local) {
+  return new Intl.DateTimeFormat(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+    timeZone: local ? undefined : "UTC",
+    timeZoneName: "short",
+  }).format(new Date(timestamp));
+}
+
+function timeNode(timestamp) {
+  return element("span", null, [
+    element("span", { class: "pipeline-time-utc" }, formatTime(timestamp, false)),
+    element(
+      "span",
+      { class: "pipeline-time-local-only" },
+      formatTime(timestamp, true),
+    ),
+  ]);
+}
+
+function groupSlices(groups) {
+  const total = groups.at(-1)?.leads_expected ?? 0;
+  let previousAvailable = 0;
+  let previousExpected = 0;
+  return groups.map((group) => {
+    const expected = group.leads_expected - previousExpected;
+    const available = group.leads_available - previousAvailable;
+    previousExpected = group.leads_expected;
+    previousAvailable = group.leads_available;
+    return {
+      ...group,
+      height: total ? (expected / total) * 100 : 0,
+      fill: expected ? Math.max(0, Math.min(100, (available / expected) * 100)) : 0,
+    };
+  });
+}
+
+function barTooltip(init) {
+  if (init.status === "unobserved") {
+    return `${initShort(init.init_time)} · no probe visibility; not a publication failure`;
+  }
+  const state = init.timing ? `${init.status} · ${init.timing}` : init.status;
+  return [
+    initShort(init.init_time),
+    state,
+    init.completion_pct == null
+      ? null
+      : `${Math.round(init.completion_pct * 100)}%`,
+    init.latency_s == null ? null : `latency ${formatLatency(init.latency_s)}`,
+  ]
+    .filter(Boolean)
+    .join(" · ");
+}
+
+function renderBar(init) {
+  const track = element("div", { class: "pipeline-bar-track" });
+  if (init.lead_groups?.length) {
+    let bottom = 0;
+    for (const group of groupSlices(init.lead_groups)) {
+      const segment = element(
+        "div",
+        {
+          class: `pipeline-bar-segment g-${group.status}`,
+          "data-timing": group.timing,
+          style: `--band-height:${group.height}%;--band-bottom:${bottom}%;--fill:${group.fill}%`,
+        },
+        element("div", { class: "pipeline-bar-segment-fill" }),
+      );
+      track.append(segment);
+      bottom += group.height;
+    }
+  } else {
+    track.append(
+      element("div", {
+        class: "pipeline-bar-fill",
+        style: `--fill:${Math.max(0, Math.min(100, (init.completion_pct ?? 0) * 100))}%`,
+      }),
+    );
+  }
+  return element(
+    "div",
+    {
+      class: "pipeline-bar",
+      "data-status": init.status,
+      "data-timing": init.timing,
+      title: barTooltip(init),
+    },
+    [
+      track,
+      element("div", { class: "pipeline-bar-label" }, initLabel(init.init_time)),
+    ],
+  );
+}
+
+function renderStructure(app, dashboard, rows) {
+  const groupsSlot = app.querySelector('[data-slot="groups"]');
+  groupsSlot.replaceChildren();
+  rows.clear();
+
+  for (const group of dashboard.groups) {
+    const section = element("section", { class: "pipeline-group" }, [
+      element("h3", null, group.label),
+    ]);
+    for (const product of group.products) {
+      const leadLabels = element("div", {
+        class: "pipeline-lead-labels",
+        "aria-hidden": "true",
+      });
+      for (const lead of product.lead_groups?.slice(1) ?? []) {
+        leadLabels.append(
+          element(
+            "span",
+            { style: `bottom:${lead.center_pct}%` },
+            lead.label,
+          ),
+        );
+      }
+
+      const advisory = element("div", {
+        class: "pipeline-row-advisory",
+        "data-slot": "row-advisory",
+        hidden: "",
+      });
+      const row = element(
+        "section",
+        { class: "pipeline-row", "data-product-id": product.id },
+        [
+          element("div", null, [
+            element("strong", null, product.row_label),
+            element("div", { class: "pipeline-source-meta" }, [
+              element("div", null, product.source ?? "—"),
+              element("div", null, `${product.cadence_hours ?? "—"}h init cadence`),
+              element("div", null, `${product.init_hours?.join("/") || "—"}z`),
+              advisory,
+            ]),
+          ]),
+          element("div", { class: "pipeline-row-body" }, [
+            leadLabels,
+            element("div", { class: "pipeline-grid", "data-slot": "grid" }),
+          ]),
+          element("div", { class: "pipeline-stats" }, [
+            element("strong", { "data-slot": "eta-init" }, "—"),
+            element("span", { "data-slot": "eta-state", hidden: "" }),
+            element("span", { "data-slot": "eta-line", hidden: "" }),
+            element(
+              "button",
+              {
+                type: "button",
+                class: "pipeline-details-button",
+                "data-slot": "details-button",
+                "aria-expanded": "false",
+                hidden: "",
+              },
+              "more details",
+            ),
+          ]),
+          element("div", {
+            class: "pipeline-row-details",
+            "data-slot": "details",
+            hidden: "",
+          }),
+        ],
+      );
+      rows.set(product.id, row);
+      section.append(row);
+    }
+    groupsSlot.append(section);
+  }
+}
+
+function etaTarget(product) {
+  const running = product.recent_inits.findLast(
+    (init) => init.status === "in_flight",
+  );
+  if (running) {
+    const p95 = product.latency_stats?.p95_s;
+    return {
+      init: running,
+      initTime: running.init_time,
+      target:
+        p95 == null
+          ? null
+          : new Date(Date.parse(running.init_time) + p95 * 1000).toISOString(),
+      running: true,
+    };
+  }
+  if (!product.next_expected_init) return null;
+  return {
+    init: null,
+    initTime: product.next_expected_init,
+    target: product.next_expected_completion_at ?? null,
+    running: false,
+  };
+}
+
+function buildDetails(product) {
+  const running = product.recent_inits.findLast(
+    (init) => init.status === "in_flight",
+  );
+  const groups = running?.lead_groups ?? [];
+  const head = element("tr", null, [
+    element("th", null, "horizon"),
+    element("th", null, "status"),
+    element("th", null, "p50"),
+    element("th", null, "p95"),
+    element("th", null, "p99"),
+  ]);
+  const body = element("tbody");
+  for (const [index, stats] of product.lead_group_stats.entries()) {
+    const live = groups[index];
+    body.append(
+      element("tr", null, [
+        element("td", null, stats.label),
+        element("td", null, live?.status?.replaceAll("_", " ") ?? "pending"),
+        element("td", null, formatLatency(stats.p50_s)),
+        element("td", null, formatLatency(stats.p95_s)),
+        element("td", null, formatLatency(stats.p99_s)),
+      ]),
+    );
+  }
+  return element("table", null, [
+    element("thead", null, head),
+    body,
+  ]);
+}
+
+function hydrateRow(row, product, now) {
+  row.querySelector('[data-slot="grid"]').replaceChildren(
+    ...product.recent_inits.slice(-10).map(renderBar),
+  );
+  hydrateEta(row, product, now);
+
+  const button = row.querySelector('[data-slot="details-button"]');
+  const details = row.querySelector('[data-slot="details"]');
+  if (product.lead_group_stats?.length) {
+    button.hidden = false;
+    details.replaceChildren(buildDetails(product));
+  } else {
+    button.hidden = true;
+    details.hidden = true;
+  }
+}
+
+function hydrateEta(row, product, now) {
+  const initSlot = row.querySelector('[data-slot="eta-init"]');
+  const stateSlot = row.querySelector('[data-slot="eta-state"]');
+  const lineSlot = row.querySelector('[data-slot="eta-line"]');
+  const target = etaTarget(product);
+  if (!target) {
+    initSlot.textContent = "—";
+    stateSlot.hidden = true;
+    lineSlot.hidden = true;
+  } else {
+    initSlot.textContent = initShort(target.initTime);
+    stateSlot.hidden = false;
+    if (target.running) {
+      const observed = (target.init?.completion_pct ?? 0) > 0;
+      stateSlot.textContent = observed ? "processing" : "pending";
+      if (target.init?.timing) {
+        stateSlot.textContent += ` · ${target.init.timing.replace("_", " ")}`;
+        stateSlot.dataset.timing = target.init.timing;
+      } else {
+        delete stateSlot.dataset.timing;
+      }
+    } else {
+      const seconds = Math.floor((Date.parse(target.initTime) - now) / 1000);
+      stateSlot.textContent =
+        seconds <= 0 ? "processing" : `init in ${formatDuration(seconds)}`;
+    }
+    lineSlot.hidden = !target.target;
+    if (target.target) {
+      const seconds = Math.floor((Date.parse(target.target) - now) / 1000);
+      lineSlot.textContent =
+        seconds <= 0 ? "ETA any moment" : `ETA in ${formatDuration(seconds)}`;
+    }
+  }
+}
+
+function renderAdvisories(app, advisories, rows) {
+  const status = app.querySelector('[data-slot="agency-status"]');
+  const summary = agencySummary(advisories);
+  status.dataset.state = summary.state;
+  status.querySelector("strong").textContent = summary.label;
+
+  for (const row of rows.values()) {
+    const marker = row.querySelector('[data-slot="row-advisory"]');
+    marker.hidden = true;
+    marker.replaceChildren();
+  }
+  const slot = app.querySelector('[data-slot="advisories"]');
+  slot.replaceChildren();
+  if (advisories.length === 0) return;
+
+  const container = element("div", { class: "pipeline-advisories" }, [
+    element(
+      "strong",
+      null,
+      `${advisories.length} active upstream dissemination advisor${advisories.length === 1 ? "y" : "ies"}`,
+    ),
+  ]);
+  for (const advisory of advisories) {
+    const description = `${advisory.agency.toUpperCase()} — ${advisory.title}`;
+    container.append(
+      element(
+        "p",
+        null,
+        advisory.url
+          ? element("a", { href: advisory.url }, description)
+          : description,
+      ),
+    );
+    for (const productId of advisory.product_ids ?? []) {
+      const marker = rows
+        .get(productId)
+        ?.querySelector('[data-slot="row-advisory"]');
+      if (!marker) continue;
+      marker.hidden = false;
+      marker.textContent = `⚠ ${advisory.agency.toUpperCase()} advisory`;
+    }
+  }
+  slot.append(container);
+}
+
+function renderSnapshot(app, snapshot, rows, now) {
+  app
+    .querySelector('[data-slot="generated-at"]')
+    .replaceChildren(timeNode(snapshot.generated_at));
+  for (const product of productsOf(snapshot)) {
+    const row = rows.get(product.id);
+    if (row) hydrateRow(row, product, now);
+  }
+  renderAdvisories(app, snapshot.advisories ?? [], rows);
+}
+
+function historyTimestamp(value) {
+  return value.replace(
+    /T(\d{2})-(\d{2})-(\d{2})Z$/,
+    "T$1:$2:$3Z",
+  );
+}
+
+function start(app) {
+  const base = app.dataset.assetsBase.replace(/\/$/, "");
+  const dashboardUrl = `${base}/dashboard.json`;
+  const historyIndexUrl = `${base}/history/index.json`;
+  const rows = new Map();
+  const ribbon = app.querySelector('[data-slot="ribbon"]');
+  const banners = app.querySelector('[data-slot="banners"]');
+  const timeToggle = app.querySelector("#pipeline-time-toggle");
+  const historyButton = app.querySelector("#pipeline-history-toggle");
+  const historyPanel = app.querySelector("#pipeline-history-panel");
+  const historyRange = app.querySelector("#pipeline-history-range");
+  const scrubLabel = app.querySelector('[data-slot="scrub-label"]');
+  const scrubError = app.querySelector('[data-slot="scrub-error"]');
+  const returnLive = app.querySelector('[data-slot="return-live"]');
+
+  let latest = null;
+  let mode = "live";
+  let historyIndex = null;
+  let pollTimer = null;
+  let countdownTimer = null;
+  let structureSignature = null;
+
+  function setTimeMode(local, persist) {
+    document.body.classList.toggle("pipeline-time-local", local);
+    timeToggle.value = local ? "local" : "utc";
+    if (persist) localStorage.setItem(TIME_MODE_KEY, local ? "local" : "utc");
+    if (latest && mode === "live") renderSnapshot(app, latest, rows, Date.now());
+  }
+
+  function showError(message) {
+    banners.replaceChildren(
+      element("div", { class: "pipeline-banner pipeline-banner--error" }, message),
+    );
+  }
+
+  function applyLive() {
+    const nextSignature = latest.groups
+      .flatMap((group) => [group.id, ...group.products.map(({ id }) => id)])
+      .join("\n");
+    if (nextSignature !== structureSignature) {
+      renderStructure(app, latest, rows);
+      structureSignature = nextSignature;
+    }
+    banners.replaceChildren();
+    app.querySelector('[data-slot="window-days"]').textContent =
+      latest.window_days ?? "—";
+    ribbon.hidden =
+      Date.now() - Date.parse(latest.generated_at) <= STALE_AFTER_MS;
+    renderSnapshot(app, latest, rows, Date.now());
+  }
+
+  async function fetchJson(url, cache = "default") {
+    const response = await fetch(url, {
+      cache,
+      headers: { Accept: "application/json" },
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    });
+    if (!response.ok) throw new Error(`HTTP ${response.status}`);
+    return response.json();
+  }
+
+  async function tick() {
+    if (mode !== "live") return;
+    try {
+      const dashboard = validateDashboard(
+        await fetchJson(dashboardUrl, "no-cache"),
+      );
+      if (mode !== "live") return;
+      latest = dashboard;
+      applyLive();
+    } catch (error) {
+      if (latest) {
+        applyLive();
+        showError(`Couldn't refresh pipeline status (${error.message}). Showing last-known state.`);
+      } else {
+        showError(`Couldn't load pipeline status (${error.message}).`);
+      }
+    }
+  }
+
+  function selectedTimestamp() {
+    if (!historyIndex?.length) return null;
+    return historyIndex[historyIndex.length - 1 - Number(historyRange.value)];
+  }
+
+  function updateScrubLabel(timestamp) {
+    const date = historyTimestamp(timestamp);
+    scrubLabel.textContent = formatTime(
+      date,
+      document.body.classList.contains("pipeline-time-local"),
+    );
+    historyRange.setAttribute("aria-valuetext", scrubLabel.textContent);
+    const max = Number(historyRange.max);
+    const percent = max ? (Number(historyRange.value) / max) * 100 : 50;
+    scrubLabel.style.setProperty("--thumb-pct", `${percent}%`);
+    historyPanel.style.setProperty("--thumb-pct", `${percent}%`);
+  }
+
+  async function showSnapshot(timestamp) {
+    try {
+      const snapshot = await fetchJson(
+        `${base}/history/${timestamp}.json`,
+        "no-cache",
+      );
+      if (mode !== "scrub") return;
+      renderSnapshot(
+        app,
+        snapshot,
+        rows,
+        Date.parse(snapshot.generated_at),
+      );
+      scrubError.hidden = true;
+    } catch (error) {
+      scrubError.hidden = false;
+      scrubError.textContent = `Snapshot unavailable (${error.message}).`;
+    }
+  }
+
+  async function openHistory() {
+    historyPanel.hidden = false;
+    historyButton.setAttribute("aria-expanded", "true");
+    if (!historyIndex) {
+      try {
+        historyIndex = await fetchJson(historyIndexUrl, "no-cache");
+        if (!Array.isArray(historyIndex) || historyIndex.length === 0) {
+          throw new Error("empty history");
+        }
+      } catch (error) {
+        scrubError.hidden = false;
+        scrubError.textContent = `History unavailable (${error.message}).`;
+        return;
+      }
+    }
+    historyRange.max = historyIndex.length - 1;
+    historyRange.value = historyIndex.length - 1;
+    historyRange.disabled = false;
+    updateScrubLabel(selectedTimestamp());
+  }
+
+  function resumeLive(close = false) {
+    mode = "live";
+    returnLive.hidden = true;
+    ribbon.hidden = false;
+    if (close) {
+      historyPanel.hidden = true;
+      historyButton.setAttribute("aria-expanded", "false");
+    }
+    tick();
+    if (pollTimer == null) pollTimer = setInterval(tick, POLL_INTERVAL_MS);
+    if (countdownTimer == null) {
+      countdownTimer = setInterval(updateLiveCountdowns, 1000);
+    }
+  }
+
+  function updateLiveCountdowns() {
+    if (mode !== "live" || !latest) return;
+    for (const product of productsOf(latest)) {
+      const row = rows.get(product.id);
+      if (row) hydrateEta(row, product, Date.now());
+    }
+  }
+
+  timeToggle.addEventListener("change", () =>
+    setTimeMode(timeToggle.value === "local", true),
+  );
+  historyButton.addEventListener("click", () => {
+    if (historyPanel.hidden) openHistory();
+    else if (mode === "scrub") resumeLive(true);
+    else {
+      historyPanel.hidden = true;
+      historyButton.setAttribute("aria-expanded", "false");
+    }
+  });
+  historyRange.addEventListener("input", () => {
+    const timestamp = selectedTimestamp();
+    if (!timestamp) return;
+    updateScrubLabel(timestamp);
+    if (Number(historyRange.value) === Number(historyRange.max)) {
+      resumeLive();
+      return;
+    }
+    mode = "scrub";
+    clearInterval(pollTimer);
+    pollTimer = null;
+    clearInterval(countdownTimer);
+    countdownTimer = null;
+    ribbon.hidden = true;
+    banners.replaceChildren();
+    returnLive.hidden = false;
+    showSnapshot(timestamp);
+  });
+  returnLive.addEventListener("click", () => resumeLive(true));
+  app.addEventListener("click", (event) => {
+    const button = event.target.closest('[data-slot="details-button"]');
+    if (!button) return;
+    const details = button
+      .closest(".pipeline-row")
+      .querySelector('[data-slot="details"]');
+    details.hidden = !details.hidden;
+    button.textContent = details.hidden ? "more details" : "less";
+    button.setAttribute("aria-expanded", String(!details.hidden));
+  });
+  document.addEventListener("visibilitychange", () => {
+    if (document.hidden) {
+      clearInterval(pollTimer);
+      pollTimer = null;
+      clearInterval(countdownTimer);
+      countdownTimer = null;
+    } else if (mode === "live") {
+      tick();
+      pollTimer ??= setInterval(tick, POLL_INTERVAL_MS);
+      countdownTimer ??= setInterval(updateLiveCountdowns, 1000);
+    }
+  });
+
+  setTimeMode(localStorage.getItem(TIME_MODE_KEY) === "local", false);
+  tick();
+  pollTimer = setInterval(tick, POLL_INTERVAL_MS);
+  countdownTimer = setInterval(updateLiveCountdowns, 1000);
+}
+
+if (typeof document !== "undefined") {
+  const app = document.querySelector("#pipeline-app");
+  if (app) start(app);
+}

--- a/test/fixtures/pipeline-dashboard.json
+++ b/test/fixtures/pipeline-dashboard.json
@@ -1,0 +1,62 @@
+{
+  "v": 1,
+  "generated_at": "2026-07-25T18:00:00Z",
+  "window_days": 90,
+  "advisories": [
+    {
+      "incident_id": "noaa:fixture-delay",
+      "agency": "noaa",
+      "title": "Fixture: GFS dissemination delay",
+      "cause": "Local failure-mode preview",
+      "product_ids": ["external-noaa-gfs-aws"],
+      "url": "https://nomads.ncep.noaa.gov/status.php"
+    }
+  ],
+  "groups": [
+    {
+      "id": "noaa-gfs",
+      "label": "NOAA GFS forecast",
+      "products": [
+        {
+          "id": "external-noaa-gfs-aws",
+          "label": "NOAA GFS forecast",
+          "source": "s3://noaa-gfs-bdp-pds",
+          "source_label": "AWS",
+          "row_label": "AWS",
+          "cadence_hours": 6,
+          "init_hours": ["00", "06", "12", "18"],
+          "lead_groups": [
+            {"name": "f000", "label": "0h", "leads_in_group": 1, "center_pct": 0.25},
+            {"name": "f024", "label": "1d", "leads_in_group": 5, "center_pct": 1.5},
+            {"name": "f072", "label": "3d", "leads_in_group": 13, "center_pct": 4.5}
+          ],
+          "latency_stats": {
+            "p50_s": 3600,
+            "p95_s": 5400,
+            "p99_s": 6000,
+            "sample_init_count": 30
+          },
+          "lead_group_stats": [
+            {"name": "f000", "label": "0h", "leads_in_group": 1, "p50_s": 900, "p95_s": 1200, "p99_s": 1500},
+            {"name": "f024", "label": "1d", "leads_in_group": 5, "p50_s": 1800, "p95_s": 2400, "p99_s": 2700},
+            {"name": "f072", "label": "3d", "leads_in_group": 13, "p50_s": 3600, "p95_s": 5400, "p99_s": 6000}
+          ],
+          "recent_inits": [
+            {"init_time": "2026-07-23T06:00:00Z", "status": "complete", "timing": "on_time", "completion_pct": 1, "latency_s": 3420, "lead_groups": [{"name": "f000", "status": "complete", "timing": "on_time", "completion_pct": 1, "latency_s": 800, "leads_available": 1, "leads_expected": 1}, {"name": "f024", "status": "complete", "timing": "on_time", "completion_pct": 1, "latency_s": 1700, "leads_available": 5, "leads_expected": 5}, {"name": "f072", "status": "complete", "timing": "on_time", "completion_pct": 1, "latency_s": 3420, "leads_available": 13, "leads_expected": 13}]},
+            {"init_time": "2026-07-23T12:00:00Z", "status": "complete", "timing": "on_time", "completion_pct": 1, "latency_s": 3510, "lead_groups": [{"name": "f000", "status": "complete", "timing": "on_time", "completion_pct": 1, "latency_s": 810, "leads_available": 1, "leads_expected": 1}, {"name": "f024", "status": "complete", "timing": "on_time", "completion_pct": 1, "latency_s": 1750, "leads_available": 5, "leads_expected": 5}, {"name": "f072", "status": "complete", "timing": "on_time", "completion_pct": 1, "latency_s": 3510, "leads_available": 13, "leads_expected": 13}]},
+            {"init_time": "2026-07-23T18:00:00Z", "status": "complete", "timing": "on_time", "completion_pct": 1, "latency_s": 3480, "lead_groups": [{"name": "f000", "status": "complete", "timing": "on_time", "completion_pct": 1, "latency_s": 790, "leads_available": 1, "leads_expected": 1}, {"name": "f024", "status": "complete", "timing": "on_time", "completion_pct": 1, "latency_s": 1720, "leads_available": 5, "leads_expected": 5}, {"name": "f072", "status": "complete", "timing": "on_time", "completion_pct": 1, "latency_s": 3480, "leads_available": 13, "leads_expected": 13}]},
+            {"init_time": "2026-07-24T00:00:00Z", "status": "complete", "timing": "on_time", "completion_pct": 1, "latency_s": 3550, "lead_groups": [{"name": "f000", "status": "complete", "timing": "on_time", "completion_pct": 1, "latency_s": 820, "leads_available": 1, "leads_expected": 1}, {"name": "f024", "status": "complete", "timing": "on_time", "completion_pct": 1, "latency_s": 1780, "leads_available": 5, "leads_expected": 5}, {"name": "f072", "status": "complete", "timing": "on_time", "completion_pct": 1, "latency_s": 3550, "leads_available": 13, "leads_expected": 13}]},
+            {"init_time": "2026-07-24T06:00:00Z", "status": "complete", "timing": "on_time", "completion_pct": 1, "latency_s": 3610, "lead_groups": [{"name": "f000", "status": "complete", "timing": "on_time", "completion_pct": 1, "latency_s": 830, "leads_available": 1, "leads_expected": 1}, {"name": "f024", "status": "complete", "timing": "on_time", "completion_pct": 1, "latency_s": 1810, "leads_available": 5, "leads_expected": 5}, {"name": "f072", "status": "complete", "timing": "on_time", "completion_pct": 1, "latency_s": 3610, "leads_available": 13, "leads_expected": 13}]},
+            {"init_time": "2026-07-24T12:00:00Z", "status": "complete", "timing": "on_time", "completion_pct": 1, "latency_s": 3500, "lead_groups": [{"name": "f000", "status": "complete", "timing": "on_time", "completion_pct": 1, "latency_s": 800, "leads_available": 1, "leads_expected": 1}, {"name": "f024", "status": "complete", "timing": "on_time", "completion_pct": 1, "latency_s": 1760, "leads_available": 5, "leads_expected": 5}, {"name": "f072", "status": "complete", "timing": "on_time", "completion_pct": 1, "latency_s": 3500, "leads_available": 13, "leads_expected": 13}]},
+            {"init_time": "2026-07-24T18:00:00Z", "status": "complete", "timing": "on_time", "completion_pct": 1, "latency_s": 3690, "lead_groups": [{"name": "f000", "status": "complete", "timing": "on_time", "completion_pct": 1, "latency_s": 840, "leads_available": 1, "leads_expected": 1}, {"name": "f024", "status": "complete", "timing": "on_time", "completion_pct": 1, "latency_s": 1830, "leads_available": 5, "leads_expected": 5}, {"name": "f072", "status": "complete", "timing": "on_time", "completion_pct": 1, "latency_s": 3690, "leads_available": 13, "leads_expected": 13}]},
+            {"init_time": "2026-07-25T00:00:00Z", "status": "complete", "timing": "delayed", "completion_pct": 1, "latency_s": 5700, "lead_groups": [{"name": "f000", "status": "complete", "timing": "on_time", "completion_pct": 1, "latency_s": 850, "leads_available": 1, "leads_expected": 1}, {"name": "f024", "status": "complete", "timing": "on_time", "completion_pct": 1, "latency_s": 1900, "leads_available": 5, "leads_expected": 5}, {"name": "f072", "status": "complete", "timing": "delayed", "completion_pct": 1, "latency_s": 5700, "leads_available": 13, "leads_expected": 13}]},
+            {"init_time": "2026-07-25T06:00:00Z", "status": "failed", "completion_pct": 0.38, "lead_groups": [{"name": "f000", "status": "complete", "timing": "on_time", "completion_pct": 1, "latency_s": 900, "leads_available": 1, "leads_expected": 1}, {"name": "f024", "status": "complete", "timing": "delayed", "completion_pct": 1, "latency_s": 3000, "leads_available": 5, "leads_expected": 5}, {"name": "f072", "status": "failed", "completion_pct": 0.38, "leads_available": 5, "leads_expected": 13}]},
+            {"init_time": "2026-07-25T12:00:00Z", "status": "in_flight", "timing": "delayed", "completion_pct": 0.38, "lead_groups": [{"name": "f000", "status": "complete", "timing": "on_time", "completion_pct": 1, "latency_s": 920, "leads_available": 1, "leads_expected": 1}, {"name": "f024", "status": "complete", "timing": "delayed", "completion_pct": 1, "latency_s": 3100, "leads_available": 5, "leads_expected": 5}, {"name": "f072", "status": "in_flight", "timing": "delayed", "completion_pct": 0.38, "leads_available": 5, "leads_expected": 13}]}
+          ],
+          "next_expected_init": "2026-07-25T18:00:00Z",
+          "next_expected_completion_at": "2026-07-25T19:30:00Z"
+        }
+      ]
+    }
+  ]
+}

--- a/test/pipeline.test.mjs
+++ b/test/pipeline.test.mjs
@@ -1,0 +1,105 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+import {
+  agencySummary,
+  validateDashboard,
+} from "../public/pipeline.mjs";
+
+function dashboard() {
+  return {
+    v: 1,
+    generated_at: "2026-07-25T18:00:00Z",
+    window_days: 90,
+    advisories: [],
+    groups: [
+      {
+        id: "noaa-gfs",
+        label: "NOAA GFS forecast",
+        products: [
+          {
+            id: "external-noaa-gfs-aws",
+            row_label: "AWS",
+            recent_inits: [],
+          },
+        ],
+      },
+    ],
+  };
+}
+
+test("accepts the versioned dashboard contract", () => {
+  assert.equal(validateDashboard(dashboard()).groups[0].id, "noaa-gfs");
+});
+
+test("rejects empty, unknown, and oversized dashboards", () => {
+  assert.throws(() => validateDashboard({}), /invalid pipeline dashboard/i);
+  assert.throws(
+    () => validateDashboard({ ...dashboard(), v: 2 }),
+    /invalid pipeline dashboard/i,
+  );
+  assert.throws(
+    () => validateDashboard({ ...dashboard(), groups: [] }),
+    /invalid pipeline dashboard/i,
+  );
+  const tooMany = dashboard();
+  tooMany.groups[0].products[0].recent_inits = Array.from(
+    { length: 11 },
+    (_, index) => ({ init_time: String(index) }),
+  );
+  assert.throws(() => validateDashboard(tooMany), /invalid pipeline product/i);
+});
+
+test("summarizes upstream agency advisories without changing pipeline state", () => {
+  assert.deepEqual(agencySummary([]), {
+    state: "nominal",
+    label: "nominal",
+  });
+  assert.deepEqual(
+    agencySummary([
+      { agency: "noaa" },
+      { agency: "noaa" },
+      { agency: "ecmwf" },
+    ]),
+    {
+      state: "advisory",
+      label: "NOAA, ECMWF advisories",
+    },
+  );
+});
+
+test("status pages share the pipeline and webhooks subnav", () => {
+  const status = readFileSync(
+    new URL("../content/status.njk", import.meta.url),
+    "utf8",
+  );
+  const pipeline = readFileSync(
+    new URL("../content/status-pipeline.njk", import.meta.url),
+    "utf8",
+  );
+  const subnav = readFileSync(
+    new URL("../_includes/status-subnav.njk", import.meta.url),
+    "utf8",
+  );
+
+  assert.match(status, /include "status-subnav\.njk"/);
+  assert.match(status, /href="\/status\/pipeline\/"/);
+  assert.match(pipeline, /include "status-subnav\.njk"/);
+  assert.match(subnav, /pipeline/);
+  assert.match(subnav, /https:\/\/status\.dynamical\.org\/webhooks/);
+});
+
+test("pipeline page links to webhooks and the integration guide", () => {
+  const template = readFileSync(
+    new URL("../content/status-pipeline.njk", import.meta.url),
+    "utf8",
+  );
+
+  assert.match(template, /https:\/\/status\.dynamical\.org\/webhooks/);
+  assert.match(template, /\/research\/when-the-forecast-is-ready\//);
+  assert.match(
+    template,
+    /weather agencies[\s\S]*pipeline-time-toggle/,
+  );
+});

--- a/test/status.test.mjs
+++ b/test/status.test.mjs
@@ -285,4 +285,8 @@ test("status page uses the requested heading and replaces stale as-of copy", () 
     STALE_MESSAGE,
     "Stale: status page experiencing delayed updates",
   );
+  assert.match(
+    template,
+    /#status-as-of\.status-stale\s*\{\s*color: var\(--pill-degraded-bg\)/,
+  );
 });


### PR DESCRIPTION
## Goal

Serve the live wxopticon pipeline from Eleventy at `/status/pipeline/`, with operational state fetched client-side from wxopticon's public R2 artifacts.

## Success criteria

- [x] Render the pipeline at `/status/pipeline/` with no Modal renderer in its read path.
- [x] Link to the pipeline from `/status/`.
- [x] Render a shared `pipeline | webhooks` subnav beneath the status header.
- [x] Put upstream-agency status beside the timezone selector.
- [x] Link the pipeline page to webhooks and the integration guide.
- [x] Preserve live polling, stale/error behavior, ETA countdowns, details, and history.
- [x] Surface upstream hosts on product rows and linked dissemination advisories in context.
- [x] Add a deterministic failure fixture and unit coverage.
- [x] Match the status-page stale warning to its amber rule in light and dark themes.
- [x] Run the full JavaScript suite and both fixture and production builds.

## Design

Eleventy emits a static shell; it does not fetch R2 at build time. The browser polls `dashboard.json` directly every 15 seconds, validates the versioned payload, and retains the last good view across transient failures. Existing immutable rich history snapshots remain available for the operator history scrubber.

Upstream advisories are contextual pipeline evidence, not a health input for the main dynamical.org status verdict. Source hosts appear with each product; active advisories are linked and attached to affected rows.

`npm run start:pipeline` serves a restamped failure fixture containing a failed run, a delayed in-flight run, and a NOAA advisory.

## Validation

- 46 Node tests passed
- JavaScript syntax and fixture JSON validation passed
- Fixture Eleventy build passed
- Production Eleventy build passed

## Rollout

Depends on dynamical-org/wxopticon#112. Deploy this page after `dashboard.json` is live and before merging dynamical-org/wxopticon#113.

## Retro

The public live path is browser-to-R2, with no Modal page renderer. The build stays deployable during an R2 outage, and fixture mode makes failure states reviewable without mutating production data.