### PR TITLE
List the static status pages

### DIFF
--- a/_includes/base.njk
+++ b/_includes/base.njk
@@ -115,7 +115,7 @@
         <li><a href="/updates">updates</a></li>
         <li><a href="/about">about</a></li>
         <li><a href="/podcast">podcast</a></li>
-        <li><a href="https://status.dynamical.org">status</a></li>
+        <li><a href="/status/">status</a></li>
       </ul>
     </nav>
     {{ content | safe }}
@@ -129,7 +129,7 @@
             <li><a href="/updates">Updates</a></li>
             <li><a href="/catalog">Catalog</a></li>
             <li><a href="/podcast">Podcast</a></li>
-            <li><a href="https://status.dynamical.org">Status</a></li>
+            <li><a href="/status/">Status</a></li>
             <li><a href="/about">About</a></li>
           </ul>
         </div>

--- a/content/status-pipeline.njk
+++ b/content/status-pipeline.njk
@@ -3,8 +3,6 @@ layout: base.njk
 title: data product pipeline status
 description: Per-model production status and upstream forecast arrival timing.
 permalink: /status/pipeline/
-noindex: true
-sitemap: false
 hideLatestPopup: true
 statusSection: pipeline
 pageStylesheet: /pipeline.css

--- a/content/status.njk
+++ b/content/status.njk
@@ -3,12 +3,6 @@ layout: base.njk
 title: status
 description: Current health of dynamical.org public endpoints and tools.
 permalink: /status/
-# Unlisted for the first iteration: reachable by direct URL, but absent from the
-# nav, the footer, sitemap.xml, and llms.txt. Deliberately not disallowed in
-# robots.txt — that file is public, so listing the path there would advertise the
-# very URL this is keeping quiet. noindex covers the crawler case.
-noindex: true
-sitemap: false
 hideLatestPopup: true
 statusIncidentFeedEnabled: true
 ---

--- a/test/pipeline.test.mjs
+++ b/test/pipeline.test.mjs
@@ -70,6 +70,10 @@ test("summarizes upstream agency advisories without changing pipeline state", ()
 });
 
 test("status pages share the pipeline and webhooks subnav", () => {
+  const base = readFileSync(
+    new URL("../_includes/base.njk", import.meta.url),
+    "utf8",
+  );
   const status = readFileSync(
     new URL("../content/status.njk", import.meta.url),
     "utf8",
@@ -85,9 +89,12 @@ test("status pages share the pipeline and webhooks subnav", () => {
 
   assert.match(status, /include "status-subnav\.njk"/);
   assert.match(status, /href="\/status\/pipeline\/"/);
+  assert.doesNotMatch(status, /noindex: true|sitemap: false/);
   assert.match(pipeline, /include "status-subnav\.njk"/);
+  assert.doesNotMatch(pipeline, /noindex: true|sitemap: false/);
   assert.match(subnav, /pipeline/);
   assert.match(subnav, /https:\/\/status\.dynamical\.org\/webhooks/);
+  assert.equal((base.match(/href="\/status\/"/g) ?? []).length, 2);
 });
 
 test("pipeline page links to webhooks and the integration guide", () => {


### PR DESCRIPTION
## Issue

The status rollout is public, but the site still retained its pre-launch discovery settings: navigation linked through the retired Modal host and both static status pages opted out of indexing and the sitemap.

## Change

- Link the primary nav and footer directly to `/status/`.
- Remove `noindex` and `sitemap: false` from `/status/` and `/status/pipeline/`.
- Remove the obsolete pre-launch comment.
- Test the direct links and discovery frontmatter.

## Validation

- `npm test` — 46 passed
- `npm run build` — production Eleventy build passed
- Generated sitemap contains both status URLs and neither page emits `noindex`.