### PR TITLE
Lighten pipeline status chrome

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -118,7 +118,7 @@ module.exports = function (eleventyConfig) {
   // Gated on its own flag, not on STATUS_URL. STATUS_URL exists so the page can
   // be pointed at a real alternate feed (staging, a moved bucket), and gating on
   // it would mean any such build also published fabricated status data at a
-  // public URL. Only `npm run start:status` sets STATUS_FIXTURE.
+  // public URL. Only the local status preview scripts set STATUS_FIXTURE.
   //
   // Restamped with build time rather than copied: the committed fixtures pin their
   // timestamps so tests can assert on them, which would otherwise make the

--- a/_includes/base.njk
+++ b/_includes/base.njk
@@ -107,15 +107,15 @@
     </script>{% endif %}
   </head>
   <body>
-    <nav aria-label="Primary">
+    <nav class="primary-nav" aria-label="Primary">
       <ul>
         <li><a href="/" class="nav-lockup"><picture><source srcset="https://assets.dynamical.org/identity/logo/lockup/lockup-white.svg" media="(prefers-color-scheme: dark)"><img src="https://assets.dynamical.org/identity/logo/lockup/lockup-black.svg" alt="dynamical.org" height="30"></picture></a></li>
-        <li><a href="/catalog">catalog</a></li>
-        <li><a href="/#research">research</a></li>
-        <li><a href="/updates">updates</a></li>
-        <li><a href="/about">about</a></li>
-        <li><a href="/podcast">podcast</a></li>
-        <li><a href="/status/">status</a></li>
+        <li><a href="/catalog"{% if page.url == "/catalog/" or "/catalog/" in page.url %} aria-current="page"{% endif %}>catalog</a></li>
+        <li><a href="/#research"{% if "/research/" in page.url %} aria-current="page"{% endif %}>research</a></li>
+        <li><a href="/updates"{% if page.url == "/updates/" or "/updates/" in page.url %} aria-current="page"{% endif %}>updates</a></li>
+        <li><a href="/about"{% if page.url == "/about/" %} aria-current="page"{% endif %}>about</a></li>
+        <li><a href="/podcast"{% if page.url == "/podcast/" or "/podcast/" in page.url %} aria-current="page"{% endif %}>podcast</a></li>
+        <li><a href="/status/"{% if page.url == "/status/" or "/status/" in page.url %} aria-current="page"{% endif %}>status</a></li>
       </ul>
     </nav>
     {{ content | safe }}

--- a/_includes/status-subnav.njk
+++ b/_includes/status-subnav.njk
@@ -1,10 +1,16 @@
-<nav class="status-subnav" aria-label="Status">
-  <a href="/status/"{% if statusSection == "uptime" %} aria-current="page"{% endif %}>uptime</a>
-  <span aria-hidden="true">|</span>
-  <a href="/status/pipeline/"{% if statusSection == "pipeline" %} aria-current="page"{% endif %}>pipeline</a>
-  <span aria-hidden="true">|</span>
-  <a href="https://status.dynamical.org/webhooks" target="_blank" rel="noopener">pipeline webhooks</a>
-</nav>
+{% macro statusSubnav(statusSection, statusFeed, pipelineAssetsBase) %}
+<div class="status-subnav-row">
+  <nav class="status-subnav" aria-label="Status">
+    <a href="/status/"{% if statusSection == "uptime" %} aria-current="page"{% endif %}>uptime</a>
+    <span aria-hidden="true">|</span>
+    <a href="/status/pipeline/"{% if statusSection == "pipeline" %} aria-current="page"{% endif %}>pipeline</a>
+    <span aria-hidden="true">|</span>
+    <a href="https://status.dynamical.org/webhooks" target="_blank" rel="noopener">pipeline webhooks</a>
+  </nav>
+  <div class="status-page-meta">
+    {{ caller() }}
+  </div>
+</div>
 <div class="status-controls">
   <ul class="status-health" aria-label="Current health" aria-live="polite"
     data-status-url="{{ statusFeed }}"
@@ -24,3 +30,4 @@
       aria-controls="pipeline-history-panel">history</button>
   {% endif %}
 </div>
+{% endmacro %}

--- a/_includes/status-subnav.njk
+++ b/_includes/status-subnav.njk
@@ -3,7 +3,7 @@
   <span aria-hidden="true">|</span>
   <a href="/status/pipeline/"{% if statusSection == "pipeline" %} aria-current="page"{% endif %}>pipeline</a>
   <span aria-hidden="true">|</span>
-  <a href="https://status.dynamical.org/webhooks">pipeline webhooks</a>
+  <a href="https://status.dynamical.org/webhooks" target="_blank" rel="noopener">pipeline webhooks</a>
 </nav>
 <div class="status-controls">
   <ul class="status-health" aria-label="Current health" aria-live="polite"

--- a/_includes/status-subnav.njk
+++ b/_includes/status-subnav.njk
@@ -3,7 +3,7 @@
   <span aria-hidden="true">|</span>
   <a href="/status/pipeline/"{% if statusSection == "pipeline" %} aria-current="page"{% endif %}>pipeline</a>
   <span aria-hidden="true">|</span>
-  <a href="https://status.dynamical.org/webhooks">webhooks</a>
+  <a href="https://status.dynamical.org/webhooks">pipeline webhooks</a>
 </nav>
 <div class="status-controls">
   <ul class="status-health" aria-label="Current health" aria-live="polite"

--- a/_includes/status-subnav.njk
+++ b/_includes/status-subnav.njk
@@ -1,12 +1,12 @@
 {% macro statusSubnav(statusSection, statusFeed, pipelineAssetsBase) %}
 <div class="status-subnav-row">
-  <nav class="status-subnav" aria-label="Status">
+  <div class="status-subnav" role="navigation" aria-label="Status">
     <a href="/status/"{% if statusSection == "uptime" %} aria-current="page"{% endif %}>uptime</a>
     <span aria-hidden="true">|</span>
     <a href="/status/pipeline/"{% if statusSection == "pipeline" %} aria-current="page"{% endif %}>pipeline</a>
     <span aria-hidden="true">|</span>
     <a href="https://status.dynamical.org/webhooks" target="_blank" rel="noopener">pipeline webhooks</a>
-  </nav>
+  </div>
   <div class="status-page-meta">
     {{ caller() }}
   </div>

--- a/_includes/status-subnav.njk
+++ b/_includes/status-subnav.njk
@@ -5,3 +5,23 @@
   <span aria-hidden="true">|</span>
   <a href="https://status.dynamical.org/webhooks">webhooks</a>
 </nav>
+<div class="status-controls">
+  <ul class="status-health" aria-label="Current health" aria-live="polite"
+    data-status-url="{{ statusFeed }}"
+    data-pipeline-url="{{ pipelineAssetsBase }}/dashboard.json">
+    <li data-slot="system-health" data-state="unavailable">
+      <span aria-hidden="true"></span>
+      <span data-health-label>systems</span> <strong>checking…</strong>
+    </li>
+    <li data-slot="agency-health" data-state="unavailable">
+      <span aria-hidden="true"></span>
+      <span data-health-label>weather agencies</span> <strong>checking…</strong>
+    </li>
+  </ul>
+  {% if statusSection == "pipeline" %}
+    <div class="pipeline-controls-actions">
+      <button type="button" id="pipeline-history-toggle" aria-expanded="false"
+        aria-controls="pipeline-history-panel">history</button>
+    </div>
+  {% endif %}
+</div>

--- a/_includes/status-subnav.njk
+++ b/_includes/status-subnav.njk
@@ -19,9 +19,7 @@
     </li>
   </ul>
   {% if statusSection == "pipeline" %}
-    <div class="pipeline-controls-actions">
-      <button type="button" id="pipeline-history-toggle" aria-expanded="false"
-        aria-controls="pipeline-history-panel">history</button>
-    </div>
+    <button type="button" id="pipeline-history-toggle" aria-expanded="false"
+      aria-controls="pipeline-history-panel">history</button>
   {% endif %}
 </div>

--- a/_includes/status-subnav.njk
+++ b/_includes/status-subnav.njk
@@ -15,7 +15,8 @@
     </li>
     <li data-slot="agency-health" data-state="unavailable">
       <span aria-hidden="true"></span>
-      <span data-health-label>weather agencies</span> <strong>checking…</strong>
+      <span data-health-label>upstream forecast sources</span>
+      <strong>checking…</strong>
     </li>
   </ul>
   {% if statusSection == "pipeline" %}

--- a/content/status-pipeline.njk
+++ b/content/status-pipeline.njk
@@ -10,22 +10,19 @@ pageStylesheet: /pipeline.css
 
 <main class="content pipeline-page" id="pipeline-app"
   data-assets-base="{{ pipelineAssetsBase }}">
-  <header class="status-page-heading">
-    <h1>dynamical.org status</h1>
-    <div class="status-page-meta">
-      <p class="status-page-updated">
-        Updated <span data-slot="generated-at">—</span>
-        <label data-slot="time-control" hidden>
-          <span class="visually-hidden">Time zone</span>
-          <select class="status-time-toggle" id="status-time-toggle">
-            <option value="local">—</option>
-            <option value="utc">UTC</option>
-          </select>
-        </label>
-      </p>
-    </div>
-  </header>
-  {% include "status-subnav.njk" %}
+  {% from "status-subnav.njk" import statusSubnav %}
+  {% call statusSubnav(statusSection, statusFeed, pipelineAssetsBase) %}
+    <p class="status-page-updated">
+      Updated <span data-slot="generated-at">—</span>
+      <label data-slot="time-control" hidden>
+        <span class="visually-hidden">Time zone</span>
+        <select class="status-time-toggle" id="status-time-toggle">
+          <option value="local">—</option>
+          <option value="utc">UTC</option>
+        </select>
+      </label>
+    </p>
+  {% endcall %}
 
   <div class="pipeline-ribbon" data-slot="ribbon" hidden>
     Pipeline data is more than 10 minutes old — it may be stalled.

--- a/content/status-pipeline.njk
+++ b/content/status-pipeline.njk
@@ -9,7 +9,7 @@ pageStylesheet: /pipeline.css
 ---
 
 <main class="content pipeline-page" id="pipeline-app"
-  data-assets-base="{{ pipelineAssetsBase }}">
+  data-assets-base="{{ pipelineAssetsBase }}" style="margin-top: 4rem;">
   {% from "status-subnav.njk" import statusSubnav %}
   {% call statusSubnav(statusSection, statusFeed, pipelineAssetsBase) %}
     <p class="status-page-updated">
@@ -53,14 +53,6 @@ pageStylesheet: /pipeline.css
   <div data-slot="advisories"></div>
   <div data-slot="groups" aria-live="polite">
     <p data-slot="loading">Loading pipeline status…</p>
-  </div>
-
-  <div class="pipeline-footer">
-    <span><span data-slot="window-days">—</span>-day rolling window · polls every 15s</span>
-    <span>
-      <a href="https://status.dynamical.org/webhooks">webhooks</a> ·
-      <a href="/research/when-the-forecast-is-ready/">integration guide</a>
-    </span>
   </div>
 
   <noscript><p>Pipeline status requires JavaScript.</p></noscript>

--- a/content/status-pipeline.njk
+++ b/content/status-pipeline.njk
@@ -12,7 +12,16 @@ pageStylesheet: /pipeline.css
   data-assets-base="{{ pipelineAssetsBase }}">
   <header class="status-page-heading">
     <h1>dynamical.org status</h1>
-    <p class="pipeline-updated">Updated <span data-slot="generated-at">—</span></p>
+    <div class="status-page-meta">
+      <p class="status-page-updated">Updated <span data-slot="generated-at">—</span></p>
+      <label>
+        <span class="visually-hidden">Time zone</span>
+        <select id="status-time-toggle">
+          <option value="local">Local time</option>
+          <option value="utc">Coordinated Universal Time (UTC)</option>
+        </select>
+      </label>
+    </div>
   </header>
   {% include "status-subnav.njk" %}
 
@@ -21,24 +30,6 @@ pageStylesheet: /pipeline.css
   </div>
   <div data-slot="banners" aria-live="polite"></div>
 
-  <div class="pipeline-controls">
-    <span class="pipeline-agencies" data-slot="agency-status" role="status"
-      title="NOAA, ECMWF, and DWD dissemination advisories">
-      <span class="pipeline-agency-dot" aria-hidden="true"></span>
-      weather agencies <strong>checking…</strong>
-    </span>
-    <div class="pipeline-controls-actions">
-      <label>
-        <span class="visually-hidden">Time zone</span>
-        <select id="pipeline-time-toggle">
-          <option value="utc">Coordinated Universal Time (UTC)</option>
-          <option value="local">Local time</option>
-        </select>
-      </label>
-      <button type="button" id="pipeline-history-toggle" aria-expanded="false"
-        aria-controls="pipeline-history-panel">history</button>
-    </div>
-  </div>
   <div class="pipeline-legend" aria-label="Pipeline bar legend">
     <span>
       <span class="pipeline-legend-mark pipeline-legend-mark--pending"

--- a/content/status-pipeline.njk
+++ b/content/status-pipeline.njk
@@ -13,14 +13,16 @@ pageStylesheet: /pipeline.css
   <header class="status-page-heading">
     <h1>dynamical.org status</h1>
     <div class="status-page-meta">
-      <p class="status-page-updated">Updated <span data-slot="generated-at">—</span></p>
-      <label>
-        <span class="visually-hidden">Time zone</span>
-        <select id="status-time-toggle">
-          <option value="local">Local time</option>
-          <option value="utc">Coordinated Universal Time (UTC)</option>
-        </select>
-      </label>
+      <p class="status-page-updated">
+        Updated <span data-slot="generated-at">—</span>
+        <label data-slot="time-control" hidden>
+          <span class="visually-hidden">Time zone</span>
+          <select class="status-time-toggle" id="status-time-toggle">
+            <option value="local">—</option>
+            <option value="utc">UTC</option>
+          </select>
+        </label>
+      </p>
     </div>
   </header>
   {% include "status-subnav.njk" %}

--- a/content/status-pipeline.njk
+++ b/content/status-pipeline.njk
@@ -16,21 +16,18 @@ pageStylesheet: /pipeline.css
   </header>
   {% include "status-subnav.njk" %}
 
-  <h2>Data product pipeline</h2>
-  <p>Forecast-run arrival timing from the upstream sources we use.</p>
-
   <div class="pipeline-ribbon" data-slot="ribbon" hidden>
     Pipeline data is more than 10 minutes old — it may be stalled.
   </div>
   <div data-slot="banners" aria-live="polite"></div>
 
   <div class="pipeline-controls">
-    <div class="pipeline-controls-primary">
-      <span class="pipeline-agencies" data-slot="agency-status" role="status"
-        title="NOAA, ECMWF, and DWD dissemination advisories">
-        <span class="pipeline-agency-dot" aria-hidden="true"></span>
-        weather agencies <strong>checking…</strong>
-      </span>
+    <span class="pipeline-agencies" data-slot="agency-status" role="status"
+      title="NOAA, ECMWF, and DWD dissemination advisories">
+      <span class="pipeline-agency-dot" aria-hidden="true"></span>
+      weather agencies <strong>checking…</strong>
+    </span>
+    <div class="pipeline-controls-actions">
       <label>
         <span class="visually-hidden">Time zone</span>
         <select id="pipeline-time-toggle">
@@ -38,13 +35,22 @@ pageStylesheet: /pipeline.css
           <option value="local">Local time</option>
         </select>
       </label>
+      <button type="button" id="pipeline-history-toggle" aria-expanded="false"
+        aria-controls="pipeline-history-panel">history</button>
     </div>
-    <button type="button" id="pipeline-history-toggle" aria-expanded="false"
-      aria-controls="pipeline-history-panel">history</button>
   </div>
-  <p class="pipeline-legend">
-    Dashed segment: forecast horizon not yet published. Dashed whole bar: no probe visibility.
-  </p>
+  <div class="pipeline-legend" aria-label="Pipeline bar legend">
+    <span>
+      <span class="pipeline-legend-mark pipeline-legend-mark--pending"
+        aria-hidden="true"></span>
+      forecast hours still expected
+    </span>
+    <span>
+      <span class="pipeline-legend-mark pipeline-legend-mark--unobserved"
+        aria-hidden="true"></span>
+      no monitoring data
+    </span>
+  </div>
 
   <div id="pipeline-history-panel" hidden>
     <span data-slot="scrub-label" aria-hidden="true">—</span>
@@ -59,13 +65,13 @@ pageStylesheet: /pipeline.css
     <p data-slot="loading">Loading pipeline status…</p>
   </div>
 
-  <footer class="pipeline-footer">
+  <div class="pipeline-footer">
     <span><span data-slot="window-days">—</span>-day rolling window · polls every 15s</span>
     <span>
       <a href="https://status.dynamical.org/webhooks">webhooks</a> ·
       <a href="/research/when-the-forecast-is-ready/">integration guide</a>
     </span>
-  </footer>
+  </div>
 
   <noscript><p>Pipeline status requires JavaScript.</p></noscript>
 </main>

--- a/content/status.njk
+++ b/content/status.njk
@@ -120,22 +120,19 @@ statusSection: uptime
 
 <main class="content" data-status-page data-status-url="{{ statusFeed }}"
   data-log-url="{{ statusLogBase }}">
-  <header class="status-page-heading">
-    <h1>dynamical.org status</h1>
-    <div class="status-page-meta">
-      <p class="status-page-updated" id="status-as-of" role="status">
-        <span data-slot="status-updated">As of —</span>
-        <label data-slot="time-control" hidden>
-          <span class="visually-hidden">Time zone</span>
-          <select class="status-time-toggle" id="status-time-toggle">
-            <option value="local">—</option>
-            <option value="utc">UTC</option>
-          </select>
-        </label>
-      </p>
-    </div>
-  </header>
-  {% include "status-subnav.njk" %}
+  {% from "status-subnav.njk" import statusSubnav %}
+  {% call statusSubnav(statusSection, statusFeed, pipelineAssetsBase) %}
+    <p class="status-page-updated" id="status-as-of" role="status">
+      <span data-slot="status-updated">As of —</span>
+      <label data-slot="time-control" hidden>
+        <span class="visually-hidden">Time zone</span>
+        <select class="status-time-toggle" id="status-time-toggle">
+          <option value="local">—</option>
+          <option value="utc">UTC</option>
+        </select>
+      </label>
+    </p>
+  {% endcall %}
 
   <section id="status-overall" aria-label="Service status" aria-live="polite">
     <p id="status-summary">Loading the latest monitor results.</p>

--- a/content/status.njk
+++ b/content/status.njk
@@ -9,37 +9,11 @@ statusSection: uptime
 ---
 
 <style>
-  .status-page-heading {
-    display: flex;
-    align-items: baseline;
-    flex-wrap: wrap;
-    gap: 0.5rem 2rem;
-    margin-top: 4rem;
-  }
-  .status-page-heading h1,
-  .status-page-heading p {
-    margin: 0;
-  }
-  #status-as-of {
-    margin-left: auto;
-    text-align: right;
-  }
   #status-as-of.status-stale {
     color: var(--pill-degraded-bg);
   }
   .status-overall {
     margin-top: 1rem;
-    padding-top: 1.6rem;
-    border-top: 0.6rem solid var(--muted-text);
-  }
-  .status-operational {
-    border-top-color: var(--pill-available-bg);
-  }
-  .status-degraded {
-    border-top-color: var(--pill-degraded-bg);
-  }
-  .status-down {
-    border-top-color: var(--pill-down-bg);
   }
   .status-list {
     --index-row-padding: 1rem;
@@ -89,20 +63,23 @@ statusSection: uptime
   }
   .status-bars > * {
     flex: 1 1 0;
-    border: 1px solid var(--pill-muted-border);
+    border: 1px dotted var(--pill-muted-border);
     background: transparent;
   }
   .status-bars > a {
     text-decoration: none;
   }
   .status-bars [data-day="unknown"] {
+    border-style: solid;
     border-color: var(--pill-down-bg);
   }
   .status-bars [data-day="operational"] {
+    border-style: solid;
     border-color: var(--pill-available-bg);
     background: var(--pill-available-bg);
   }
   .status-bars [data-day="down"] {
+    border-style: solid;
     border-color: var(--pill-down-bg);
     background: var(--pill-down-bg);
   }
