### PR TITLE
Point remaining status links at the on-site pages

### DIFF
--- a/content/llms.njk
+++ b/content/llms.njk
@@ -38,7 +38,8 @@ Forecast datasets archive past and present model runs; each run is identified by
 
 ## Quality & operations
 - [Weather station scorecard]({{ metadata.url }}scorecard/): forecast accuracy vs. observations across US weather stations.
-- [Status](https://status.dynamical.org): live uptime, per-run timing, and upstream arrival history.
+- [Status]({{ metadata.url }}status/): live uptime.
+- [Pipeline status]({{ metadata.url }}status/pipeline/): per-run timing and upstream arrival history.
 - Per-dataset validation reports are linked from each catalog page.
 
 ## About & updates

--- a/content/projects/projects.11tydata.js
+++ b/content/projects/projects.11tydata.js
@@ -1,5 +1,5 @@
 // Projects — metadata records for the work dynamical ships. Every project has
-// its own page already (e.g. /catalog, /scorecard, status.dynamical.org), so
+// its own page already (e.g. /catalog, /scorecard, /status/pipeline/), so
 // these files generate NO page of their own: they're frontmatter-only records
 // that the homepage and area pages read via collections.projects.
 //

--- a/content/projects/wxopticon.njk
+++ b/content/projects/wxopticon.njk
@@ -1,9 +1,9 @@
 ---
 title: "Weather forecast production pipelines and observability"
 type: "Project"
-url: "https://status.dynamical.org"
+url: "/status/pipeline/"
 featured: 5
 areas:
   - weather-product-design
 ---
-<p>Arrival monitoring for the weather sources we depend on: when to expect each model run, whether today's run is on time, and a signed webhook the moment data crosses a readiness boundary &mdash; live at status.dynamical.org.</p>
+<p>Arrival monitoring for the weather sources we depend on: when to expect each model run, whether today's run is on time, and a signed webhook the moment data crosses a readiness boundary &mdash; live at dynamical.org/status/pipeline.</p>

--- a/content/research/virtual-data-products.md
+++ b/content/research/virtual-data-products.md
@@ -73,7 +73,7 @@ Enough talk. Let us show you the numbers.
 
 We define latency as _the time between the moment a file first becomes available at the source and the moment that data is first available in our Zarrs_ — specifically, from a file's "modified" or "created" timestamp at the source to the timestamp of the first Icechunk snapshot containing the same data.
 
-These statistics are calculated on a relatively short history of our first virtual Zarr, [NOAA HRRR forecast, 48 hour, virtual](https://dynamical.org/catalog/noaa-hrrr-forecast-48-hour-virtual/). As we build up a longer track record, we'll add them to our [data product pipeline status](https://status.dynamical.org/pipeline) page, where you can audit the [details](https://dynamical.org/research/when-the-forecast-is-ready/) and see them covered under tight latency thresholds in our [SLA](https://dynamical.org/sla/).
+These statistics are calculated on a relatively short history of our first virtual Zarr, [NOAA HRRR forecast, 48 hour, virtual](https://dynamical.org/catalog/noaa-hrrr-forecast-48-hour-virtual/). As we build up a longer track record, we'll add them to our [data product pipeline status](https://dynamical.org/status/pipeline/) page, where you can audit the [details](https://dynamical.org/research/when-the-forecast-is-ready/) and see them covered under tight latency thresholds in our [SLA](https://dynamical.org/sla/).
 
 #### Latency (seconds)
 


### PR DESCRIPTION
## Summary

Follow-up to the status/pipeline move (#154) and wxopticon's retirement of its Modal-rendered pages. `status.dynamical.org` and `status.dynamical.org/pipeline` now 301 into this site, so the last few links bounce cross-origin for no reason.

- `content/projects/wxopticon.njk` — card `url` and closing prose → `/status/pipeline/` (the card describes arrival monitoring, which is the pipeline page, not uptime)
- `content/llms.njk` — split the single Status entry into `/status/` (uptime) and `/status/pipeline/` (per-run timing and arrival history), now that they're two pages
- `content/research/virtual-data-products.md` — pipeline link → `https://dynamical.org/status/pipeline/`, matching the absolute-URL style of its neighbors

`status.dynamical.org/webhooks` still serves the real management app, so those links are untouched.

**Deliberately left alone:** `content/updates/2026-07-13.md` keeps its `status.dynamical.org` references — it's a dated record of that launch, and the URL still resolves.

## Validation

- `npm run build` — passed, 2,800 files
- `npm test` — 56/56 passed
- inspected built output: `docs/llms.txt`, `docs/index.html`, and `docs/research/virtual-data-products/index.html` all emit the on-site paths

## Related

#146 fixes the same stale links inside the wxopticon lab note.