### PR TITLE
Clarify status navigation and pipeline timezones

### DIFF
--- a/_includes/status-subnav.njk
+++ b/_includes/status-subnav.njk
@@ -1,4 +1,6 @@
 <nav class="status-subnav" aria-label="Status">
+  <a href="/status/"{% if statusSection == "uptime" %} aria-current="page"{% endif %}>uptime</a>
+  <span aria-hidden="true">|</span>
   <a href="/status/pipeline/"{% if statusSection == "pipeline" %} aria-current="page"{% endif %}>pipeline</a>
   <span aria-hidden="true">|</span>
   <a href="https://status.dynamical.org/webhooks">webhooks</a>

--- a/content/status-pipeline.njk
+++ b/content/status-pipeline.njk
@@ -42,6 +42,9 @@ pageStylesheet: /pipeline.css
     <button type="button" id="pipeline-history-toggle" aria-expanded="false"
       aria-controls="pipeline-history-panel">history</button>
   </div>
+  <p class="pipeline-legend">
+    Dashed segment: forecast horizon not yet published. Dashed whole bar: no probe visibility.
+  </p>
 
   <div id="pipeline-history-panel" hidden>
     <span data-slot="scrub-label" aria-hidden="true">—</span>

--- a/content/status.njk
+++ b/content/status.njk
@@ -5,6 +5,7 @@ description: Current health of dynamical.org public endpoints and tools.
 permalink: /status/
 hideLatestPopup: true
 statusIncidentFeedEnabled: true
+statusSection: uptime
 ---
 
 <style>
@@ -172,10 +173,10 @@ statusIncidentFeedEnabled: true
   <p id="status-history" role="status" hidden></p>
 
   <div class="status-groups" id="status-groups" hidden style="margin-top: 4rem;">
-    <section aria-labelledby="endpoints-heading">
+    <section aria-labelledby="core-heading">
       <header>
-        <h2 id="endpoints-heading">Endpoints</h2>
-        <p>The data-serving path</p>
+        <h2 id="core-heading">Core</h2>
+        <p>Data-serving and website</p>
       </header>
       <ul class="index-list status-list" id="status-endpoints"></ul>
     </section>

--- a/public/pipeline.css
+++ b/public/pipeline.css
@@ -36,6 +36,12 @@
   margin: 3rem 0 2rem;
 }
 
+.pipeline-legend {
+  margin: -1.2rem 0 2rem;
+  color: var(--muted-text);
+  font-size: 1.1rem;
+}
+
 .pipeline-controls-primary {
   justify-content: flex-start;
 }

--- a/public/pipeline.mjs
+++ b/public/pipeline.mjs
@@ -99,17 +99,36 @@ function formatDuration(seconds) {
   return `${Math.floor(seconds / 60)}m ${seconds % 60}s`;
 }
 
