### PR TITLE
Lighten uptime section structure

### DIFF
--- a/content/status.njk
+++ b/content/status.njk
@@ -41,14 +41,9 @@ statusSection: uptime
   .status-down {
     border-top-color: var(--pill-down-bg);
   }
-  .status-groups section > header {
-    border-bottom: 1px solid var(--border-color);
-  }
-  .status-groups section > header p {
-    color: var(--muted-text);
-  }
   .status-list {
     --index-row-padding: 1rem;
+    --index-row-border: 0;
   }
   .status-list header {
     display: flex;
@@ -176,7 +171,6 @@ statusSection: uptime
     <section aria-labelledby="core-heading">
       <header>
         <h2 id="core-heading">Core</h2>
-        <p>Data-serving and website</p>
       </header>
       <ul class="index-list status-list" id="status-endpoints"></ul>
     </section>
@@ -184,7 +178,6 @@ statusSection: uptime
     <section aria-labelledby="tools-heading" style="margin-top: 4rem;">
       <header>
         <h2 id="tools-heading">Tools &amp; resources</h2>
-        <p>Built on top of the data</p>
       </header>
       <ul class="index-list status-list" id="status-tools"></ul>
     </section>

--- a/test/pipeline.test.mjs
+++ b/test/pipeline.test.mjs
@@ -124,13 +124,16 @@ test("pipeline page links to webhooks and the integration guide", () => {
   assert.match(template, /Dashed segment: forecast horizon not yet published/);
 });
 
-test("uptime groups data-serving and website checks under Core", () => {
+test("uptime uses light section headings without subtitles or rules", () => {
   const template = readFileSync(
     new URL("../content/status.njk", import.meta.url),
     "utf8",
   );
   assert.match(template, />Core</);
-  assert.match(template, />Data-serving and website</);
+  assert.match(template, /--index-row-border: 0/);
   assert.doesNotMatch(template, />Endpoints</);
+  assert.doesNotMatch(template, /Data-serving and website/);
+  assert.doesNotMatch(template, /Built on top of the data/);
   assert.doesNotMatch(template, /The data-serving path/);
+  assert.doesNotMatch(template, /\.status-groups section > header/);
 });


### PR DESCRIPTION
Remove the Core and Tools section subtitles, the category header rules, and dotted row separators. The operational-state rule and 90-day bar outlines remain because they communicate status rather than page structure.

Validation: `npm test` — 48 passed.