### PR TITLE
Stop reporting localhost and preview errors to Sentry

### DIFF
--- a/_includes/base.njk
+++ b/_includes/base.njk
@@ -89,12 +89,22 @@
       // Gate the loader injection, not `sentryOnLoad`. After running that handler the loader
       // does `isInitialized() || Sentry.init()`, so returning early from it without calling
       // init makes the loader initialize itself with the dashboard's default config — the
-      // opposite of suppressing. The loader is also eager, not lazy, so it ran on every page
-      // load. Not injecting the script at all is what keeps local dev and *.pages.dev
-      // previews out of the dashboard.
+      // opposite of suppressing. Not injecting the script at all is what keeps local dev and
+      // *.pages.dev previews out of the dashboard.
       if (location.hostname === 'dynamical.org') {
         window.sentryOnLoad = function () {
-          Sentry.init({ environment: 'production' });
+          Sentry.init({
+            environment: 'production',
+            // Errors only — PostHog covers product analytics, and session replay of real
+            // visitors is more than /privacy/ discloses. Performance and Replay are also
+            // off for this DSN in the dashboard, which is what keeps the loader on the
+            // errors-only bundle; these zeros are what stops a dashboard change from
+            // quietly turning them back on, since the loader merges our options over its
+            // own defaults and adds each integration whenever the matching rate is truthy.
+            tracesSampleRate: 0,
+            replaysSessionSampleRate: 0,
+            replaysOnErrorSampleRate: 0,
+          });
         };
         var sentryLoader = document.createElement('script');
         sentryLoader.src = 'https://js.sentry-cdn.com/{{ metadata.sentryPublicKey }}.min.js';

--- a/_includes/base.njk
+++ b/_includes/base.njk
@@ -84,16 +84,25 @@
       ]
     }
     </script>
-    {% if metadata.sentryPublicKey %}<!-- Sentry browser error monitoring (Loader Script): errors only, no tracing or replay -->
+    {% if metadata.sentryPublicKey %}<!-- Sentry browser error monitoring (Loader Script) -->
     <script>
-      // Defining sentryOnLoad defers init to us, so the loader only reports on the production host;
-      // keeps local dev and *.pages.dev previews out of the dashboard.
-      window.sentryOnLoad = function () {
-        if (location.hostname !== 'dynamical.org') return;
-        Sentry.init({ environment: 'production' });
-      };
-    </script>
-    <script src="https://js.sentry-cdn.com/{{ metadata.sentryPublicKey }}.min.js" crossorigin="anonymous" async></script>{% endif %}
+      // Gate the loader injection, not `sentryOnLoad`. After running that handler the loader
+      // does `isInitialized() || Sentry.init()`, so returning early from it without calling
+      // init makes the loader initialize itself with the dashboard's default config — the
+      // opposite of suppressing. The loader is also eager, not lazy, so it ran on every page
+      // load. Not injecting the script at all is what keeps local dev and *.pages.dev
+      // previews out of the dashboard.
+      if (location.hostname === 'dynamical.org') {
+        window.sentryOnLoad = function () {
+          Sentry.init({ environment: 'production' });
+        };
+        var sentryLoader = document.createElement('script');
+        sentryLoader.src = 'https://js.sentry-cdn.com/{{ metadata.sentryPublicKey }}.min.js';
+        sentryLoader.crossOrigin = 'anonymous';
+        sentryLoader.async = true;
+        document.head.appendChild(sentryLoader);
+      }
+    </script>{% endif %}
     {% if metadata.posthogKey %}<!-- PostHog analytics: pageviews and interactions; anonymous visitors get no person profile -->
     <script>
       if (location.hostname === 'dynamical.org') {

--- a/_includes/base.njk
+++ b/_includes/base.njk
@@ -106,7 +106,7 @@
             replaysOnErrorSampleRate: 0,
           });
         };
-        var sentryLoader = document.createElement('script');
+        const sentryLoader = document.createElement('script');
         sentryLoader.src = 'https://js.sentry-cdn.com/{{ metadata.sentryPublicKey }}.min.js';
         sentryLoader.crossOrigin = 'anonymous';
         sentryLoader.async = true;