@@ -140,9 +117,6 @@ statusSection: uptime
     color: var(--muted-text);
   }
   @media (max-width: 680px) {
-    #status-as-of {
-      flex-basis: 100%;
-    }
     .status-list header {
       flex-direction: column;
       align-items: start;
@@ -155,12 +129,21 @@ statusSection: uptime
   data-log-url="{{ statusLogBase }}">
   <header class="status-page-heading">
     <h1>dynamical.org status</h1>
-    <p id="status-as-of" role="status"><strong>As of —</strong></p>
+    <div class="status-page-meta">
+      <p class="status-page-updated" id="status-as-of" role="status">As of —</p>
+      <label>
+        <span class="visually-hidden">Time zone</span>
+        <select id="status-time-toggle">
+          <option value="local">Local time</option>
+          <option value="utc">Coordinated Universal Time (UTC)</option>
+        </select>
+      </label>
+    </div>
   </header>
   {% include "status-subnav.njk" %}
 
-  <section class="status-overall" id="status-overall" aria-labelledby="status-overall-heading" aria-live="polite">
-    <h2 id="status-overall-heading">Checking current status…</h2>
+  <section class="status-overall" id="status-overall" aria-label="Service status"
+    aria-live="polite">
     <p id="status-summary">Loading the latest monitor results.</p>
     <ul id="status-incidents" hidden></ul>
   </section>

--- a/content/status.njk
+++ b/content/status.njk
@@ -12,9 +12,6 @@ statusSection: uptime
   #status-as-of.status-stale {
     color: var(--pill-degraded-bg);
   }
-  .status-overall {
-    margin-top: 1rem;
-  }
   .status-list {
     --index-row-padding: 1rem;
     --index-row-border: 0;
@@ -83,10 +80,6 @@ statusSection: uptime
     border-color: var(--pill-down-bg);
     background: var(--pill-down-bg);
   }
