### PR TITLE
Add custom PostHog events for the catalog and newsletter funnel

### DIFF
--- a/_includes/base.njk
+++ b/_includes/base.njk
@@ -124,6 +124,20 @@
         });
       }
     </script>{% endif %}
+    <script>
+      // Custom events go through this rather than calling posthog directly. Defined
+      // unconditionally — outside the posthog block above and independent of whether a key
+      // is configured — so page scripts can instrument freely without every call site
+      // repeating a guard, and so nothing breaks off production where posthog is undefined.
+      // Analytics must never take down a page.
+      window.track = function (event, properties) {
+        try {
+          if (typeof posthog !== 'undefined') posthog.capture(event, properties);
+        } catch (e) {
+          /* swallow: instrumentation is never worth an exception */
+        }
+      };
+    </script>
   </head>
   <body>
     <nav class="primary-nav" aria-label="Primary">
@@ -169,7 +183,7 @@
             action="https://buttondown.email/api/emails/embed-subscribe/dynamical"
             method="post"
             target="popupwindow"
-            onsubmit="window.open('https://buttondown.email/dynamical', 'popupwindow')"
+            onsubmit="window.open('https://buttondown.email/dynamical', 'popupwindow'); track('newsletter_subscribed', { placement: 'footer' })"
             class="footer-subscribe"
           >
             <label class="visually-hidden" for="footer-email">Email</label>

--- a/_includes/base.njk
+++ b/_includes/base.njk
@@ -183,7 +183,7 @@
             action="https://buttondown.email/api/emails/embed-subscribe/dynamical"
             method="post"
             target="popupwindow"
-            onsubmit="window.open('https://buttondown.email/dynamical', 'popupwindow'); track('newsletter_subscribed', { placement: 'footer' })"
+            onsubmit="window.open('https://buttondown.email/dynamical', 'popupwindow'); window.track('newsletter_subscribed', { placement: 'footer' })"
             class="footer-subscribe"
           >
             <label class="visually-hidden" for="footer-email">Email</label>

--- a/content/catalog-pages.njk
+++ b/content/catalog-pages.njk
@@ -413,6 +413,13 @@ eleventyComputed:
           b.tabIndex = active ? 0 : -1;
           panels[j].hidden = !active;
         });
+        // Which access path people reach for per dataset — the dynamical-catalog
+        // client versus assembling pystac + icechunk by hand. Tells us where the
+        // documentation and library effort is actually being spent.
+        track("snippet_variant_selected", {
+          dataset: "{{ entry.id }}",
+          variant: button.textContent.trim(),
+        });
       });
     });
   });

--- a/content/catalog-pages.njk
+++ b/content/catalog-pages.njk
@@ -417,7 +417,9 @@ eleventyComputed:
         // client versus assembling pystac + icechunk by hand. Tells us where the
         // documentation and library effort is actually being spent.
         track("snippet_variant_selected", {
-          dataset: "{{ entry.id }}",
+          // `dump` emits a JSON string literal, so an id containing a quote or an
+          // ampersand can't break out of the script or arrive HTML-escaped.
+          dataset: {{ entry.id | dump | safe }},
           variant: button.textContent.trim(),
         });
       });

--- a/content/catalog/asos-parquet.njk
+++ b/content/catalog/asos-parquet.njk
@@ -370,9 +370,32 @@ ORDER BY station, valid`
     }
   }
 
+  // Which of the canned queries this is, or 'custom' once the user has edited it.
+  // The query text itself is deliberately never reported — it is free-form user
+  // input, so it is both unbounded cardinality and not ours to collect.
+  function querySource(query) {
+    for (const [key, example] of Object.entries(EXAMPLE_QUERIES)) {
+      if (query === example.query.trim()) return { source: 'example', example: key };
+    }
+    return { source: 'custom' };
+  }
+
+  // DuckDB prefixes its messages ("Parser Error: ...", "Binder Error: ...", so on),
+  // which buckets failures usefully without putting raw messages in a property.
+  function errorKind(message) {
+    const match = /^([A-Za-z ]*Error)\b/.exec(message);
+    return match ? match[1] : 'other';
+  }
+
   async function runCustomQuery() {
     const query = document.getElementById('sqlQuery').value.trim();
     if (!query) { updateStatus('Enter a query'); return; }
+
+    // Reported once from `finally` so the no-results early return, the error path,
+    // and the success path are all counted. How often this tool fails, and on what,
+    // is invisible today.
+    const started = performance.now();
+    const run = { ok: false, row_count: 0, ...querySource(query) };
 
     try {
       const btn = document.getElementById('runQueryBtn');
@@ -388,6 +411,8 @@ ORDER BY station, valid`
 
       const result = await conn.query(query);
       const rows = result.toArray();