--- a/test/analytics-gating.test.mjs
+++ b/test/analytics-gating.test.mjs
@@ -1,0 +1,95 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import vm from "node:vm";
+
+// The third-party snippets in base.njk are inline, so they can't be imported. Pull each
+// one out of the template and run it against a stub DOM to assert what it does per host.
+//
+// This exists because the previous Sentry gate read correctly but did the opposite of what
+// it claimed: it returned early from `sentryOnLoad` without calling `Sentry.init()`, and the
+// loader then ran `isInitialized() || Sentry.init()` and initialized itself with the
+// dashboard's default config. Only an end-to-end "what actually happens on localhost" check
+// catches that class of bug.
+
+const BASE = readFileSync(new URL("../_includes/base.njk", import.meta.url), "utf8");
+const KEY = "testkey123";
+
+function inlineScript(marker) {
+  const blocks = [...BASE.matchAll(/<script>([\s\S]*?)<\/script>/g)].map((m) => m[1]);
+  const found = blocks.filter((b) => b.includes(marker));
+  assert.equal(found.length, 1, `expected exactly one inline script containing "${marker}"`);
+  return found[0]
+    .replaceAll("{{ metadata.sentryPublicKey }}", KEY)
+    .replaceAll("{{ metadata.posthogKey }}", KEY);
+}
+
+// Records every <script> the snippet injects, by either appendChild or insertBefore.
+function run(source, hostname) {
+  const injected = [];
+  const scriptStub = () => ({ parentNode: { insertBefore: (el) => injected.push(el) } });
+  const sandbox = {
+    location: { hostname },
+    console,
+    document: {
+      createElement: () => ({}),
+      head: { appendChild: (el) => injected.push(el) },
+      getElementsByTagName: () => [scriptStub()],
+    },
+  };
+  sandbox.window = sandbox;
+  vm.runInContext(source, vm.createContext(sandbox));
+  return { sandbox, injected };
+}
+
+const OFF_PRODUCTION = ["localhost", "127.0.0.1", "dynamical-org.pages.dev", "dynamical.org.evil.com"];
+
+test("sentry loader is not injected off production", () => {
+  const source = inlineScript("sentryLoader");
+  for (const hostname of OFF_PRODUCTION) {
+    const { sandbox, injected } = run(source, hostname);
+    assert.deepEqual(injected, [], `injected a script on ${hostname}`);
+    assert.equal(sandbox.sentryOnLoad, undefined, `defined sentryOnLoad on ${hostname}`);
+  }
+});
+
+test("sentry loader is injected on production and initializes itself", () => {
+  const { sandbox, injected } = run(inlineScript("sentryLoader"), "dynamical.org");
+
+  assert.equal(injected.length, 1);
+  assert.equal(injected[0].src, `https://js.sentry-cdn.com/${KEY}.min.js`);
+  assert.equal(injected[0].crossOrigin, "anonymous");
+
+  // The gate is only safe because sentryOnLoad calls init. If it ever stops doing so, the
+  // loader falls through to its own `Sentry.init()` with the dashboard defaults (tracing
+  // and session replay included) instead of the config declared here.
+  assert.equal(typeof sandbox.sentryOnLoad, "function");
+  const initCalls = [];
+  sandbox.Sentry = { init: (opts) => initCalls.push(opts) };
+  sandbox.sentryOnLoad();
+  assert.equal(initCalls.length, 1);
+  assert.equal(initCalls[0].environment, "production");
+});
+
+test("posthog is not loaded off production", () => {
+  const source = inlineScript("posthog.init");
+  for (const hostname of OFF_PRODUCTION) {
+    const { sandbox, injected } = run(source, hostname);
+    assert.deepEqual(injected, [], `injected a script on ${hostname}`);
+    assert.equal(sandbox.posthog, undefined, `defined posthog on ${hostname}`);
+  }
+});
+
+test("posthog is loaded on production", () => {
+  const { sandbox, injected } = run(inlineScript("posthog.init"), "dynamical.org");
+
+  assert.equal(injected.length, 1);
+  assert.match(injected[0].src, /posthog\.com\/static\/array\.js$/);
+
+  // The stub snippet queues calls until array.js swaps in the real client; init must be
+  // queued with the project key so the queued pageview is attributed correctly.
+  const init = sandbox.posthog._i.at(-1);
+  assert.equal(init[0], KEY);
+  assert.equal(init[1].api_host, "https://us.i.posthog.com");
+  assert.equal(init[1].person_profiles, "identified_only");
+});