-function initShort(timestamp) {
-  const date = new Date(timestamp);
-  const month = String(date.getUTCMonth() + 1).padStart(2, "0");
-  const day = String(date.getUTCDate()).padStart(2, "0");
-  const hour = String(date.getUTCHours()).padStart(2, "0");
-  return `${month}-${day} ${hour}z`;
+export function initParts(timestamp, timeZone = "UTC") {
+  const parts = new Intl.DateTimeFormat("en-US", {
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    hourCycle: "h23",
+    timeZone,
+    timeZoneName: "short",
+  }).formatToParts(new Date(timestamp));
+  const part = (type) =>
+    parts.find((candidate) => candidate.type === type)?.value;
+  const hour = part("hour");
+  return {
+    date: `${part("month")}-${part("day")}`,
+    time: timeZone === "UTC" ? `${hour}z` : `${hour} ${part("timeZoneName")}`,
+  };
 }
 
-function initLabel(timestamp) {
-  const [date, hour] = initShort(timestamp).split(" ");
-  return element("span", null, [element("strong", null, date), hour]);
+function selectedTimeZone(local) {
+  return local ? Intl.DateTimeFormat().resolvedOptions().timeZone : "UTC";
+}
+
+function initShort(timestamp, local) {
+  const { date, time } = initParts(timestamp, selectedTimeZone(local));
+  return `${date} ${time}`;
+}
+
+function initLabel(timestamp, local) {
+  const { date, time } = initParts(timestamp, selectedTimeZone(local));
+  return element("span", null, [element("strong", null, date), time]);
 }
 
 function formatTime(timestamp, local) {
@@ -151,13 +170,13 @@ function groupSlices(groups) {
   });
 }
 
-function barTooltip(init) {
+function barTooltip(init, local) {
   if (init.status === "unobserved") {
-    return `${initShort(init.init_time)} · no probe visibility; not a publication failure`;
+    return `${initShort(init.init_time, local)} · no probe visibility; not a publication failure`;
   }
   const state = init.timing ? `${init.status} · ${init.timing}` : init.status;
   return [
-    initShort(init.init_time),
+    initShort(init.init_time, local),
     state,
     init.completion_pct == null
       ? null
@@ -168,7 +187,7 @@ function barTooltip(init) {
     .join(" · ");
 }
 
-function renderBar(init) {
+function renderBar(init, local) {
   const track = element("div", { class: "pipeline-bar-track" });
   if (init.lead_groups?.length) {
     let bottom = 0;
@@ -179,6 +198,10 @@ function renderBar(init) {
           class: `pipeline-bar-segment g-${group.status}`,
           "data-timing": group.timing,
           style: `--band-height:${group.height}%;--band-bottom:${bottom}%;--fill:${group.fill}%`,
+          title:
+            group.status === "pending"
+              ? "Forecast horizon not yet published"
+              : null,
         },
         element("div", { class: "pipeline-bar-segment-fill" }),
       );
@@ -199,11 +222,15 @@ function renderBar(init) {
       class: "pipeline-bar",
       "data-status": init.status,
       "data-timing": init.timing,
-      title: barTooltip(init),
+      title: barTooltip(init, local),
     },
     [
       track,
-      element("div", { class: "pipeline-bar-label" }, initLabel(init.init_time)),
+      element(
+        "div",
+        { class: "pipeline-bar-label" },
+        initLabel(init.init_time, local),
+      ),
     ],
   );
 }
@@ -340,11 +367,11 @@ function buildDetails(product) {
   ]);
 }
 
-function hydrateRow(row, product, now) {
+function hydrateRow(row, product, now, local) {
   row.querySelector('[data-slot="grid"]').replaceChildren(
-    ...product.recent_inits.slice(-10).map(renderBar),
+    ...product.recent_inits.slice(-10).map((init) => renderBar(init, local)),
   );
-  hydrateEta(row, product, now);
+  hydrateEta(row, product, now, local);
 
   const button = row.querySelector('[data-slot="details-button"]');
   const details = row.querySelector('[data-slot="details"]');
@@ -357,7 +384,7 @@ function hydrateRow(row, product, now) {
   }
 }
 
-function hydrateEta(row, product, now) {
+function hydrateEta(row, product, now, local) {
   const initSlot = row.querySelector('[data-slot="eta-init"]');
   const stateSlot = row.querySelector('[data-slot="eta-state"]');
   const lineSlot = row.querySelector('[data-slot="eta-line"]');
@@ -367,7 +394,7 @@ function hydrateEta(row, product, now) {
     stateSlot.hidden = true;
     lineSlot.hidden = true;
   } else {
-    initSlot.textContent = initShort(target.initTime);
+    initSlot.textContent = initShort(target.initTime, local);
     stateSlot.hidden = false;
     if (target.running) {
       const observed = (target.init?.completion_pct ?? 0) > 0;
@@ -438,12 +465,13 @@ function renderAdvisories(app, advisories, rows) {
 }
 
 function renderSnapshot(app, snapshot, rows, now) {
+  const local = document.body.classList.contains("pipeline-time-local");
   app
     .querySelector('[data-slot="generated-at"]')
     .replaceChildren(timeNode(snapshot.generated_at));
   for (const product of productsOf(snapshot)) {
     const row = rows.get(product.id);
-    if (row) hydrateRow(row, product, now);
+    if (row) hydrateRow(row, product, now, local);
   }
   renderAdvisories(app, snapshot.advisories ?? [], rows);
 }
@@ -476,12 +504,27 @@ function start(app) {
   let pollTimer = null;
   let countdownTimer = null;
   let structureSignature = null;
+  let displayedSnapshot = null;
+  let displayedAt = null;
+
+  function displaySnapshot(snapshot, now) {
+    displayedSnapshot = snapshot;
+    displayedAt = now;
+    renderSnapshot(app, snapshot, rows, now);
+  }
 
   function setTimeMode(local, persist) {
     document.body.classList.toggle("pipeline-time-local", local);
     timeToggle.value = local ? "local" : "utc";
     if (persist) localStorage.setItem(TIME_MODE_KEY, local ? "local" : "utc");
-    if (latest && mode === "live") renderSnapshot(app, latest, rows, Date.now());
+    if (displayedSnapshot) {
+      displaySnapshot(
+        displayedSnapshot,
+        mode === "live" ? Date.now() : displayedAt,
+      );
+    }
+    const selected = mode === "scrub" ? selectedTimestamp() : null;
+    if (selected) updateScrubLabel(selected);
   }
 
   function showError(message) {
@@ -503,7 +546,7 @@ function start(app) {
       latest.window_days ?? "—";
     ribbon.hidden =
       Date.now() - Date.parse(latest.generated_at) <= STALE_AFTER_MS;
-    renderSnapshot(app, latest, rows, Date.now());
+    displaySnapshot(latest, Date.now());
   }
 
   async function fetchJson(url, cache = "default") {
@@ -560,12 +603,7 @@ function start(app) {
         "no-cache",
       );
       if (mode !== "scrub") return;
-      renderSnapshot(
-        app,
-        snapshot,
-        rows,
-        Date.parse(snapshot.generated_at),
-      );
+      displaySnapshot(snapshot, Date.parse(snapshot.generated_at));
       scrubError.hidden = true;
     } catch (error) {
       scrubError.hidden = false;
@@ -611,9 +649,10 @@ function start(app) {
 
   function updateLiveCountdowns() {
     if (mode !== "live" || !latest) return;
+    const local = document.body.classList.contains("pipeline-time-local");
     for (const product of productsOf(latest)) {
       const row = rows.get(product.id);
-      if (row) hydrateEta(row, product, Date.now());
+      if (row) hydrateEta(row, product, Date.now(), local);
     }
   }
 

--- a/test/pipeline.test.mjs
+++ b/test/pipeline.test.mjs
@@ -4,6 +4,7 @@ import test from "node:test";
 
 import {
   agencySummary,
+  initParts,
   validateDashboard,
 } from "../public/pipeline.mjs";
 
@@ -69,7 +70,16 @@ test("summarizes upstream agency advisories without changing pipeline state", ()
   );
 });
 
-test("status pages share the pipeline and webhooks subnav", () => {
+test("formats init labels in UTC and the selected local timezone", () => {
+  const timestamp = "2026-07-26T00:00:00Z";
+  assert.deepEqual(initParts(timestamp), { date: "07-26", time: "00z" });
+  assert.deepEqual(initParts(timestamp, "America/Chicago"), {
+    date: "07-25",
+    time: "19 CDT",
+  });
+});
+
+test("status pages share the uptime, pipeline, and webhooks subnav", () => {
   const base = readFileSync(
     new URL("../_includes/base.njk", import.meta.url),
     "utf8",
@@ -88,10 +98,12 @@ test("status pages share the pipeline and webhooks subnav", () => {
   );
 
   assert.match(status, /include "status-subnav\.njk"/);
+  assert.match(status, /statusSection: uptime/);
   assert.match(status, /href="\/status\/pipeline\/"/);
   assert.doesNotMatch(status, /noindex: true|sitemap: false/);
   assert.match(pipeline, /include "status-subnav\.njk"/);
   assert.doesNotMatch(pipeline, /noindex: true|sitemap: false/);
+  assert.match(subnav, />uptime</);
   assert.match(subnav, /pipeline/);
   assert.match(subnav, /https:\/\/status\.dynamical\.org\/webhooks/);
   assert.equal((base.match(/href="\/status\/"/g) ?? []).length, 2);
@@ -109,4 +121,16 @@ test("pipeline page links to webhooks and the integration guide", () => {
     template,
     /weather agencies[\s\S]*pipeline-time-toggle/,
   );
+  assert.match(template, /Dashed segment: forecast horizon not yet published/);
+});
+
+test("uptime groups data-serving and website checks under Core", () => {
+  const template = readFileSync(
+    new URL("../content/status.njk", import.meta.url),
+    "utf8",
+  );
+  assert.match(template, />Core</);
+  assert.match(template, />Data-serving and website</);
+  assert.doesNotMatch(template, />Endpoints</);
+  assert.doesNotMatch(template, /The data-serving path/);
 });


### PR DESCRIPTION
## Changes

- Make the status subnav `uptime | pipeline | webhooks`, with the current page marked.
- Rename the uptime group from “Endpoints” to “Core” and its description to “Data-serving and website.”
- Explain that a dashed segment is an unpublished forecast horizon and an entirely dashed bar means no probe visibility.
- Make the timezone selector rerender bar labels, run headings, hover text, ETAs, updated timestamps, and historical snapshots.

## Validation

- `npm test` — 48 passed
- `node --check public/pipeline.mjs`
- Production Eleventy build passed
- UTC/local formatting has a deterministic regression test across a date boundary.