+      run.ok = true;
+      run.row_count = rows.length;
 
       if (rows.length === 0) {
         updateStatus('No results');
@@ -566,9 +591,15 @@ ORDER BY station, valid`
       updateStatus(data.length.toLocaleString() + ' records');
     } catch (error) {
       let errorMsg = error.message || String(error);
+      // Rendering runs after the query resolves, so a failure here can arrive with
+      // run.ok already true. `ok` tracks whether the user got results, not whether
+      // DuckDB returned.
+      run.ok = false;
+      run.error_kind = errorKind(errorMsg);
       if (errorMsg.includes('WebAssembly') || errorMsg.includes('[object')) {
         const urlMatches = query.match(/https?:\/\/[^\s'")]+/g);
         if (urlMatches) {
+          run.error_kind = 'file_access';
           console.group('Diagnosing URLs...');
           for (const url of urlMatches) {
             try {
@@ -586,6 +617,7 @@ ORDER BY station, valid`
       const btn = document.getElementById('runQueryBtn');
       btn.disabled = false;
       btn.textContent = 'Run Query';
+      track('query_run', { ...run, duration_ms: Math.round(performance.now() - started) });
     }
   }
 

--- a/content/updates.njk
+++ b/content/updates.njk
@@ -12,7 +12,7 @@ redirect_from: [/follow, /follow.html]
     action="https://buttondown.email/api/emails/embed-subscribe/dynamical"
     method="post"
     target="popupwindow"
-    onsubmit="window.open('https://buttondown.email/dynamical', 'popupwindow')"
+    onsubmit="window.open('https://buttondown.email/dynamical', 'popupwindow'); track('newsletter_subscribed', { placement: 'updates' })"
     class="embeddable-buttondown-form"
   >
     <label for="email">Email</label>

--- a/content/updates.njk
+++ b/content/updates.njk
@@ -12,7 +12,7 @@ redirect_from: [/follow, /follow.html]
     action="https://buttondown.email/api/emails/embed-subscribe/dynamical"
     method="post"
     target="popupwindow"
-    onsubmit="window.open('https://buttondown.email/dynamical', 'popupwindow'); track('newsletter_subscribed', { placement: 'updates' })"
+    onsubmit="window.open('https://buttondown.email/dynamical', 'popupwindow'); window.track('newsletter_subscribed', { placement: 'updates' })"
     class="embeddable-buttondown-form"
   >
     <label for="email">Email</label>