-  .status-bars + p {
-    display: flex;
-    justify-content: space-between;
-  }
   .status-incident-heading,
   .status-incident header {
     display: flex;
@@ -130,27 +123,28 @@ statusSection: uptime
   <header class="status-page-heading">
     <h1>dynamical.org status</h1>
     <div class="status-page-meta">
-      <p class="status-page-updated" id="status-as-of" role="status">As of —</p>
-      <label>
-        <span class="visually-hidden">Time zone</span>
-        <select id="status-time-toggle">
-          <option value="local">Local time</option>
-          <option value="utc">Coordinated Universal Time (UTC)</option>
-        </select>
-      </label>
+      <p class="status-page-updated" id="status-as-of" role="status">
+        <span data-slot="status-updated">As of —</span>
+        <label data-slot="time-control" hidden>
+          <span class="visually-hidden">Time zone</span>
+          <select class="status-time-toggle" id="status-time-toggle">
+            <option value="local">—</option>
+            <option value="utc">UTC</option>
+          </select>
+        </label>
+      </p>
     </div>
   </header>
   {% include "status-subnav.njk" %}
 
-  <section class="status-overall" id="status-overall" aria-label="Service status"
-    aria-live="polite">
+  <section id="status-overall" aria-label="Service status" aria-live="polite">
     <p id="status-summary">Loading the latest monitor results.</p>
     <ul id="status-incidents" hidden></ul>
   </section>
 
   <p id="status-history" role="status" hidden></p>
 
-  <div class="status-groups" id="status-groups" hidden style="margin-top: 4rem;">
+  <div id="status-groups" hidden>
     <section aria-labelledby="core-heading">
       <header>
         <h2 id="core-heading">Core</h2>
@@ -158,7 +152,7 @@ statusSection: uptime
       <ul class="index-list status-list" id="status-endpoints"></ul>
     </section>
 
-    <section aria-labelledby="tools-heading" style="margin-top: 4rem;">
+    <section aria-labelledby="tools-heading">
       <header>
         <h2 id="tools-heading">Tools &amp; resources</h2>
       </header>
@@ -166,12 +160,12 @@ statusSection: uptime
     </section>
   </div>
 
-  <p style="margin-top: 4rem;">
+  <p>
     For per-model run timing and upstream source arrival history, see the
     <a href="/status/pipeline/">data product pipeline</a>.
   </p>
 
-  <section aria-labelledby="status-incident-heading" style="margin-top: 4rem;">
+  <section aria-labelledby="status-incident-heading">
     <header class="status-incident-heading">
       <h2 id="status-incident-heading">Incident history</h2>
       <a href="{{ statusIncidentFeed }}">RSS</a>

--- a/content/status.njk
+++ b/content/status.njk
@@ -118,7 +118,7 @@ statusSection: uptime
   }
 </style>
 
-<main class="content" data-status-page data-status-url="{{ statusFeed }}"
+<main class="content" style="margin-top: 4rem;" data-status-page data-status-url="{{ statusFeed }}"
   data-log-url="{{ statusLogBase }}">
   {% from "status-subnav.njk" import statusSubnav %}
   {% call statusSubnav(statusSection, statusFeed, pipelineAssetsBase) %}

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "build": "STAC_CACHE_DURATION=0s npx @11ty/eleventy",
     "test": "node --test test/*.test.mjs",
     "start": "npx @11ty/eleventy --serve --port=8081",
-    "start:pipeline": "PIPELINE_FIXTURE=1 PIPELINE_ASSETS_BASE=/pipeline-preview npx @11ty/eleventy --serve --port=8081",
-    "start:status": "STATUS_FIXTURE=1 STATUS_URL=/status-preview/status.json STATUS_LOG_URL=/status-preview npx @11ty/eleventy --serve --port=8081",
+    "start:pipeline": "PIPELINE_FIXTURE=1 PIPELINE_ASSETS_BASE=/pipeline-preview STATUS_FIXTURE=1 STATUS_URL=/status-preview/status.json STATUS_LOG_URL=/status-preview npx @11ty/eleventy --serve --port=8081",
+    "start:status": "PIPELINE_FIXTURE=1 PIPELINE_ASSETS_BASE=/pipeline-preview STATUS_FIXTURE=1 STATUS_URL=/status-preview/status.json STATUS_LOG_URL=/status-preview npx @11ty/eleventy --serve --port=8081",
     "start:staging": "STAC_BASE_URL=https://stac-staging.dynamical.org npx @11ty/eleventy --serve --port=8081",
     "build:staging": "STAC_BASE_URL=https://stac-staging.dynamical.org STAC_CACHE_DURATION=0s npx @11ty/eleventy",
     "clean": "rm -r docs .cache"

--- a/public/main.css
+++ b/public/main.css
@@ -162,7 +162,6 @@ a:visited {
   align-items: baseline;
   flex-wrap: wrap;
   gap: 0.5rem 2rem;
-  margin-top: 4rem;
 }
 
 .status-page-heading h1,
@@ -179,8 +178,13 @@ a:visited {
   font-size: 1.2rem;
 }
 