--- a/test/analytics-gating.test.mjs
+++ b/test/analytics-gating.test.mjs
@@ -71,6 +71,21 @@ test("sentry loader is injected on production and initializes itself", () => {
   assert.equal(initCalls[0].environment, "production");
 });
 
+test("sentry init keeps tracing and session replay off", () => {
+  // Errors only. The loader merges these over its dashboard-supplied defaults and adds the
+  // BrowserTracing and Replay integrations whenever the matching rate is truthy, so the
+  // zeros have to be explicit — omitting them re-enables whatever the dashboard says, which
+  // for this DSN previously meant 100% trace sampling and 10% session replay.
+  const { sandbox } = run(inlineScript("sentryLoader"), "dynamical.org");
+  const initCalls = [];
+  sandbox.Sentry = { init: (opts) => initCalls.push(opts) };
+  sandbox.sentryOnLoad();
+
+  for (const option of ["tracesSampleRate", "replaysSessionSampleRate", "replaysOnErrorSampleRate"]) {
+    assert.equal(initCalls[0][option], 0, `${option} must be an explicit 0`);
+  }
+});
+
 test("posthog is not loaded off production", () => {
   const source = inlineScript("posthog.init");
   for (const hostname of OFF_PRODUCTION) {


### PR DESCRIPTION
Closes dynamical-org/meta#152 (frontend half).

## The bug

`base.njk` gated Sentry inside `sentryOnLoad`:

```js
window.sentryOnLoad = function () {
  if (location.hostname !== 'dynamical.org') return;
  Sentry.init({ environment: 'production' });
};
```

This reads as "only report on production". It does the opposite. From the live loader
(`js.sentry-cdn.com/<key>.min.js`), after calling our handler it runs:

```js
"function" == typeof n.sentryOnLoad && (n.sentryOnLoad(), n.sentryOnLoad = void 0)
...
m() || e.init();   // m() === "is Sentry already initialized?"
```

Returning early leaves the client uninitialized, so `m()` is false and **the loader calls
`Sentry.init()` itself** — merging over the default config baked into the loader by the
dashboard's Client Keys settings:

```json
{"dsn":"https://…@o4508761427804160.ingest.us.sentry.io/4511790930132992",
 "tracesSampleRate":1,"replaysSessionSampleRate":0.1,"replaysOnErrorSampleRate":1}
```

The loader's final argument was `false`, disabling lazy loading — so
`bundle.tracing.replay.min.js` was fetched and initialized on **every localhost page load**,
not only when an error fired.

## The fix

Gate the injection rather than the init. Off production the loader is never added to the
page, so there is no Sentry global, no bundle download, and nothing to report.

Verified in a browser against a local build of this branch:

```
hostname: "localhost"
sentryRequests: []      sentryGlobalDefined: "undefined"
posthogRequests: []     sentryOnLoadDefined: "undefined"
```

## Errors only

Separately, the comment claimed "errors only, no tracing or replay" while the loader config
above shows **100% trace sampling and 10% session replay**, applying in production too —
our `Sentry.init()` merged *over* those defaults rather than replacing them, and the loader
auto-added the BrowserTracing and Replay integrations.

Session replay records a DOM-mutation replay of a real visitor's session. `/privacy/`
describes Sentry as capturing "the page URL, browser/device details, and a stack trace" —
materially less than that. PostHog already covers product analytics.

Performance and Replay are now **off for this DSN in the dashboard**, which has three
effects, all confirmed against the live loader:

| | before | after |
|---|---|---|
| bundle | `bundle.tracing.replay.min.js` (84KB gzip) | `bundle.min.js` (29KB gzip) |
| default config | DSN + 3 sample rates | DSN only |
| loading | eager, every page load | lazy, only on error |

The init call now also sets `tracesSampleRate`, `replaysSessionSampleRate`, and
`replaysOnErrorSampleRate` to explicit zeros. Redundant against today's dashboard, but the
loader adds each integration whenever the matching rate is truthy, so without them the
dashboard silently decides — which is exactly how this happened.

## Tests

`test/analytics-gating.test.mjs` extracts each inline snippet from `base.njk` and runs it in
a `node:vm` sandbox with a stub DOM, asserting per hostname what gets injected, and that the
init call keeps tracing and replay at zero. The old code fails these. PostHog is covered too
— its gate is correct today and this keeps it that way. 61 tests pass (was 56).