--- a/test/track-helper.test.mjs
+++ b/test/track-helper.test.mjs
@@ -1,0 +1,69 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import vm from "node:vm";
+
+// Every custom event goes through `window.track`. Two properties make that safe to call
+// from any page script, and both are easy to undo by accident:
+//
+//   1. It is defined outside the `{% if metadata.posthogKey %}` block. Inside it, a build
+//      without a key would leave `track` undefined and every call site would throw.
+//   2. It no-ops rather than throwing when posthog is absent — which is the normal state
+//      off production, where the snippet is gated on the hostname.
+
+const BASE = readFileSync(new URL("../_includes/base.njk", import.meta.url), "utf8");
+
+function trackSource() {
+  const blocks = [...BASE.matchAll(/<script>([\s\S]*?)<\/script>/g)].map((m) => m[1]);
+  const found = blocks.filter((b) => b.includes("window.track = function"));
+  assert.equal(found.length, 1, "expected exactly one script defining window.track");
+  return found[0];
+}
+
+function run(source, globals = {}) {
+  const sandbox = { console, ...globals };
+  sandbox.window = sandbox;
+  vm.runInContext(source, vm.createContext(sandbox));
+  return sandbox;
+}
+
+test("track is defined outside the posthog key conditional", () => {
+  const start = BASE.indexOf("{% if metadata.posthogKey %}");
+  assert.notEqual(start, -1, "posthog block not found");
+  const end = BASE.indexOf("{% endif %}", start);
+  assert.notEqual(end, -1, "posthog block is unterminated");
+
+  const guarded = BASE.slice(start, end);
+  assert.ok(
+    !guarded.includes("window.track"),
+    "track is defined inside `{% if metadata.posthogKey %}`; a build without a key would " +
+      "leave it undefined and every call site would throw",
+  );
+});
+
+test("track forwards to posthog.capture when it is present", () => {
+  const calls = [];
+  const sandbox = run(trackSource(), { posthog: { capture: (e, p) => calls.push([e, p]) } });
+
+  sandbox.track("query_run", { ok: true });
+
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0][0], "query_run");
+  assert.equal(calls[0][1].ok, true);
+});
+
+test("track is a silent no-op when posthog is absent or broken", () => {
+  // Off production the snippet never runs, so posthog is simply not there.
+  const absent = run(trackSource());
+  assert.doesNotThrow(() => absent.track("query_run", { ok: true }));
+
+  // And a vendor bundle that loaded but throws must not take a page down with it.
+  const broken = run(trackSource(), {
+    posthog: {
+      capture() {
+        throw new Error("vendor exploded");
+      },
+    },
+  });
+  assert.doesNotThrow(() => broken.track("query_run", { ok: true }));
+});


### PR DESCRIPTION
Follows dynamical-org/dynamical.org#161. Companion to dynamical-org/wxopticon#119, which
adds the two webhooks-app events.

Everything on the site was autocapture-only, so the questions worth asking were all
unanswerable: which access path people use, whether the ASOS query tool actually works for
them, how often the newsletter form converts.

## Events

| Event | Properties | Answers |
|---|---|---|
| `snippet_variant_selected` | `dataset`, `variant` | `dynamical-catalog` vs hand-rolled `pystac + icechunk`, per dataset — where docs and library effort are going |
| `query_run` | `source`, `example`, `ok`, `row_count`, `error_kind`, `duration_ms` | Whether the DuckDB-WASM tool works, and how it fails |
| `newsletter_subscribed` | `placement` | Footer vs `/updates` conversion |

`query_run` is reported from `finally`, so the no-results early return, the error path, and
the success path are all counted — not just the happy one.

## What is deliberately not collected

- **The SQL text.** Free-form user input: unbounded cardinality and not ours to collect.
  Errors bucket by DuckDB's own message prefix (`Parser Error`, `Binder Error`) instead.
- **A `dataset_page_viewed` event.** `$pageview` with a pathname breakdown already covers it.

## The `track` helper

All events go through `window.track`, defined in `base.njk` **outside** the
`{% if metadata.posthogKey %}` block and wrapped in try/catch. Call sites then need no
`typeof posthog` guard and nothing breaks off production, where the snippet is
hostname-gated and `posthog` is undefined. Moving it back inside that conditional would turn
every call site into a TypeError, so `test/track-helper.test.mjs` pins it, along with the
no-op and never-throw behavior. 59 tests pass (was 56).

## Verified in a browser

Against a local build, with a stub recording what `track` sends:

```
snippet_variant_selected {dataset: "ecmwf-ifs-ens-forecast-15-day-0-25-degree",
                          variant: "dynamical-catalog"}
newsletter_subscribed    {placement: "footer"}
```

And real DuckDB-WASM runs on `/catalog/asos-parquet/`:

```
invalid SQL   -> {ok: false, row_count: 0, source: "custom", error_kind: "Parser Error", duration_ms: 8}
canned example-> {ok: true,  row_count: 5427, source: "example", example: "default_ytd", duration_ms: 9751}
```

Worth noting from that last one: the default example query takes ~10s. `duration_ms` will
tell you whether that is typical.