-.status-page-meta label {
-  display: block;
+.status-time-toggle {
+  width: 4.2em;
+  padding: 0;
+  border: 0;
+  color: inherit;
+  background: transparent;
+  font: inherit;
 }
 
 .status-controls {
@@ -285,15 +289,12 @@ p {
   margin-bottom: 1.2rem;
 }
 
-/* Give bullet/numbered lists in article content room to breathe. Without
-   this, multi-line list items (e.g. the SLA page) run together and are hard
-   to scan. Scoped to .content so nav/footer lists keep their own layout. */
-.content ul,
-.content ol {
+/* Classless lists are prose; classed lists own their component layout. */
+:where(.content) :is(ul, ol):not([class]) {
   margin-bottom: 1.2rem;
 }
 
-.content li + li {
+:where(.content) :is(ul, ol):not([class]) > li + li {
   margin-top: 0.6rem;
 }
 
@@ -689,11 +690,6 @@ article img,
 }
 .index-list > li {
   padding: var(--index-row-padding) 0;
-}
-/* Separator between rows only. Beats the generic `.content li + li` margin by
-   equal specificity + later source order. */
-.index-list > li + li {
-  margin-top: 0;
 }
 .index-list > li:not(:last-child) {
   border-bottom: var(--index-row-border);

--- a/public/main.css
+++ b/public/main.css
@@ -149,7 +149,6 @@ a:visited {
   display: flex;
   gap: 0.8rem;
   margin: 0.6rem 0 3rem;
-  font-size: 1.2rem;
 }
 
 .status-subnav [aria-current="page"] {

--- a/public/main.css
+++ b/public/main.css
@@ -145,37 +145,33 @@ a:visited {
   color: var(--link-visited-color);
 }
 
-.status-subnav {
+.status-subnav-row {
   display: flex;
-  gap: 0.8rem;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: 0.5rem 2rem;
   margin: 0.6rem 0 1.5rem;
 }
 
+.status-subnav {
+  display: flex;
+  gap: 0.8rem;
+}
+
+.primary-nav [aria-current="page"],
 .status-subnav [aria-current="page"] {
   color: var(--text-color);
   font-weight: 700;
   text-decoration: none;
 }
 
-.status-page-heading {
-  display: flex;
-  align-items: baseline;
-  flex-wrap: wrap;
-  gap: 0.5rem 2rem;
-}
-
-.status-page-heading h1,
 .status-page-meta p {
   margin: 0;
 }
 
 .status-page-meta {
-  margin-left: auto !important;
+  margin-left: auto;
   text-align: right;
-}
-
-.status-page-updated {
-  font-size: 1.2rem;
 }
 
 .status-time-toggle {
@@ -236,6 +232,7 @@ a:visited {
 @media (max-width: 680px) {
   .status-page-meta {
     flex-basis: 100%;
+    margin-left: 0;
     text-align: left;
   }
 

--- a/public/main.css
+++ b/public/main.css
@@ -148,13 +148,101 @@ a:visited {
 .status-subnav {
   display: flex;
   gap: 0.8rem;
-  margin: 0.6rem 0 3rem;
+  margin: 0.6rem 0 1.5rem;
 }
 
 .status-subnav [aria-current="page"] {
   color: var(--text-color);
   font-weight: 700;
   text-decoration: none;
+}
+
+.status-page-heading {
+  display: flex;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: 0.5rem 2rem;
+  margin-top: 4rem;
+}
+
+.status-page-heading h1,
+.status-page-meta p {
+  margin: 0;
+}
+
+.status-page-meta {
+  margin-left: auto !important;
+  text-align: right;
+}
+
+.status-page-updated {
+  font-size: 1.2rem;
+}
+
+.status-page-meta label {
+  display: block;
+}
+
+.status-controls {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 1.2rem;
+  margin-bottom: 2rem;
+}
+
+.status-health {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.8rem 1.6rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.status-health li {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.5rem;
+}
+
+.status-health li > [aria-hidden] {
+  align-self: center;
+  width: 0.9rem;
+  height: 0.9rem;
+  border-radius: 50%;
+  background: var(--border-muted-color);
+}
+
+.status-health [data-state="operational"] > [aria-hidden],
+.status-health [data-state="nominal"] > [aria-hidden] {
+  background: var(--pill-available-bg);
+}
+
+.status-health [data-state="degraded"] > [aria-hidden],
+.status-health [data-state="advisory"] > [aria-hidden] {
+  background: var(--pill-degraded-bg);
+}
+
+.status-health [data-state="down"] > [aria-hidden] {
+  background: var(--pill-down-bg);
+}
+
+@media (max-width: 680px) {
+  .status-page-meta {
+    flex-basis: 100%;
+    text-align: left;
+  }
+
+  .status-health {
+    flex: 1 1 100%;
+    min-width: 0;
+  }
+
+  .status-health li {
+    flex: 1 1 100%;
+  }
 }
 
 /* Prevent visited-link styling from recoloring interactive SVG maps (e.g. scorecard). */

--- a/public/pipeline.css
+++ b/public/pipeline.css
@@ -24,7 +24,7 @@
 }
 
 .pipeline-controls,
-.pipeline-controls-primary {
+.pipeline-controls-actions {
   display: flex;
   align-items: center;
   flex-wrap: wrap;
@@ -33,17 +33,42 @@
 
 .pipeline-controls {
   justify-content: space-between;
-  margin: 3rem 0 2rem;
+  margin: 0 0 2rem;
 }
 
 .pipeline-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.8rem 1.6rem;
   margin: -1.2rem 0 2rem;
   color: var(--muted-text);
   font-size: 1.1rem;
 }
 
-.pipeline-controls-primary {
-  justify-content: flex-start;
+.pipeline-legend > span {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.pipeline-legend-mark {
+  display: inline-block;
+  width: 2.4rem;
+  height: 1rem;
+  box-sizing: border-box;
+}
+
+.pipeline-legend-mark--pending {
+  border: 1px dotted var(--pipeline-unobserved);
+  background: linear-gradient(
+    to right,
+    var(--pipeline-ok) 0 50%,
+    transparent 50%
+  );
+}
+
+.pipeline-legend-mark--unobserved {
+  border: 1px dotted var(--pipeline-unobserved);
 }
 
 .pipeline-agencies {
@@ -251,8 +276,11 @@
   background: var(--pipeline-failed);
 }
 
-.pipeline-bar[data-status="unobserved"] .pipeline-bar-track,
 .pipeline-bar-segment.g-pending {
+  border: 1px dotted var(--pipeline-unobserved);
+}
+
+.pipeline-bar[data-status="unobserved"] .pipeline-bar-track {
   border-style: dotted;
   border-color: var(--pipeline-unobserved);
 }
@@ -343,8 +371,8 @@
   flex-wrap: wrap;
   gap: 1.2rem;
   margin-top: 2rem;
-  padding-top: 1rem;
-  border-top: 1px solid var(--border-muted-color);
+  padding: 0;
+  border: 0;
   color: var(--muted-text);
 }
 

--- a/public/pipeline.css
+++ b/public/pipeline.css
@@ -39,10 +39,6 @@
   border: 1px dotted var(--pipeline-unobserved);
 }
 
-.pipeline-footer {
-  font-size: 1.2rem;
-}
-
 .pipeline-ribbon:not([hidden]),
 .pipeline-banner {
   margin-bottom: 1.5rem;
@@ -79,7 +75,6 @@
 
 .pipeline-advisories {
   margin: 1.5rem 0;
-  font-size: 1.2rem;
 }
 
 .pipeline-advisories p {
@@ -302,14 +297,6 @@
 .pipeline-row-details th:first-child,
 .pipeline-row-details td:first-child {
   text-align: left;
-}
-
-.pipeline-footer {
-  display: flex;
-  justify-content: space-between;
-  flex-wrap: wrap;
-  gap: 1.2rem;
-  color: var(--muted-text);
 }
 
 .pipeline-time-local .pipeline-time-utc,

--- a/public/pipeline.css
+++ b/public/pipeline.css
@@ -5,18 +5,11 @@
   --pipeline-unobserved: #a8a8ad;
 }
 
-.pipeline-controls-actions {
-  display: flex;
-  align-items: center;
-  flex-wrap: wrap;
-  gap: 1.2rem;
-}
-
 .pipeline-legend {
   display: flex;
   flex-wrap: wrap;
   gap: 0.8rem 1.6rem;
-  margin: -1.2rem 0 2rem;
+  margin: 0 0 2rem;
   color: var(--muted-text);
   font-size: 1.1rem;
 }
@@ -31,7 +24,6 @@
   display: inline-block;
   width: 2.4rem;
   height: 1rem;
-  box-sizing: border-box;
 }
 
 .pipeline-legend-mark--pending {
@@ -47,9 +39,7 @@
   border: 1px dotted var(--pipeline-unobserved);
 }
 
-.pipeline-controls-actions button,
-.pipeline-footer,
-.status-page-updated {
+.pipeline-footer {
   font-size: 1.2rem;
 }
 
@@ -319,9 +309,6 @@
   justify-content: space-between;
   flex-wrap: wrap;
   gap: 1.2rem;
-  margin-top: 2rem;
-  padding: 0;
-  border: 0;
   color: var(--muted-text);
 }
 
@@ -341,11 +328,6 @@ body:not(.pipeline-time-local) .pipeline-time-local-only {
 }
 
 @media (max-width: 680px) {
-  .pipeline-updated {
-    flex-basis: 100%;
-    text-align: left;
-  }
-
   .pipeline-grid {
     gap: 0.3rem;
   }

--- a/public/pipeline.css
+++ b/public/pipeline.css
@@ -5,35 +5,11 @@
   --pipeline-unobserved: #a8a8ad;
 }
 
-.pipeline-page .status-page-heading {
-  display: flex;
-  align-items: baseline;
-  flex-wrap: wrap;
-  gap: 0.5rem 2rem;
-  margin-top: 4rem;
-}
-
-.pipeline-page .status-page-heading h1,
-.pipeline-page .status-page-heading p {
-  margin: 0;
-}
-
-.pipeline-updated {
-  margin-left: auto !important;
-  text-align: right;
-}
-
-.pipeline-controls,
 .pipeline-controls-actions {
   display: flex;
   align-items: center;
   flex-wrap: wrap;
   gap: 1.2rem;
-}
-
-.pipeline-controls {
-  justify-content: space-between;
-  margin: 0 0 2rem;
 }
 
 .pipeline-legend {
@@ -71,37 +47,9 @@
   border: 1px dotted var(--pipeline-unobserved);
 }
 
-.pipeline-agencies {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.6rem;
-  white-space: nowrap;
-}
-
-.pipeline-agency-dot {
-  width: 0.9rem;
-  height: 0.9rem;
-  border-radius: 50%;
-  background: var(--pipeline-unobserved);
-}
-
-.pipeline-agencies[data-state="nominal"] .pipeline-agency-dot {
-  background: var(--pipeline-ok);
-}
-
-.pipeline-agencies[data-state="advisory"] {
-  color: var(--pill-degraded-fg);
-  background: var(--pill-degraded-bg);
-  padding: 0.2rem 0.5rem;
-}
-
-.pipeline-agencies[data-state="advisory"] .pipeline-agency-dot {
-  background: currentColor;
-}
-
-.pipeline-controls button,
+.pipeline-controls-actions button,
 .pipeline-footer,
-.pipeline-updated {
+.status-page-updated {
   font-size: 1.2rem;
 }
 
@@ -245,7 +193,8 @@
   height: var(--band-height, 0%);
 }
 
-.pipeline-bar-segment + .pipeline-bar-segment:not(:last-child) {
+.pipeline-bar-segment
+  + .pipeline-bar-segment:not(:last-child, .g-pending, .g-unobserved) {
   border-top: 1px solid var(--text-color);
 }
 
@@ -276,13 +225,13 @@
   background: var(--pipeline-failed);
 }
 
-.pipeline-bar-segment.g-pending {
+.pipeline-bar-segment.g-pending,
+.pipeline-bar-segment.g-unobserved {
   border: 1px dotted var(--pipeline-unobserved);
 }
 
 .pipeline-bar[data-status="unobserved"] .pipeline-bar-track {
-  border-style: dotted;
-  border-color: var(--pipeline-unobserved);
+  border: 1px dotted var(--pipeline-unobserved);
 }
 
 .pipeline-bar[data-status="unobserved"] .pipeline-bar-fill,

--- a/public/pipeline.mjs
+++ b/public/pipeline.mjs
@@ -628,8 +628,6 @@ function start(app) {
       structureSignature = nextSignature;
     }
     banners.replaceChildren();
-    app.querySelector('[data-slot="window-days"]').textContent =
-      latest.window_days ?? "—";
     ribbon.hidden =
       Date.now() - Date.parse(latest.generated_at) <= STALE_AFTER_MS;
     displaySnapshot(latest, Date.now());

--- a/public/pipeline.mjs
+++ b/public/pipeline.mjs
@@ -135,15 +135,18 @@ function initLabel(timestamp, local) {
   return element("span", null, [element("strong", null, date), time]);
 }
 
-function formatTime(timestamp, local) {
-  return new Intl.DateTimeFormat(undefined, {
+function formatTime(timestamp, local, includeZone = true) {
+  const options = {
     month: "short",
     day: "numeric",
     hour: "numeric",
     minute: "2-digit",
     timeZone: local ? undefined : "UTC",
-    timeZoneName: "short",
-  }).format(new Date(timestamp));
+  };
+  if (includeZone) options.timeZoneName = "short";
+  return new Intl.DateTimeFormat(undefined, options).format(
+    new Date(timestamp),
+  );
 }
 
 export function clockTime(timestamp, timeZone = "UTC") {
@@ -157,11 +160,15 @@ export function clockTime(timestamp, timeZone = "UTC") {
 
 function timeNode(timestamp) {
   return element("span", null, [
-    element("span", { class: "pipeline-time-utc" }, formatTime(timestamp, false)),
+    element(
+      "span",
+      { class: "pipeline-time-utc" },
+      formatTime(timestamp, false, false),
+    ),
     element(
       "span",
       { class: "pipeline-time-local-only" },
-      formatTime(timestamp, true),
+      formatTime(timestamp, true, false),
     ),
   ]);
 }
@@ -544,6 +551,7 @@ function renderAdvisories(app, advisories, rows) {
 
 function renderSnapshot(app, snapshot, rows, now) {
   const local = document.body.classList.contains("pipeline-time-local");
+  app.querySelector('[data-slot="time-control"]').hidden = false;
   app
     .querySelector('[data-slot="generated-at"]')
     .replaceChildren(timeNode(snapshot.generated_at));

--- a/public/pipeline.mjs
+++ b/public/pipeline.mjs
@@ -1,7 +1,14 @@
+import {
+  agencyHealth,
+  renderHealth,
+  systemHealth,
+} from "./status-health.mjs";
+import { setupTimeToggle } from "./status-time.mjs";
+
 const POLL_INTERVAL_MS = 15_000;
+const HEALTH_REFRESH_INTERVAL_MS = 5 * 60 * 1000;
 const STALE_AFTER_MS = 10 * 60 * 1000;
 const FETCH_TIMEOUT_MS = 10_000;
-const TIME_MODE_KEY = "wxopticon:time-mode";
 const DASHBOARD_VERSION = 1;
 
 function hasTimestamp(value) {
@@ -47,15 +54,12 @@ export function validateDashboard(data) {
 }
 
 export function agencySummary(advisories) {
-  const active = advisories ?? [];
-  if (active.length === 0) {
-    return { state: "nominal", label: "nominal" };
-  }
-  const agencies = [...new Set(active.map(({ agency }) => agency.toUpperCase()))];
-  return {
-    state: "advisory",
-    label: `${agencies.join(", ")} advisor${active.length === 1 ? "y" : "ies"}`,
-  };
+  const health = agencyHealth(advisories ?? []);
+  return { state: health.state, label: health.value };
+}
+
+export function displaySource(source) {
+  return source?.replace(/^https?:\/\//, "") ?? "—";
 }
 
 function productsOf(snapshot) {
@@ -290,7 +294,7 @@ function renderStructure(app, dashboard, rows) {
           element("div", null, [
             element("strong", null, product.row_label),
             element("div", { class: "pipeline-source-meta" }, [
-              element("div", null, product.source ?? "—"),
+              element("div", null, displaySource(product.source)),
               element("div", null, `${product.cadence_hours ?? "—"}h init cadence`),
               element("div", null, `${product.init_hours?.join("/") || "—"}z`),
               advisory,
@@ -497,10 +501,7 @@ function hydrateEta(row, product, now, local) {
 }
 
 function renderAdvisories(app, advisories, rows) {
-  const status = app.querySelector('[data-slot="agency-status"]');
-  const summary = agencySummary(advisories);
-  status.dataset.state = summary.state;
-  status.querySelector("strong").textContent = summary.label;
+  renderHealth(app, "agency-health", agencyHealth(advisories));
 
   for (const row of rows.values()) {
     const marker = row.querySelector('[data-slot="row-advisory"]');
@@ -567,13 +568,14 @@ function start(app) {
   const rows = new Map();
   const ribbon = app.querySelector('[data-slot="ribbon"]');
   const banners = app.querySelector('[data-slot="banners"]');
-  const timeToggle = app.querySelector("#pipeline-time-toggle");
+  const timeToggle = app.querySelector("#status-time-toggle");
   const historyButton = app.querySelector("#pipeline-history-toggle");
   const historyPanel = app.querySelector("#pipeline-history-panel");
   const historyRange = app.querySelector("#pipeline-history-range");
   const scrubLabel = app.querySelector('[data-slot="scrub-label"]');
   const scrubError = app.querySelector('[data-slot="scrub-error"]');
   const returnLive = app.querySelector('[data-slot="return-live"]');
+  const statusUrl = app.querySelector(".status-health").dataset.statusUrl;
 
   let latest = null;
   let mode = "live";
@@ -590,10 +592,9 @@ function start(app) {
     renderSnapshot(app, snapshot, rows, now);
   }
 
-  function setTimeMode(local, persist) {
+  function setTimeMode(local) {
     document.body.classList.toggle("pipeline-time-local", local);
     timeToggle.value = local ? "local" : "utc";
-    if (persist) localStorage.setItem(TIME_MODE_KEY, local ? "local" : "utc");
     if (displayedSnapshot) {
       displaySnapshot(
         displayedSnapshot,
@@ -652,6 +653,18 @@ function start(app) {
       } else {
         showError(`Couldn't load pipeline status (${error.message}).`);
       }
+    }
+  }
+
+  async function loadSystemHealth() {
+    try {
+      renderHealth(
+        app,
+        "system-health",
+        systemHealth(await fetchJson(statusUrl, "no-cache")),
+      );
+    } catch {
+      renderHealth(app, "system-health", systemHealth(null));
     }
   }
 
@@ -739,9 +752,6 @@ function start(app) {
     }
   }
 
-  timeToggle.addEventListener("change", () =>
-    setTimeMode(timeToggle.value === "local", true),
-  );
   historyButton.addEventListener("click", () => {
     if (historyPanel.hidden) openHistory();
     else if (mode === "scrub") resumeLive(true);
@@ -792,8 +802,10 @@ function start(app) {
     }
   });
 
-  setTimeMode(localStorage.getItem(TIME_MODE_KEY) === "local", false);
+  setTimeMode(setupTimeToggle(timeToggle, setTimeMode));
+  loadSystemHealth();
   tick();
+  setInterval(loadSystemHealth, HEALTH_REFRESH_INTERVAL_MS);
   pollTimer = setInterval(tick, POLL_INTERVAL_MS);
   countdownTimer = setInterval(updateLiveCountdowns, 1000);
 }

--- a/public/status-health.mjs
+++ b/public/status-health.mjs
@@ -1,0 +1,40 @@
+function unavailable(label) {
+  return { state: "unavailable", label, value: "unavailable" };
+}
+
+export function systemHealth(data) {
+  if (!Array.isArray(data?.endpoints) || data.endpoints.length === 0) {
+    return unavailable("systems");
+  }
+  const statuses = new Set(data.endpoints.map(({ status }) => status));
+  if (statuses.has("down")) {
+    return { state: "down", label: "systems", value: "disrupted" };
+  }
+  if ([...statuses].some((status) => status !== "operational")) {
+    return { state: "degraded", label: "some systems", value: "degraded" };
+  }
+  return { state: "operational", label: "all systems", value: "operational" };
+}
+
+export function agencyHealth(advisories) {
+  if (!Array.isArray(advisories)) return unavailable("weather agencies");
+  if (advisories.length === 0) {
+    return { state: "nominal", label: "weather agencies", value: "nominal" };
+  }
+  const agencies = [
+    ...new Set(advisories.map(({ agency }) => agency.toUpperCase())),
+  ];
+  return {
+    state: "advisory",
+    label: "weather agencies",
+    value: `${agencies.join(", ")} advisor${advisories.length === 1 ? "y" : "ies"}`,
+  };
+}
+
+export function renderHealth(root, slot, health) {
+  const item = root.querySelector(`[data-slot="${slot}"]`);
+  if (!item) return;
+  item.dataset.state = health.state;
+  item.querySelector("[data-health-label]").textContent = health.label;
+  item.querySelector("strong").textContent = health.value;
+}

--- a/public/status-health.mjs
+++ b/public/status-health.mjs
@@ -2,6 +2,8 @@ function unavailable(label) {
   return { state: "unavailable", label, value: "unavailable" };
 }
 
+const UPSTREAM_LABEL = "upstream forecast sources";
+
 export function systemHealth(data) {
   if (!Array.isArray(data?.endpoints) || data.endpoints.length === 0) {
     return unavailable("systems");
@@ -17,16 +19,16 @@ export function systemHealth(data) {
 }
 
 export function agencyHealth(advisories) {
-  if (!Array.isArray(advisories)) return unavailable("weather agencies");
+  if (!Array.isArray(advisories)) return unavailable(UPSTREAM_LABEL);
   if (advisories.length === 0) {
-    return { state: "nominal", label: "weather agencies", value: "nominal" };
+    return { state: "nominal", label: UPSTREAM_LABEL, value: "nominal" };
   }
   const agencies = [
     ...new Set(advisories.map(({ agency }) => agency.toUpperCase())),
   ];
   return {
     state: "advisory",
-    label: "weather agencies",
+    label: UPSTREAM_LABEL,
     value: `${agencies.join(", ")} advisor${advisories.length === 1 ? "y" : "ies"}`,
   };
 }

--- a/public/status-time.mjs
+++ b/public/status-time.mjs
@@ -1,0 +1,23 @@
+const TIME_MODE_KEY = "wxopticon:time-mode";
+
+export function localTimeLabel(now = new Date()) {
+  const zone = new Intl.DateTimeFormat("en-US", {
+    timeZoneName: "short",
+  })
+    .formatToParts(now)
+    .find(({ type }) => type === "timeZoneName")?.value;
+  return zone ? `Local time (${zone})` : "Local time";
+}
+
+export function setupTimeToggle(toggle, onChange) {
+  const localOption = toggle.querySelector('option[value="local"]');
+  localOption.textContent = localTimeLabel();
+  const local = localStorage.getItem(TIME_MODE_KEY) !== "utc";
+  toggle.value = local ? "local" : "utc";
+  toggle.addEventListener("change", () => {
+    const nextLocal = toggle.value === "local";
+    localStorage.setItem(TIME_MODE_KEY, nextLocal ? "local" : "utc");
+    onChange(nextLocal);
+  });
+  return local;
+}

--- a/public/status-time.mjs
+++ b/public/status-time.mjs
@@ -1,17 +1,17 @@
 const TIME_MODE_KEY = "wxopticon:time-mode";
 
-export function localTimeLabel(now = new Date()) {
+export function localZoneLabel(now = new Date()) {
   const zone = new Intl.DateTimeFormat("en-US", {
     timeZoneName: "short",
   })
     .formatToParts(now)
     .find(({ type }) => type === "timeZoneName")?.value;
-  return zone ? `Local time (${zone})` : "Local time";
+  return zone ?? "LOC";
 }
 
 export function setupTimeToggle(toggle, onChange) {
   const localOption = toggle.querySelector('option[value="local"]');
-  localOption.textContent = localTimeLabel();
+  localOption.textContent = localZoneLabel();
   const local = localStorage.getItem(TIME_MODE_KEY) !== "utc";
   toggle.value = local ? "local" : "utc";
   toggle.addEventListener("change", () => {

--- a/public/status.mjs
+++ b/public/status.mjs
@@ -6,6 +6,12 @@ import {
   parseEventLog,
   uptimeSummary,
 } from "./status-log.mjs";
+import {
+  agencyHealth,
+  renderHealth,
+  systemHealth,
+} from "./status-health.mjs";
+import { setupTimeToggle } from "./status-time.mjs";
 
 const PUBLIC_STATUSES = new Set(["operational", "degraded", "down"]);
 const PUBLIC_GROUPS = new Set(["endpoint", "tool"]);
@@ -89,13 +95,14 @@ function statusLabel(status) {
   }[status];
 }
 
-function formatTimestamp(timestamp) {
+function formatTimestamp(timestamp, local) {
   return new Intl.DateTimeFormat(undefined, {
     year: "numeric",
     month: "short",
     day: "numeric",
     hour: "numeric",
     minute: "2-digit",
+    timeZone: local ? undefined : "UTC",
     timeZoneName: "short",
   }).format(new Date(timestamp));
 }
@@ -258,26 +265,18 @@ async function loadHistory(root) {
   }
 }
 
-function renderStatus(root, data, loadedHistory) {
+function renderStatus(root, data, loadedHistory, local) {
   const overall = summarizeOverallStatus(data);
   const overallPanel = root.querySelector("#status-overall");
-  const heading = root.querySelector("#status-overall-heading");
   const summary = root.querySelector("#status-summary");
   const incidents = root.querySelector("#status-incidents");
   const asOf = root.querySelector("#status-as-of");
   const historyNotice = root.querySelector("#status-history");
   const groups = root.querySelector("#status-groups");
 
-  overallPanel.className = `status-overall status-${overall.status}`;
-  heading.textContent = {
-    operational: "All systems operational",
-    degraded: "Some services are degraded",
-    down: "Service disruption",
-  }[overall.status];
-  summary.textContent =
-    overall.status === "operational"
-      ? "All monitored public endpoints and tools are reporting normally."
-      : "The affected components are listed below.";
+  renderHealth(root, "system-health", systemHealth(data));
+  overallPanel.hidden = overall.status === "operational";
+  summary.textContent = "The affected components are listed below.";
 
   incidents.replaceChildren();
   incidents.hidden = overall.incidents.length === 0;
@@ -304,10 +303,8 @@ function renderStatus(root, data, loadedHistory) {
   } else {
     const generatedTime = document.createElement("time");
     generatedTime.dateTime = data.generated_at;
-    generatedTime.textContent = formatTimestamp(data.generated_at);
-    const asOfLabel = document.createElement("strong");
-    asOfLabel.append("As of ", generatedTime);
-    asOf.replaceChildren(asOfLabel);
+    generatedTime.textContent = formatTimestamp(data.generated_at, local);
+    asOf.replaceChildren("As of ", generatedTime);
   }
   const history =
     loadedHistory && isHistoryCurrent(loadedHistory.asOf, data.generated_at)
@@ -339,7 +336,7 @@ function renderStatus(root, data, loadedHistory) {
       emptyCells,
     );
   }
-  renderIncidentLog(root, history, data);
+  renderIncidentLog(root, history, data, local);
 }
 
 function setHistoryNotice(element, message) {
@@ -347,7 +344,7 @@ function setHistoryNotice(element, message) {
   element.textContent = message ?? "";
 }
 
-function renderIncidentLog(root, history, data) {
+function renderIncidentLog(root, history, data, local) {
   const list = root.querySelector("#status-incident-log");
   const empty = root.querySelector("#status-incident-empty");
   list.replaceChildren();
@@ -383,9 +380,9 @@ function renderIncidentLog(root, history, data) {
           : "Ongoing";
     timing.textContent =
       incident.ending === "observation-ended"
-        ? `${formatTimestamp(incident.start)} – ${formatTimestamp(incident.end)} · ${formatDuration(incident.start, end)}. Recovery was not witnessed.`
-        : `${formatTimestamp(incident.start)} – ${
-            incident.end ? formatTimestamp(incident.end) : "ongoing"
+        ? `${formatTimestamp(incident.start, local)} – ${formatTimestamp(incident.end, local)} · ${formatDuration(incident.start, end)}. Recovery was not witnessed.`
+        : `${formatTimestamp(incident.start, local)} – ${
+            incident.end ? formatTimestamp(incident.end, local) : "ongoing"
           } · ${formatDuration(incident.start, end)}.`;
     header.append(name, state);
     item.append(header, timing);
@@ -401,23 +398,20 @@ function renderIncidentLog(root, history, data) {
 
 function renderUnavailable(root) {
   const overallPanel = root.querySelector("#status-overall");
-  overallPanel.className = "status-overall status-unavailable";
-  root.querySelector("#status-overall-heading").textContent =
-    "Status temporarily unavailable";
+  overallPanel.hidden = false;
   root.querySelector("#status-summary").textContent =
     "The status feed could not be loaded. Try again shortly.";
   root.querySelector("#status-incidents").hidden = true;
   setHistoryNotice(root.querySelector("#status-history"), null);
   root.querySelector("#status-groups").hidden = true;
-  renderIncidentLog(root, null, { endpoints: [] });
-  const asOfLabel = document.createElement("strong");
-  asOfLabel.textContent = "As of —";
+  renderIncidentLog(root, null, { endpoints: [] }, true);
   const asOf = root.querySelector("#status-as-of");
   asOf.classList.remove("status-stale");
-  asOf.replaceChildren(asOfLabel);
+  asOf.textContent = "As of —";
+  renderHealth(root, "system-health", systemHealth(null));
 }
 
-async function loadStatus(root) {
+async function loadStatus(root, render) {
   const history = loadHistory(root);
   try {
     const response = await fetch(root.dataset.statusUrl, {
@@ -429,17 +423,51 @@ async function loadStatus(root) {
       throw new Error(`Status request failed: ${response.status}`);
     }
     const data = validateStatusData(await response.json());
-    renderStatus(root, data, await history);
+    render(data, await history);
   } catch (error) {
     console.error("Unable to load public status", error);
-    renderUnavailable(root);
+    render(null, null);
+  }
+}
+
+async function loadAgencyHealth(root) {
+  const url = root.querySelector(".status-health").dataset.pipelineUrl;
+  try {
+    const response = await fetch(url, {
+      cache: "no-store",
+      headers: { Accept: "application/json" },
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    });
+    if (!response.ok) throw new Error(`Agency request failed: ${response.status}`);
+    const data = await response.json();
+    renderHealth(root, "agency-health", agencyHealth(data.advisories));
+  } catch {
+    renderHealth(root, "agency-health", agencyHealth(null));
   }
 }
 
 if (typeof document !== "undefined") {
   const root = document.querySelector("[data-status-page]");
   if (root) {
-    loadStatus(root);
-    setInterval(() => loadStatus(root), REFRESH_INTERVAL_MS);
+    let data = null;
+    let history = null;
+    let local = true;
+    const render = (nextData, nextHistory) => {
+      data = nextData;
+      history = nextHistory;
+      if (data) renderStatus(root, data, history, local);
+      else renderUnavailable(root);
+    };
+    local = setupTimeToggle(
+      root.querySelector("#status-time-toggle"),
+      (nextLocal) => {
+        local = nextLocal;
+        if (data) renderStatus(root, data, history, local);
+      },
+    );
+    loadStatus(root, render);
+    loadAgencyHealth(root);
+    setInterval(() => loadStatus(root, render), REFRESH_INTERVAL_MS);
+    setInterval(() => loadAgencyHealth(root), REFRESH_INTERVAL_MS);
   }
 }

--- a/public/status.mjs
+++ b/public/status.mjs
@@ -95,16 +95,19 @@ function statusLabel(status) {
   }[status];
 }
 
-function formatTimestamp(timestamp, local) {
-  return new Intl.DateTimeFormat(undefined, {
+function formatTimestamp(timestamp, local, includeZone = true) {
+  const options = {
     year: "numeric",
     month: "short",
     day: "numeric",
     hour: "numeric",
     minute: "2-digit",
     timeZone: local ? undefined : "UTC",
-    timeZoneName: "short",
-  }).format(new Date(timestamp));
+  };
+  if (includeZone) options.timeZoneName = "short";
+  return new Intl.DateTimeFormat(undefined, options).format(
+    new Date(timestamp),
+  );
 }
 
 function formatDuration(start, end) {
@@ -182,7 +185,6 @@ export function barDescription(cells) {
 function barStrip(cells) {
   const strip = document.createElement("div");
   strip.className = "status-bars";
-  const days = cells.length;
   strip.setAttribute("role", "group");
   strip.setAttribute("aria-label", barDescription(cells));
   for (const cell of cells) {
@@ -201,15 +203,7 @@ function barStrip(cells) {
     }
     strip.append(day);
   }
-  const scale = document.createElement("p");
-  const first = document.createElement("span");
-  first.textContent = `${days} day${days === 1 ? "" : "s"} ago`;
-  const last = document.createElement("span");
-  last.textContent = "Today";
-  scale.append(first, last);
-  const wrapper = document.createDocumentFragment();
-  wrapper.append(strip, scale);
-  return wrapper;
+  return strip;
 }
 
 export function buildHistory(eventsText, metaText) {
@@ -271,6 +265,8 @@ function renderStatus(root, data, loadedHistory, local) {
   const summary = root.querySelector("#status-summary");
   const incidents = root.querySelector("#status-incidents");
   const asOf = root.querySelector("#status-as-of");
+  const updated = asOf.querySelector('[data-slot="status-updated"]');
+  const timeControl = asOf.querySelector('[data-slot="time-control"]');
   const historyNotice = root.querySelector("#status-history");
   const groups = root.querySelector("#status-groups");
 
@@ -288,13 +284,14 @@ function renderStatus(root, data, loadedHistory, local) {
 
   const stale = isStatusDataStale(data.generated_at);
   asOf.classList.toggle("status-stale", stale);
+  timeControl.hidden = stale;
   if (stale) {
     const icon = document.createElement("span");
     icon.setAttribute("aria-hidden", "true");
     icon.textContent = "⚠";
     const label = document.createElement("strong");
     label.textContent = "Stale:";
-    asOf.replaceChildren(
+    updated.replaceChildren(
       icon,
       " ",
       label,
@@ -303,8 +300,12 @@ function renderStatus(root, data, loadedHistory, local) {
   } else {
     const generatedTime = document.createElement("time");
     generatedTime.dateTime = data.generated_at;
-    generatedTime.textContent = formatTimestamp(data.generated_at, local);
-    asOf.replaceChildren("As of ", generatedTime);
+    generatedTime.textContent = formatTimestamp(
+      data.generated_at,
+      local,
+      false,
+    );
+    updated.replaceChildren("As of ", generatedTime);
   }
   const history =
     loadedHistory && isHistoryCurrent(loadedHistory.asOf, data.generated_at)
@@ -407,7 +408,8 @@ function renderUnavailable(root) {
   renderIncidentLog(root, null, { endpoints: [] }, true);
   const asOf = root.querySelector("#status-as-of");
   asOf.classList.remove("status-stale");
-  asOf.textContent = "As of —";
+  asOf.querySelector('[data-slot="status-updated"]').textContent = "As of —";
+  asOf.querySelector('[data-slot="time-control"]').hidden = true;
   renderHealth(root, "system-health", systemHealth(null));
 }
 

--- a/test/pipeline.test.mjs
+++ b/test/pipeline.test.mjs
@@ -237,12 +237,16 @@ test("status pages share the uptime, pipeline, and pipeline webhooks subnav", ()
     "utf8",
   );
 
-  assert.match(status, /include "status-subnav\.njk"/);
+  assert.match(status, /from "status-subnav\.njk" import statusSubnav/);
+  assert.match(status, /call statusSubnav\(statusSection, statusFeed, pipelineAssetsBase\)/);
   assert.match(status, /statusSection: uptime/);
   assert.match(status, /href="\/status\/pipeline\/"/);
   assert.doesNotMatch(status, /noindex: true|sitemap: false/);
-  assert.match(pipeline, /include "status-subnav\.njk"/);
+  assert.match(pipeline, /from "status-subnav\.njk" import statusSubnav/);
+  assert.match(pipeline, /call statusSubnav\(statusSection, statusFeed, pipelineAssetsBase\)/);
   assert.doesNotMatch(pipeline, /noindex: true|sitemap: false/);
+  assert.match(subnav, /class="status-subnav-row"/);
+  assert.match(subnav, /\{\{ caller\(\) \}\}/);
   assert.match(subnav, />uptime</);
   assert.match(subnav, /pipeline/);
   assert.match(subnav, /https:\/\/status\.dynamical\.org\/webhooks/);
@@ -261,6 +265,27 @@ test("status pages share the uptime, pipeline, and pipeline webhooks subnav", ()
   assert.match(status, /id="status-time-toggle"/);
   assert.match(pipeline, /id="status-time-toggle"/);
   assert.equal((base.match(/href="\/status\/"/g) ?? []).length, 2);
+});
+
+test("primary navigation styles the current section like the status subnav", () => {
+  const base = readFileSync(
+    new URL("../_includes/base.njk", import.meta.url),
+    "utf8",
+  );
+  const mainCss = readFileSync(
+    new URL("../public/main.css", import.meta.url),
+    "utf8",
+  );
+
+  assert.match(base, /class="primary-nav"/);
+  for (const section of ["catalog", "research", "updates", "about", "podcast", "status"]) {
+    assert.match(base, new RegExp(`>${section}<`));
+  }
+  assert.equal((base.match(/aria-current="page"/g) ?? []).length, 6);
+  assert.match(
+    mainCss,
+    /\.primary-nav \[aria-current="page"\],[\s\S]*\.status-subnav \[aria-current="page"\][\s\S]*font-weight: 700;[\s\S]*text-decoration: none;/,
+  );
 });
 
 test("the shared time control shows only the browser's local zone", () => {

--- a/test/pipeline.test.mjs
+++ b/test/pipeline.test.mjs
@@ -209,14 +209,37 @@ test("pipeline page links to webhooks and the integration guide", () => {
     new URL("../content/status-pipeline.njk", import.meta.url),
     "utf8",
   );
+  const pipelineCss = readFileSync(
+    new URL("../public/pipeline.css", import.meta.url),
+    "utf8",
+  );
+  const mainCss = readFileSync(
+    new URL("../public/main.css", import.meta.url),
+    "utf8",
+  );
 
   assert.match(template, /https:\/\/status\.dynamical\.org\/webhooks/);
   assert.match(template, /\/research\/when-the-forecast-is-ready\//);
+  assert.match(template, /weather agencies[\s\S]*pipeline-controls-actions/);
   assert.match(
     template,
-    /weather agencies[\s\S]*pipeline-time-toggle/,
+    /pipeline-controls-actions[\s\S]*pipeline-time-toggle[\s\S]*pipeline-history-toggle/,
   );
-  assert.match(template, /Dashed segment: forecast horizon not yet published/);
+  assert.match(template, /forecast hours still expected/);
+  assert.match(template, /no monitoring data/);
+  assert.doesNotMatch(template, /Data product pipeline|Forecast-run arrival/);
+  assert.match(
+    pipelineCss,
+    /\.pipeline-bar-segment\.g-pending\s*{\s*border: 1px dotted var\(--pipeline-unobserved\)/,
+  );
+  assert.match(
+    pipelineCss,
+    /\.pipeline-footer\s*{[^}]*padding: 0;[^}]*border: 0;/s,
+  );
+  assert.doesNotMatch(
+    mainCss,
+    /\.status-subnav\s*{[^}]*font-size:/s,
+  );
 });
 
 test("uptime uses light section headings without subtitles or rules", () => {

--- a/test/pipeline.test.mjs
+++ b/test/pipeline.test.mjs
@@ -219,7 +219,7 @@ test("retains live horizon status, time, and duration in details", () => {
   );
 });
 
-test("status pages share the uptime, pipeline, and webhooks subnav", () => {
+test("status pages share the uptime, pipeline, and pipeline webhooks subnav", () => {
   const base = readFileSync(
     new URL("../_includes/base.njk", import.meta.url),
     "utf8",
@@ -246,6 +246,7 @@ test("status pages share the uptime, pipeline, and webhooks subnav", () => {
   assert.match(subnav, />uptime</);
   assert.match(subnav, /pipeline/);
   assert.match(subnav, /https:\/\/status\.dynamical\.org\/webhooks/);
+  assert.match(subnav, />pipeline webhooks<\/a>/);
   assert.match(subnav, /data-slot="system-health"/);
   assert.match(subnav, /data-slot="agency-health"/);
   assert.match(subnav, /upstream forecast sources/);

--- a/test/pipeline.test.mjs
+++ b/test/pipeline.test.mjs
@@ -103,12 +103,12 @@ test("summarizes shared system and agency health", () => {
   });
   assert.deepEqual(agencyHealth([]), {
     state: "nominal",
-    label: "weather agencies",
+    label: "upstream forecast sources",
     value: "nominal",
   });
   assert.deepEqual(agencyHealth([{ agency: "noaa" }]), {
     state: "advisory",
-    label: "weather agencies",
+    label: "upstream forecast sources",
     value: "NOAA advisory",
   });
 });
@@ -248,6 +248,8 @@ test("status pages share the uptime, pipeline, and webhooks subnav", () => {
   assert.match(subnav, /https:\/\/status\.dynamical\.org\/webhooks/);
   assert.match(subnav, /data-slot="system-health"/);
   assert.match(subnav, /data-slot="agency-health"/);
+  assert.match(subnav, /upstream forecast sources/);
+  assert.doesNotMatch(subnav, /weather agencies/);
   assert.match(subnav, /statusSection == "pipeline"/);
   assert.match(subnav, /pipeline-history-toggle/);
   assert.doesNotMatch(subnav, /pipeline-controls-actions/);

--- a/test/pipeline.test.mjs
+++ b/test/pipeline.test.mjs
@@ -7,10 +7,16 @@ import {
   barTooltip,
   clockTime,
   detailRows,
+  displaySource,
   etaLineText,
   initParts,
   validateDashboard,
 } from "../public/pipeline.mjs";
+import {
+  agencyHealth,
+  systemHealth,
+} from "../public/status-health.mjs";
+import { localTimeLabel } from "../public/status-time.mjs";
 
 function dashboard() {
   return {
@@ -74,6 +80,39 @@ test("summarizes upstream agency advisories without changing pipeline state", ()
   );
 });
 
+test("summarizes shared system and agency health", () => {
+  assert.deepEqual(
+    systemHealth({
+      endpoints: [
+        { status: "operational" },
+        { status: "operational" },
+      ],
+    }),
+    { state: "operational", label: "all systems", value: "operational" },
+  );
+  assert.deepEqual(
+    systemHealth({
+      endpoints: [{ status: "operational" }, { status: "down" }],
+    }),
+    { state: "down", label: "systems", value: "disrupted" },
+  );
+  assert.deepEqual(systemHealth({ endpoints: [{ status: "new-state" }] }), {
+    state: "degraded",
+    label: "some systems",
+    value: "degraded",
+  });
+  assert.deepEqual(agencyHealth([]), {
+    state: "nominal",
+    label: "weather agencies",
+    value: "nominal",
+  });
+  assert.deepEqual(agencyHealth([{ agency: "noaa" }]), {
+    state: "advisory",
+    label: "weather agencies",
+    value: "NOAA advisory",
+  });
+});
+
 test("formats init labels in UTC and the selected local timezone", () => {
   const timestamp = "2026-07-26T00:00:00Z";
   assert.deepEqual(initParts(timestamp), { date: "07-26", time: "00z" });
@@ -81,6 +120,12 @@ test("formats init labels in UTC and the selected local timezone", () => {
     date: "07-25",
     time: "19 CDT",
   });
+});
+
+test("shortens displayed web sources without changing other schemes", () => {
+  assert.equal(displaySource("https://nomads.ncep.noaa.gov"), "nomads.ncep.noaa.gov");
+  assert.equal(displaySource("http://example.com/data"), "example.com/data");
+  assert.equal(displaySource("s3://noaa-gfs-bdp-pds"), "s3://noaa-gfs-bdp-pds");
 });
 
 test("preserves run and lead-group detail in bar tooltips", () => {
@@ -201,7 +246,30 @@ test("status pages share the uptime, pipeline, and webhooks subnav", () => {
   assert.match(subnav, />uptime</);
   assert.match(subnav, /pipeline/);
   assert.match(subnav, /https:\/\/status\.dynamical\.org\/webhooks/);
+  assert.match(subnav, /data-slot="system-health"/);
+  assert.match(subnav, /data-slot="agency-health"/);
+  assert.match(subnav, /statusSection == "pipeline"/);
+  assert.match(subnav, /pipeline-controls-actions[\s\S]*pipeline-history-toggle/);
+  assert.match(status, /id="status-time-toggle"/);
+  assert.match(pipeline, /id="status-time-toggle"/);
   assert.equal((base.match(/href="\/status\/"/g) ?? []).length, 2);
+});
+
+test("the shared time control names the browser's local zone", () => {
+  assert.match(
+    localTimeLabel(new Date("2026-07-26T12:00:00Z")),
+    /^Local time \(.+\)$/,
+  );
+});
+
+test("either local status preview serves both fixture feeds", () => {
+  const { scripts } = JSON.parse(
+    readFileSync(new URL("../package.json", import.meta.url), "utf8"),
+  );
+  for (const name of ["start:status", "start:pipeline"]) {
+    assert.match(scripts[name], /STATUS_FIXTURE=1/);
+    assert.match(scripts[name], /PIPELINE_FIXTURE=1/);
+  }
 });
 
 test("pipeline page links to webhooks and the integration guide", () => {
@@ -220,17 +288,16 @@ test("pipeline page links to webhooks and the integration guide", () => {
 
   assert.match(template, /https:\/\/status\.dynamical\.org\/webhooks/);
   assert.match(template, /\/research\/when-the-forecast-is-ready\//);
-  assert.match(template, /weather agencies[\s\S]*pipeline-controls-actions/);
-  assert.match(
-    template,
-    /pipeline-controls-actions[\s\S]*pipeline-time-toggle[\s\S]*pipeline-history-toggle/,
-  );
   assert.match(template, /forecast hours still expected/);
   assert.match(template, /no monitoring data/);
   assert.doesNotMatch(template, /Data product pipeline|Forecast-run arrival/);
   assert.match(
     pipelineCss,
-    /\.pipeline-bar-segment\.g-pending\s*{\s*border: 1px dotted var\(--pipeline-unobserved\)/,
+    /\.pipeline-bar-segment\.g-pending,[\s\S]*\.pipeline-bar-segment\.g-unobserved\s*{\s*border: 1px dotted var\(--pipeline-unobserved\)/,
+  );
+  assert.match(
+    pipelineCss,
+    /\.pipeline-bar\[data-status="unobserved"\] \.pipeline-bar-track\s*{\s*border: 1px dotted/,
   );
   assert.match(
     pipelineCss,
@@ -247,8 +314,17 @@ test("uptime uses light section headings without subtitles or rules", () => {
     new URL("../content/status.njk", import.meta.url),
     "utf8",
   );
+  const script = readFileSync(
+    new URL("../public/status.mjs", import.meta.url),
+    "utf8",
+  );
   assert.match(template, />Core</);
   assert.match(template, /--index-row-border: 0/);
+  assert.doesNotMatch(template, /\.status-overall\s*{[^}]*border-top:/s);
+  assert.doesNotMatch(
+    script,
+    /All monitored public endpoints and tools are reporting normally\./,
+  );
   assert.doesNotMatch(template, />Endpoints</);
   assert.doesNotMatch(template, /Data-serving and website/);
   assert.doesNotMatch(template, /Built on top of the data/);

--- a/test/pipeline.test.mjs
+++ b/test/pipeline.test.mjs
@@ -246,6 +246,10 @@ test("status pages share the uptime, pipeline, and pipeline webhooks subnav", ()
   assert.match(subnav, />uptime</);
   assert.match(subnav, /pipeline/);
   assert.match(subnav, /https:\/\/status\.dynamical\.org\/webhooks/);
+  assert.match(
+    subnav,
+    /href="https:\/\/status\.dynamical\.org\/webhooks" target="_blank" rel="noopener"/,
+  );
   assert.match(subnav, />pipeline webhooks<\/a>/);
   assert.match(subnav, /data-slot="system-health"/);
   assert.match(subnav, /data-slot="agency-health"/);

--- a/test/pipeline.test.mjs
+++ b/test/pipeline.test.mjs
@@ -246,6 +246,8 @@ test("status pages share the uptime, pipeline, and pipeline webhooks subnav", ()
   assert.match(pipeline, /call statusSubnav\(statusSection, statusFeed, pipelineAssetsBase\)/);
   assert.doesNotMatch(pipeline, /noindex: true|sitemap: false/);
   assert.match(subnav, /class="status-subnav-row"/);
+  assert.match(subnav, /class="status-subnav" role="navigation" aria-label="Status"/);
+  assert.doesNotMatch(subnav, /<nav class="status-subnav"/);
   assert.match(subnav, /\{\{ caller\(\) \}\}/);
   assert.match(subnav, />uptime</);
   assert.match(subnav, /pipeline/);

--- a/test/pipeline.test.mjs
+++ b/test/pipeline.test.mjs
@@ -16,7 +16,7 @@ import {
   agencyHealth,
   systemHealth,
 } from "../public/status-health.mjs";
-import { localTimeLabel } from "../public/status-time.mjs";
+import { localZoneLabel } from "../public/status-time.mjs";
 
 function dashboard() {
   return {
@@ -249,17 +249,17 @@ test("status pages share the uptime, pipeline, and webhooks subnav", () => {
   assert.match(subnav, /data-slot="system-health"/);
   assert.match(subnav, /data-slot="agency-health"/);
   assert.match(subnav, /statusSection == "pipeline"/);
-  assert.match(subnav, /pipeline-controls-actions[\s\S]*pipeline-history-toggle/);
+  assert.match(subnav, /pipeline-history-toggle/);
+  assert.doesNotMatch(subnav, /pipeline-controls-actions/);
   assert.match(status, /id="status-time-toggle"/);
   assert.match(pipeline, /id="status-time-toggle"/);
   assert.equal((base.match(/href="\/status\/"/g) ?? []).length, 2);
 });
 
-test("the shared time control names the browser's local zone", () => {
-  assert.match(
-    localTimeLabel(new Date("2026-07-26T12:00:00Z")),
-    /^Local time \(.+\)$/,
-  );
+test("the shared time control shows only the browser's local zone", () => {
+  const label = localZoneLabel(new Date("2026-07-26T12:00:00Z"));
+  assert.ok(label.length > 0);
+  assert.doesNotMatch(label, /local time/i);
 });
 
 test("either local status preview serves both fixture feeds", () => {
@@ -290,6 +290,8 @@ test("pipeline page links to webhooks and the integration guide", () => {
   assert.match(template, /\/research\/when-the-forecast-is-ready\//);
   assert.match(template, /forecast hours still expected/);
   assert.match(template, /no monitoring data/);
+  assert.match(template, /status-page-updated[\s\S]*status-time-toggle/);
+  assert.doesNotMatch(template, /Local time|Coordinated Universal Time/);
   assert.doesNotMatch(template, /Data product pipeline|Forecast-run arrival/);
   assert.match(
     pipelineCss,
@@ -299,14 +301,19 @@ test("pipeline page links to webhooks and the integration guide", () => {
     pipelineCss,
     /\.pipeline-bar\[data-status="unobserved"\] \.pipeline-bar-track\s*{\s*border: 1px dotted/,
   );
-  assert.match(
+  assert.doesNotMatch(
     pipelineCss,
-    /\.pipeline-footer\s*{[^}]*padding: 0;[^}]*border: 0;/s,
+    /\.pipeline-footer\s*{[^}]*(?:padding|border|margin-top):/s,
   );
   assert.doesNotMatch(
     mainCss,
     /\.status-subnav\s*{[^}]*font-size:/s,
   );
+  assert.match(
+    mainCss,
+    /:where\(\.content\) :is\(ul, ol\):not\(\[class\]\) > li \+ li/,
+  );
+  assert.doesNotMatch(mainCss, /\.content \.status-health li \+ li/);
 });
 
 test("uptime uses light section headings without subtitles or rules", () => {
@@ -320,7 +327,8 @@ test("uptime uses light section headings without subtitles or rules", () => {
   );
   assert.match(template, />Core</);
   assert.match(template, /--index-row-border: 0/);
-  assert.doesNotMatch(template, /\.status-overall\s*{[^}]*border-top:/s);
+  assert.doesNotMatch(template, /class="status-(?:overall|groups)"/);
+  assert.doesNotMatch(template, /style="margin-top:/);
   assert.doesNotMatch(
     script,
     /All monitored public endpoints and tools are reporting normally\./,

--- a/test/pipeline.test.mjs
+++ b/test/pipeline.test.mjs
@@ -306,13 +306,21 @@ test("either local status preview serves both fixture feeds", () => {
   }
 });
 
-test("pipeline page links to webhooks and the integration guide", () => {
+test("pipeline page uses the shared subnav without a separate footer", () => {
   const template = readFileSync(
     new URL("../content/status-pipeline.njk", import.meta.url),
     "utf8",
   );
+  const subnav = readFileSync(
+    new URL("../_includes/status-subnav.njk", import.meta.url),
+    "utf8",
+  );
   const pipelineCss = readFileSync(
     new URL("../public/pipeline.css", import.meta.url),
+    "utf8",
+  );
+  const pipelineScript = readFileSync(
+    new URL("../public/pipeline.mjs", import.meta.url),
     "utf8",
   );
   const mainCss = readFileSync(
@@ -320,10 +328,12 @@ test("pipeline page links to webhooks and the integration guide", () => {
     "utf8",
   );
 
-  assert.match(template, /https:\/\/status\.dynamical\.org\/webhooks/);
-  assert.match(template, /\/research\/when-the-forecast-is-ready\//);
+  assert.match(subnav, /https:\/\/status\.dynamical\.org\/webhooks/);
   assert.match(template, /forecast hours still expected/);
   assert.match(template, /no monitoring data/);
+  assert.doesNotMatch(template, /pipeline-footer|window-days/);
+  assert.doesNotMatch(pipelineScript, /window-days/);
+  assert.match(template, /style="margin-top: 4rem;"/);
   assert.match(template, /status-page-updated[\s\S]*status-time-toggle/);
   assert.doesNotMatch(template, /Local time|Coordinated Universal Time/);
   assert.doesNotMatch(template, /Data product pipeline|Forecast-run arrival/);
@@ -334,10 +344,6 @@ test("pipeline page links to webhooks and the integration guide", () => {
   assert.match(
     pipelineCss,
     /\.pipeline-bar\[data-status="unobserved"\] \.pipeline-bar-track\s*{\s*border: 1px dotted/,
-  );
-  assert.doesNotMatch(
-    pipelineCss,
-    /\.pipeline-footer\s*{[^}]*(?:padding|border|margin-top):/s,
   );
   assert.doesNotMatch(
     mainCss,
@@ -362,7 +368,6 @@ test("uptime uses light section headings without subtitles or rules", () => {
   assert.match(template, />Core</);
   assert.match(template, /--index-row-border: 0/);
   assert.doesNotMatch(template, /class="status-(?:overall|groups)"/);
-  assert.doesNotMatch(template, /style="margin-top:/);
   assert.doesNotMatch(
     script,
     /All monitored public endpoints and tools are reporting normally\./,

--- a/test/status.test.mjs
+++ b/test/status.test.mjs
@@ -270,7 +270,7 @@ test("uptime description states the fixed window without a coverage suffix", () 
   );
 });
 
-test("status page uses the requested heading and replaces stale as-of copy", () => {
+test("status page passes its timestamp into the shared subnav row", () => {
   const template = readFileSync(
     new URL("../content/status.njk", import.meta.url),
     "utf8",
@@ -280,7 +280,8 @@ test("status page uses the requested heading and replaces stale as-of copy", () 
     "utf8",
   );
 
-  assert.match(template, />dynamical\.org status</);
+  assert.doesNotMatch(template, />dynamical\.org status</);
+  assert.match(template, /call statusSubnav\(statusSection, statusFeed, pipelineAssetsBase\)/);
   assert.match(template, /data-slot="status-updated">As of —</);
   assert.doesNotMatch(template, /id="status-as-of"[^>]*><strong>/);
   assert.match(template, /status-page-updated[\s\S]*status-time-toggle/);

--- a/test/status.test.mjs
+++ b/test/status.test.mjs
@@ -275,14 +275,22 @@ test("status page uses the requested heading and replaces stale as-of copy", () 
     new URL("../content/status.njk", import.meta.url),
     "utf8",
   );
+  const script = readFileSync(
+    new URL("../public/status.mjs", import.meta.url),
+    "utf8",
+  );
 
   assert.match(template, />dynamical\.org status</);
-  assert.match(template, /id="status-as-of"[^>]*>As of —</);
+  assert.match(template, /data-slot="status-updated">As of —</);
   assert.doesNotMatch(template, /id="status-as-of"[^>]*><strong>/);
+  assert.match(template, /status-page-updated[\s\S]*status-time-toggle/);
+  assert.doesNotMatch(template, /Local time|Coordinated Universal Time/);
   assert.match(
     template,
     /\.status-bars > \*\s*{[^}]*border: 1px dotted/s,
   );
+  assert.doesNotMatch(template, /\.status-bars \+ p/);
+  assert.doesNotMatch(script, /textContent = "Today"|day.*ago/);
   assert.doesNotMatch(
     template,
     /Current health of dynamical\.org public endpoints, tools, and resources\./,

--- a/test/status.test.mjs
+++ b/test/status.test.mjs
@@ -282,6 +282,7 @@ test("status page passes its timestamp into the shared subnav row", () => {
 
   assert.doesNotMatch(template, />dynamical\.org status</);
   assert.match(template, /call statusSubnav\(statusSection, statusFeed, pipelineAssetsBase\)/);
+  assert.match(template, /style="margin-top: 4rem;"/);
   assert.match(template, /data-slot="status-updated">As of —</);
   assert.doesNotMatch(template, /id="status-as-of"[^>]*><strong>/);
   assert.match(template, /status-page-updated[\s\S]*status-time-toggle/);

--- a/test/status.test.mjs
+++ b/test/status.test.mjs
@@ -277,6 +277,12 @@ test("status page uses the requested heading and replaces stale as-of copy", () 
   );
 
   assert.match(template, />dynamical\.org status</);
+  assert.match(template, /id="status-as-of"[^>]*>As of —</);
+  assert.doesNotMatch(template, /id="status-as-of"[^>]*><strong>/);
+  assert.match(
+    template,
+    /\.status-bars > \*\s*{[^}]*border: 1px dotted/s,
+  );
   assert.doesNotMatch(
     template,
     /Current health of dynamical\.org public endpoints, tools, and resources\./,


### PR DESCRIPTION
## Summary

- simplify the pipeline heading, navigation, legend, history control, and footer
- match the pre-migration dotted treatment for pending segments and make fully unobserved bars fully dotted
- show system and upstream-forecast-source health on both status pages from their independent feeds
- embed a compact local-zone/UTC selector directly in each page timestamp
- align each page timestamp to the right of the shared status subnav
- style the active primary-nav section like the active status-subnav item
- remove the redundant uptime operational summary and green rule
- keep 90 rolling uptime bars visible, with unobserved days blank and dotted
- remove repeated uptime scale labels to increase row density
- shorten displayed HTTP(S) source names without changing the dashboard artifact
- make either local status preview command serve both fixture feeds
- scope prose list spacing to classless lists so component lists need no corrective overrides
- remove dead selectors, redundant defaults, and hand-set page-level top margins
- label the separate webhook manager `pipeline webhooks` and open it in a new tab

## Plan

- [x] Match the pre-migration pending border.
- [x] Simplify pipeline headings, controls, legend, and footer.
- [x] Render shared system and weather-agency health on both status pages.
- [x] Make timestamps use the same plain heading style.
- [x] Put a shared, local-by-default timezone selector below each timestamp.
- [x] Move the selector into the timestamp and show only zone abbreviations.
- [x] Move each timestamp into the shared status-subnav row.
- [x] Match active primary-nav styling to the status subnav.
- [x] Remove the redundant operational summary and status rule.
- [x] Make no-data bars fully dotted.
- [x] Shorten displayed HTTP(S) source names without changing feed data.
- [x] Make either local preview command serve both fixture feeds.
- [x] Add focused tests and run the full suite and production build.
- [x] Scope prose list spacing semantically instead of overriding components.
- [x] Remove dead/redundant styles and page-level top margins.
- [x] Mark pipeline webhooks as a separate-site transition.

### 2026-07-26 — Shared health follow-up

Service health comes from `status.json`; agency health comes from the pipeline dashboard. Each indicator is fetched independently, so a failed secondary request does not block the page's primary data.

### 2026-07-26 — Retro

The two status pages now share navigation, health semantics, and timezone behavior with less page-specific chrome. The combined fixture preview caught and fixed a mobile health-row overflow before review.

### 2026-07-26 — Screenshot feedback

The desktop health-row misalignment came from the general article-list rule adding top margin only to the second indicator. Restricting that rule to classless prose lists keeps both indicators on the same baseline without component-specific overrides. The redundant “90 days ago” and “Today” labels were also removed; the uptime sentence and accessible bar description retain the window context.

### 2026-07-26 — Style cleanup

Classless lists inside `.content` now receive prose spacing; classed component lists own their layout and no longer require health/index-list overrides. Dead hooks, redundant default declarations, compensating margins, and hand-set page-level top margins were removed. The compact timestamp selector now displays only the local zone abbreviation or `UTC`.

### 2026-07-26 — Upstream label

The shared “weather agencies” indicator is now labeled “upstream forecast sources” across nominal, advisory, and unavailable states on both pages.

### 2026-07-26 — Standalone webhook manager

The status subnav keeps the `pipeline webhooks` entry, but opens it in a new tab with `noopener` so the navigation makes the separate authenticated service boundary explicit.

### 2026-07-26 — Shared status row

`status-subnav.njk` is now a Nunjucks macro with a caller block. Uptime and pipeline retain their distinct client-side timestamp hooks while passing their timestamp markup into the same responsive row. The primary navigation now marks its current section with the same bold, un-underlined treatment as the status subnav.

## Verification

- `npm test` — 56 passing
- `npm run build` — passing
- compared fixed-input output with the pre-migration wxopticon page
- reviewed hydrated uptime and pipeline fixtures in headless Chrome at desktop and mobile widths

This PR is intentionally left unmerged for review.

### 2026-07-26 — Footer removal

The pipeline footer and its now-unused `window-days` DOM write were removed. Both status-page content containers now carry the requested inline 4rem top margin. Tests assert that neither the footer slot nor its JavaScript dependency returns.

### 2026-07-26 — Final retro

The page now has one navigation path and no decorative footer contract for JavaScript to depend on. The full 56-test suite and production build pass.
