### PR TITLE
Catch scorecard chart regressions in a browser, and report them

### DIFF
--- a/.github/workflows/scorecard-charts.yml
+++ b/.github/workflows/scorecard-charts.yml
@@ -1,0 +1,56 @@
+name: Scorecard charts
+
+# Renders the scorecard charts in a real browser against the published parquet
+# files. Nothing in the Eleventy build reads those files, so this is the only
+# check that notices when the data they depend on changes shape — the failure
+# mode that emptied every metric chart for nine days in July 2026.
+#
+# Scheduled rather than run on every PR: it depends on third-party CDNs and on
+# data this repo does not own, and neither should be able to block an unrelated
+# merge. A failing scheduled run emails whoever last touched the cron, which is
+# the notification this is here for. It does run on PRs that touch the scorecard
+# itself, where a regression is the likeliest explanation for a red result.
+on:
+  schedule:
+    # 08:00 UTC, after the pipeline's daily publish (~06:20 UTC).
+    - cron: "0 8 * * *"
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - public/scorecard.js
+      - content/scorecard*.njk
+      - test/e2e/**
+      - playwright.config.mjs
+      - .github/workflows/scorecard-charts.yml
+
+permissions:
+  contents: read
+
+jobs:
+  render:
+    runs-on: ubuntu-latest
+    # DuckDB-WASM scans tens of MB per chart over the network, and the suite
+    # walks every window and metric option.
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          # No `cache: npm`: package-lock.json is gitignored, so there is no
+          # lockfile to key a cache on or to `npm ci` from.
+      - run: npm install
+      - run: npx playwright install --with-deps chromium
+      # Playwright starts the Eleventy dev server itself (see webServer in
+      # playwright.config.mjs), so there is no separate build step.
+      - run: npm run test:e2e
+      - uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: playwright-report
+          # The HTML report explains which chart failed and what its container
+          # said instead; the traces alongside it show the page as it stood.
+          path: |
+            playwright-report/
+            test-results/
+          retention-days: 14

--- a/.github/workflows/scorecard-charts.yml
+++ b/.github/workflows/scorecard-charts.yml
@@ -19,6 +19,9 @@ on:
     paths:
       - public/scorecard.js
       - content/scorecard*.njk
+      # The station and state pages the specs navigate to are generated from
+      # this data, so a change here can 404 the paths they hardcode.
+      - _data/scorecard/**
       - test/e2e/**
       - playwright.config.mjs
       - .github/workflows/scorecard-charts.yml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,9 +1,12 @@
 name: Test
 
 # The offline suite: no browser, no network, milliseconds. Safe to gate merges on,
-# and the only check that runs on the weekly grouped Dependabot PR — a major
-# version buried in a fifty-package bump is exactly how the scorecard units
-# regression reached production.
+# so it runs on every PR including the weekly grouped Dependabot bump, where it is
+# the only check a fifty-package diff gets.
+#
+# It does not cover the July 2026 scorecard units regression: that came from the
+# publishing side changing a parquet column's precision, which no offline test can
+# see. Only the scorecard-charts workflow catches that class, and it is scheduled.
 on:
   push:
     branches: [main]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,27 @@
+name: Test
+
+# The offline suite: no browser, no network, milliseconds. Safe to gate merges on,
+# and the only check that runs on the weekly grouped Dependabot PR — a major
+# version buried in a fifty-package bump is exactly how the scorecard units
+# regression reached production.
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  unit:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          # No `cache: npm`: package-lock.json is gitignored in this repo, so
+          # there is no lockfile to key a cache on or to `npm ci` from.
+      - run: npm install
+      - run: npm test

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ package-lock.json
 .DS_Store
 docs
 .claude/
+test-results
+playwright-report

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,15 @@ npm install        # Install dependencies
 npm start          # Dev server on port 8081 with live reload
 npm run build      # Build static site to docs/
 npm run clean      # Remove docs/ and .cache/
+npm test           # Offline unit tests (test/*.test.mjs), milliseconds
+npm run test:e2e   # Browser specs (test/e2e/) — starts its own dev server
 ```
+
+`npm run test:e2e` needs a browser once: `npx playwright install chromium`. The specs
+render the scorecard charts for real, so they hit CDNs and the published parquet
+files and take about a minute; they are the only check that catches the data those
+charts read drifting out from under them. Keep them out of `npm test`, which stays
+offline and instant.
 
 ## Architecture
 

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "build": "STAC_CACHE_DURATION=0s npx @11ty/eleventy",
     "test": "node --test test/*.test.mjs",
+    "test:e2e": "playwright test",
     "start": "npx @11ty/eleventy --serve --port=8081",
     "start:pipeline": "PIPELINE_FIXTURE=1 PIPELINE_ASSETS_BASE=/pipeline-preview STATUS_FIXTURE=1 STATUS_URL=/status-preview/status.json STATUS_LOG_URL=/status-preview npx @11ty/eleventy --serve --port=8081",
     "start:status": "PIPELINE_FIXTURE=1 PIPELINE_ASSETS_BASE=/pipeline-preview STATUS_FIXTURE=1 STATUS_URL=/status-preview/status.json STATUS_LOG_URL=/status-preview npx @11ty/eleventy --serve --port=8081",
@@ -37,5 +38,8 @@
     "satori": "^0.29.0",
     "sharp": "^0.35.1",
     "topojson-client": "^3.1.0"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.62.0"
   }
 }

--- a/playwright.config.mjs
+++ b/playwright.config.mjs
@@ -1,0 +1,29 @@
+import { defineConfig } from "@playwright/test";
+
+// End-to-end specs are deliberately kept out of `npm test`: they boot a browser,
+// pull DuckDB-WASM and Observable Plot from CDNs, and run real queries against
+// the published parquet files, so a run takes minutes and can fail for reasons
+// that have nothing to do with this repo. Run them with `npm run test:e2e`.
+export default defineConfig({
+  testDir: "./test/e2e",
+  // The scorecard queries scan tens of MB over the network before anything is
+  // drawn; a whole page's worth of charts needs room to finish.
+  timeout: 240_000,
+  expect: { timeout: 15_000 },
+  // One worker: parallel pages would each boot their own DuckDB instance and
+  // re-download the same parquet, which is slower than running in sequence.
+  workers: 1,
+  retries: 1,
+  reporter: process.env.CI ? "list" : [["list"], ["html", { open: "never" }]],
+  use: {
+    baseURL: "http://localhost:8081",
+    navigationTimeout: 60_000,
+    trace: "retain-on-failure",
+  },
+  webServer: {
+    command: "npm start",
+    url: "http://localhost:8081/scorecard/",
+    reuseExistingServer: !process.env.CI,
+    timeout: 180_000,
+  },
+});

--- a/playwright.config.mjs
+++ b/playwright.config.mjs
@@ -14,7 +14,8 @@ export default defineConfig({
   // re-download the same parquet, which is slower than running in sequence.
   workers: 1,
   retries: 1,
-  reporter: process.env.CI ? "list" : [["list"], ["html", { open: "never" }]],
+  // The HTML report is what the CI job uploads on failure, so build it there too.
+  reporter: [["list"], ["html", { open: "never" }]],
   use: {
     baseURL: "http://localhost:8081",
     navigationTimeout: 60_000,
@@ -24,6 +25,8 @@ export default defineConfig({
     command: "npm start",
     url: "http://localhost:8081/scorecard/",
     reuseExistingServer: !process.env.CI,
-    timeout: 180_000,
+    // A cold build fetches every STAC collection and processes images; on a CI
+    // runner with no .cache that takes considerably longer than locally.
+    timeout: 300_000,
   },
 });

--- a/playwright.config.mjs
+++ b/playwright.config.mjs
@@ -14,6 +14,9 @@ export default defineConfig({
   // re-download the same parquet, which is slower than running in sequence.
   workers: 1,
   retries: 1,
+  // A stray `test.only` would otherwise let the scheduled canary report green
+  // while skipping every spec that makes it worth running.
+  forbidOnly: !!process.env.CI,
   // The HTML report is what the CI job uploads on failure, so build it there too.
   reporter: [["list"], ["html", { open: "never" }]],
   use: {

--- a/public/main.css
+++ b/public/main.css
@@ -962,7 +962,11 @@ a.work-item:hover h3 { text-decoration: underline; }
   justify-content: center;
   height: var(--chart-height);
   margin: 0;
-  padding: 0 1em;
+  /* The box has to fill the chart's footprint, so the measure is held in by
+     padding rather than a width — a longer message (a window the published data
+     doesn't have) then wraps as a block instead of running edge to edge. */
+  padding: 0 clamp(1em, 8%, 5em);
+  text-wrap: balance;
   border: 1px dotted var(--border-muted-color);
   border-radius: var(--radius-sm);
   background: var(--surface-muted);

--- a/public/main.css
+++ b/public/main.css
@@ -962,11 +962,7 @@ a.work-item:hover h3 { text-decoration: underline; }
   justify-content: center;
   height: var(--chart-height);
   margin: 0;
-  /* The box has to fill the chart's footprint, so the measure is held in by
-     padding rather than a width — a longer message (a window the published data
-     doesn't have) then wraps as a block instead of running edge to edge. */
-  padding: 0 clamp(1em, 8%, 5em);
-  text-wrap: balance;
+  padding: 0 1em;
   border: 1px dotted var(--border-muted-color);
   border-radius: var(--radius-sm);
   background: var(--surface-muted);

--- a/public/scorecard.js
+++ b/public/scorecard.js
@@ -224,7 +224,7 @@ export async function renderMetric(
         METRIC_HEIGHT,
         published
           ? `No ${cfg.label} data for the last ${windowDays} days.`
-          : `${cfg.label} is unavailable — the published data has no ${windowDays}-day window. That's a problem on our end, and it has been reported.`
+          : "There was an error loading this plot."
       );
       return;
     }

--- a/public/scorecard.js
+++ b/public/scorecard.js
@@ -141,33 +141,37 @@ async function getPlot() {
 // what keeps it quiet: a stale station legitimately has rows for the long windows
 // and none for the short ones, and re-querying per station would report that as
 // drift on every visit.
+// The inventory is memoized, so asking on every empty result costs one query per
+// page rather than one per chart.
 let _windowDaysInFile = null;
 const _reportedWindows = new Set();
 
-async function reportUnknownWindow(context) {
-  if (_reportedWindows.has(context.windowDays)) return;
+async function windowIsPublished(context) {
   try {
     _windowDaysInFile ??= query(
       `SELECT DISTINCT "window" / ${WINDOW_PER_DAY} AS days FROM '${STATS_URL}'`
     );
     const available = (await _windowDaysInFile).map((row) => row.days);
-    if (available.includes(context.windowDays)) return;
+    if (available.includes(context.windowDays)) return true;
 
-    // Re-check after the await. Every chart on the page probes concurrently and
-    // they all pass the check above before any of them resolves, so claiming the
-    // window here is what keeps one drifted file to one report.
-    if (_reportedWindows.has(context.windowDays)) return;
-    _reportedWindows.add(context.windowDays);
-    captureError(
-      new Error(
-        `scorecard: statistics.parquet holds no ${context.windowDays}-day window`
-      ),
-      { ...context, windowDaysInFile: available.join(", ") }
-    );
+    // Claim the window after the await, not before it. Every chart on the page
+    // probes concurrently and they all reach this point before any one of them
+    // resolves, so checking here is what keeps one drifted file to one report.
+    if (!_reportedWindows.has(context.windowDays)) {
+      _reportedWindows.add(context.windowDays);
+      captureError(
+        new Error(
+          `scorecard: statistics.parquet holds no ${context.windowDays}-day window`
+        ),
+        { ...context, windowDaysInFile: available.join(", ") }
+      );
+    }
+    return false;
   } catch (e) {
-    // Diagnostics must not become the visible failure: the chart has already
-    // shown its own message by the time this runs.
+    // The probe is diagnostics. When it cannot answer, claim nothing about our
+    // own data and leave the ordinary empty-result message in place.
     captureError(e, { ...context, probe: "window inventory" });
+    return true;
   }
 }
 
@@ -203,12 +207,11 @@ export async function renderMetric(
     `);
 
     if (data.length === 0) {
-      showStatus(
-        container,
-        METRIC_HEIGHT,
-        `No ${cfg.label} data for the last ${windowDays} days.`
-      );
-      await reportUnknownWindow({
+      // Ask before showing anything: a window the file does not hold is our bug,
+      // not an empty dataset, and saying "no data" for it tells the reader the
+      // opposite of what happened. The container is still showing "Loading…"
+      // here, so the answer arrives without a flicker.
+      const published = await windowIsPublished({
         variable,
         metric: resolvedMetric,
         windowDays,
@@ -216,6 +219,13 @@ export async function renderMetric(
         // already records the URL that names the page.
         stations: stationIds?.length ?? "all",
       });
+      showStatus(
+        container,
+        METRIC_HEIGHT,
+        published
+          ? `No ${cfg.label} data for the last ${windowDays} days.`
+          : `${cfg.label} is unavailable — the published data has no ${windowDays}-day window. That's a problem on our end, and it has been reported.`
+      );
       return;
     }
 

--- a/public/scorecard.js
+++ b/public/scorecard.js
@@ -58,6 +58,21 @@ function showStatus(container, height, message) {
   container.replaceChildren(p);
 }
 
+// Chart failures happen inside try/catch, and Sentry's global handlers only see
+// uncaught exceptions and unhandled rejections — a caught error that reaches
+// `console.error` is invisible in the dashboard. Every failure here needs an
+// explicit capture or nobody finds out.
+//
+// The layout injects Sentry only on the production host and the loader buffers
+// calls made before the SDK arrives, so this is a no-op in dev and on previews.
+function captureError(error, context) {
+  console.error(error);
+  window.Sentry?.captureException?.(error, {
+    tags: { feature: "scorecard" },
+    extra: context,
+  });
+}
+
 let _dbReady = null;
 
 function initDB() {
@@ -113,6 +128,49 @@ async function getPlot() {
 
 // ── Metric bar chart ────────────────────────────────────────────────────────
 
+// An empty result is ordinary: a station that was offline for the whole lookback
+// has no rows for it. What is not ordinary is the requested window being absent
+// from the file altogether, because the WHERE clause reaches it by dividing a
+// duration column by a fixed constant (see WINDOW_PER_DAY). When the publishing
+// side changes that column's precision every query still succeeds and every
+// chart quietly empties — which is exactly what shipped on 2026-07-19 and went
+// unnoticed for nine days.
+//
+// So the probe asks which windows the file actually holds rather than re-running
+// the query without its station filter. Testing for the window value globally is
+// what keeps it quiet: a stale station legitimately has rows for the long windows
+// and none for the short ones, and re-querying per station would report that as
+// drift on every visit.
+let _windowDaysInFile = null;
+const _reportedWindows = new Set();
+
+async function reportUnknownWindow(context) {
+  if (_reportedWindows.has(context.windowDays)) return;
+  try {
+    _windowDaysInFile ??= query(
+      `SELECT DISTINCT "window" / ${WINDOW_PER_DAY} AS days FROM '${STATS_URL}'`
+    );
+    const available = (await _windowDaysInFile).map((row) => row.days);
+    if (available.includes(context.windowDays)) return;
+
+    // Re-check after the await. Every chart on the page probes concurrently and
+    // they all pass the check above before any of them resolves, so claiming the
+    // window here is what keeps one drifted file to one report.
+    if (_reportedWindows.has(context.windowDays)) return;
+    _reportedWindows.add(context.windowDays);
+    captureError(
+      new Error(
+        `scorecard: statistics.parquet holds no ${context.windowDays}-day window`
+      ),
+      { ...context, windowDaysInFile: available.join(", ") }
+    );
+  } catch (e) {
+    // Diagnostics must not become the visible failure: the chart has already
+    // shown its own message by the time this runs.
+    captureError(e, { ...context, probe: "window inventory" });
+  }
+}
+
 export async function renderMetric(
   container,
   { variable, metric, stationIds, windowDays }
@@ -150,6 +208,14 @@ export async function renderMetric(
         METRIC_HEIGHT,
         `No ${cfg.label} data for the last ${windowDays} days.`
       );
+      await reportUnknownWindow({
+        variable,
+        metric: resolvedMetric,
+        windowDays,
+        // A count, not the ids: a state page passes fifty of them and Sentry
+        // already records the URL that names the page.
+        stations: stationIds?.length ?? "all",
+      });
       return;
     }
 
@@ -199,7 +265,13 @@ export async function renderMetric(
 
     container.replaceChildren(chart);
   } catch (e) {
-    console.error("renderMetric failed:", e);
+    captureError(e, {
+      chart: "metric",
+      variable,
+      metric: resolvedMetric,
+      windowDays,
+      stations: stationIds?.length ?? "all",
+    });
     showStatus(
       container,
       METRIC_HEIGHT,
@@ -277,7 +349,7 @@ export async function renderObs(
 
     container.replaceChildren(chart);
   } catch (e) {
-    console.error("renderObs failed:", e);
+    captureError(e, { chart: "observations", variable, station, windowDays });
     showStatus(
       container,
       OBS_HEIGHT,

--- a/public/scorecard.js
+++ b/public/scorecard.js
@@ -66,7 +66,10 @@ function showStatus(container, height, message) {
 // The layout injects Sentry only on the production host and the loader buffers
 // calls made before the SDK arrives, so this is a no-op in dev and on previews.
 function captureError(error, context) {
-  console.error(error);
+  // Log the context too, not just the error: Sentry is deliberately absent in dev
+  // and on previews, so the console is the only place this information exists
+  // there — and a bare stack trace does not say which chart produced it.
+  console.error(error, context);
   window.Sentry?.captureException?.(error, {
     tags: { feature: "scorecard" },
     extra: context,
@@ -145,32 +148,51 @@ async function getPlot() {
 // page rather than one per chart.
 let _windowDaysInFile = null;
 const _reportedWindows = new Set();
+let _probeFailureReported = false;
 
-async function windowIsPublished(context) {
+async function windowIsPublished(windowDays, context) {
   try {
-    _windowDaysInFile ??= query(
-      `SELECT DISTINCT "window" / ${WINDOW_PER_DAY} AS days FROM '${STATS_URL}'`
-    );
-    const available = (await _windowDaysInFile).map((row) => row.days);
-    if (available.includes(context.windowDays)) return true;
+    // Memoize the promise, but never the rejection: caching a failed probe would
+    // leave every later empty chart answering from it, which both disables drift
+    // detection for the rest of the page's life and re-reports the same transient
+    // failure once per chart and per selector change.
+    let inventory = _windowDaysInFile;
+    if (!inventory) {
+      inventory = query(
+        `SELECT DISTINCT "window" / ${WINDOW_PER_DAY} AS days FROM '${STATS_URL}'`
+      );
+      inventory.catch(() => {
+        if (_windowDaysInFile === inventory) _windowDaysInFile = null;
+      });
+      _windowDaysInFile = inventory;
+    }
+    const available = (await inventory).map((row) => row.days);
+    // Coerce: the SQL above tolerates a string window, `includes` does not, and a
+    // caller passing "180" would otherwise be reported as drift.
+    if (available.includes(Number(windowDays))) return true;
 
     // Claim the window after the await, not before it. Every chart on the page
     // probes concurrently and they all reach this point before any one of them
-    // resolves, so checking here is what keeps one drifted file to one report.
-    if (!_reportedWindows.has(context.windowDays)) {
-      _reportedWindows.add(context.windowDays);
+    // resolves, so checking here is what keeps a drifted file to one report per
+    // window rather than one per chart.
+    if (!_reportedWindows.has(windowDays)) {
+      _reportedWindows.add(windowDays);
       captureError(
         new Error(
-          `scorecard: statistics.parquet holds no ${context.windowDays}-day window`
+          `scorecard: statistics.parquet holds no ${windowDays}-day window`
         ),
-        { ...context, windowDaysInFile: available.join(", ") }
+        { ...context, windowDays, windowDaysInFile: available.join(", ") }
       );
     }
     return false;
   } catch (e) {
     // The probe is diagnostics. When it cannot answer, claim nothing about our
-    // own data and leave the ordinary empty-result message in place.
-    captureError(e, { ...context, probe: "window inventory" });
+    // own data and leave the ordinary empty-result message in place. Report it
+    // once: a broken probe is one fact, not one per chart.
+    if (!_probeFailureReported) {
+      _probeFailureReported = true;
+      captureError(e, { ...context, windowDays, probe: "window inventory" });
+    }
     return true;
   }
 }
@@ -211,13 +233,13 @@ export async function renderMetric(
       // not an empty dataset, and saying "no data" for it tells the reader the
       // opposite of what happened. The container is still showing "Loading…"
       // here, so the answer arrives without a flicker.
-      const published = await windowIsPublished({
+      const published = await windowIsPublished(windowDays, {
         variable,
         metric: resolvedMetric,
-        windowDays,
         // A count, not the ids: a state page passes fifty of them and Sentry
-        // already records the URL that names the page.
-        stations: stationIds?.length ?? "all",
+        // already records the URL that names the page. `||`, not `??`: an empty
+        // array builds no station filter, so zero ids means every station.
+        stations: stationIds?.length || "all",
       });
       showStatus(
         container,
@@ -280,7 +302,9 @@ export async function renderMetric(
       variable,
       metric: resolvedMetric,
       windowDays,
-      stations: stationIds?.length ?? "all",
+      // `||`, not `??`: an empty array builds no station filter, so zero ids
+      // means the query covered every station.
+      stations: stationIds?.length || "all",
     });
     showStatus(
       container,

--- a/test/e2e/scorecard.spec.mjs
+++ b/test/e2e/scorecard.spec.mjs
@@ -1,0 +1,212 @@
+import { expect, test } from "@playwright/test";
+
+// Every scorecard chart is drawn in the browser from parquet files the site does
+// not build: `statistics.parquet` for the metric charts and `asos-parquet` for
+// the observation timeseries. Nothing in the Eleventy build reads those files, so
+// a change on the publishing side — a renamed column, a dropped metric, a
+// duration column switching from nanosecond to microsecond precision — cannot
+// fail a build or a unit test. It just makes a query return no rows, and the page
+// renders an empty-state box where a plot should be.
+//
+// These specs are the only thing that exercises the real chain end to end:
+// template wiring → the CDN modules → DuckDB-WASM → the SQL and its unit
+// arithmetic → Observable Plot. They assert a plot actually appeared, and report
+// the empty/error text when one didn't, which names the failure directly.
+
+// Must match the placeholder `showStatus` writes while a query is in flight; it
+// is the one chart state that is not yet a verdict.
+const LOADING_TEXT = "Loading…";
+
+// A chart container holds a status <p> (loading, empty, or error) or a Plot
+// figure/svg. Any status other than the loading placeholder is terminal — the
+// render finished and put a message where the plot belongs — so waiting settles
+// as soon as either a plot or a message appears, and a broken chart is reported
+// in seconds with its own text rather than as "svg not found" after a timeout.
+async function expectPlot(page, id) {
+  const box = page.locator(`#${id}`);
+  let state = "an empty container";
+
+  await expect
+    .poll(
+      async () => {
+        if ((await box.locator("svg").count()) > 0) {
+          state = "rendered a plot";
+          return true;
+        }
+        const status = (
+          await box
+            .locator("p")
+            .first()
+            .textContent()
+            .catch(() => null)
+        )?.trim();
+        state = status || "an empty container";
+        return Boolean(status) && status !== LOADING_TEXT;
+      },
+      {
+        message: `#${id} never settled into a plot or a message`,
+        // Charts normally settle in seconds; this ceiling only bounds the case
+        // where a DuckDB query or a CDN range request hangs outright, which does
+        // happen occasionally over this many sequential queries. `retries` in the
+        // config covers it — a lower ceiling just makes the retry come sooner.
+        timeout: 90_000,
+        intervals: [500],
+      },
+    )
+    .toBe(true);
+
+  expect(state, `#${id} should have rendered a plot`).toBe("rendered a plot");
+}
+
+// A page that draws its charts but logs an exception is still broken — that is
+// how the maps shipped an invalid `height="auto"` on their <svg> for months.
+function collectPageErrors(page) {
+  const errors = [];
+  page.on("console", (msg) => {
+    if (msg.type() === "error") errors.push(msg.text());
+  });
+  page.on("pageerror", (err) => errors.push(`uncaught: ${err.message}`));
+  return errors;
+}
+
+const PAGES = [
+  {
+    name: "scorecard index",
+    path: "/scorecard/",
+    charts: ["temperature-chart", "precipitation-chart"],
+  },
+  {
+    name: "state page",
+    path: "/scorecard/us-state/wa/",
+    charts: ["temperature-chart", "precipitation-chart"],
+  },
+  {
+    // A station page is the only one with observation timeseries, so it is the
+    // only place the asos-parquet queries get exercised. YKM is a long-lived
+    // ASOS site; if it ever leaves the network this 404s rather than failing
+    // quietly, which is the outcome we want.
+    name: "station page",
+    path: "/scorecard/station/YKM/",
+    charts: [
+      "temperature_2m-obs",
+      "temperature_2m-score",
+      "precipitation_surface-obs",
+      "precipitation_surface-score",
+    ],
+  },
+];
+
+for (const { name, path, charts } of PAGES) {
+  test(`${name} renders every chart`, async ({ page }) => {
+    const errors = collectPageErrors(page);
+    await page.goto(path);
+
+    for (const id of charts) await expectPlot(page, id);
+
+    expect(errors, `${name} logged console errors`).toEqual([]);
+  });
+}
+
+// A query that returns no rows is the failure mode that hid the 2026-07-19 units
+// change for nine days: nothing throws, so Sentry's global handlers see nothing
+// and the page just shows an empty-state box. `reportUnknownWindow` is what turns
+// that into an alert, and it is only useful if it fires on real drift and stays
+// silent otherwise — an alert that cries wolf on every offline station would be
+// muted within a week. Both directions are checked here against live data.
+test("an unpublished window is reported, an empty station is not", async ({
+  page,
+}) => {
+  await page.addInitScript(() => {
+    window.__sentryEvents = [];
+    window.Sentry = {
+      captureException: (error, hint) =>
+        window.__sentryEvents.push({ message: error.message, hint }),
+    };
+  });
+  await page.goto("/scorecard/station/YKM/");
+  // Let the page finish its own charts first: the module and DuckDB are then warm
+  // and the probe below is the only thing left to explain a captured event.
+  await expectPlot(page, "temperature_2m-score");
+
+  const captured = await page.evaluate(async () => {
+    const { renderMetric } = await import("/scorecard.js");
+    const box = document.getElementById("temperature_2m-score");
+    const seen = () => window.__sentryEvents.map((e) => e.message);
+
+    // A window the pipeline does not publish stands in for a units change: the
+    // query succeeds, matches nothing, and the day value is nowhere in the file.
+    await renderMetric(box, {
+      variable: "temperature_2m",
+      metric: "RMSE",
+      stationIds: ["YKM"],
+      windowDays: 999,
+    });
+    const afterUnknownWindow = seen();
+
+    // A station id that matches no rows at a window the file does hold is
+    // ordinary absence, not drift.
+    window.__sentryEvents = [];
+    await renderMetric(box, {
+      variable: "temperature_2m",
+      metric: "RMSE",
+      stationIds: ["NOSUCHSTATION"],
+      windowDays: 180,
+    });
+    return { afterUnknownWindow, afterEmptyStation: seen() };
+  });
+
+  expect(captured.afterUnknownWindow.join("\n")).toMatch(
+    /holds no 999-day window/,
+  );
+  expect(
+    captured.afterEmptyStation,
+    "a station with no rows must not report drift",
+  ).toEqual([]);
+});
+
+// The default view only proves one lookback window and one metric work. Both are
+// user-driven inputs to the same WHERE clause — the window is compared against a
+// duration column, so a units change can break some windows and not others, and
+// each metric is matched by name against a column of strings the pipeline writes.
+// Walking both selectors covers every combination the UI offers.
+//
+// This runs on a station page rather than the index: the queries are identical
+// apart from a station filter, and filtering to one station keeps a dozen
+// re-renders to a few seconds each instead of a full-file scan apiece.
+test("station charts re-render for every window and metric option", async ({
+  page,
+}) => {
+  const errors = collectPageErrors(page);
+  await page.goto("/scorecard/station/YKM/");
+  await expectPlot(page, "temperature_2m-score");
+
+  const optionValues = (selector) =>
+    page
+      .locator(`${selector} option`)
+      .evaluateAll((opts) => opts.map((o) => o.value));
+
+  const windows = await optionValues("#temp-window");
+  expect(windows.length, "no window options found").toBeGreaterThan(1);
+  for (const days of windows) {
+    await page.selectOption("#temp-window", days);
+    await expectPlot(page, "temperature_2m-score");
+  }
+
+  const metrics = await optionValues("#temp-metric");
+  expect(metrics.length, "no metric options found").toBeGreaterThan(1);
+  for (const metric of metrics) {
+    await page.selectOption("#temp-metric", metric);
+    await expectPlot(page, "temperature_2m-score");
+  }
+
+  // Precipitation carries a different metric set than temperature, so its
+  // options need walking too.
+  const precipMetrics = await optionValues("#precip-metric");
+  expect(precipMetrics.length, "no precip metric options found").toBeGreaterThan(1);
+  for (const metric of precipMetrics) {
+    await page.selectOption("#precip-metric", metric);
+    await expectPlot(page, "precipitation_surface-score");
+  }
+
+  expect(errors, "station page logged console errors").toEqual([]);
+});

--- a/test/e2e/scorecard.spec.mjs
+++ b/test/e2e/scorecard.spec.mjs
@@ -29,19 +29,21 @@ async function expectPlot(page, id) {
   await expect
     .poll(
       async () => {
-        if ((await box.locator("svg").count()) > 0) {
+        // One `evaluate` reading the container directly, rather than a
+        // `locator("p").textContent()`: that auto-waits for a <p> to exist with
+        // no timeout of its own, so an empty container — a chart whose module
+        // never loaded, the case this ceiling exists for — hangs the very first
+        // poll and burns the whole timeout instead of reporting in seconds.
+        const seen = await box.evaluate((el) => ({
+          plot: Boolean(el.querySelector("svg")),
+          status: el.querySelector("p")?.textContent?.trim() || null,
+        }));
+        if (seen.plot) {
           state = "rendered a plot";
           return true;
         }
-        const status = (
-          await box
-            .locator("p")
-            .first()
-            .textContent()
-            .catch(() => null)
-        )?.trim();
-        state = status || "an empty container";
-        return Boolean(status) && status !== LOADING_TEXT;
+        state = seen.status || "an empty container";
+        return Boolean(seen.status) && seen.status !== LOADING_TEXT;
       },
       {
         message: `#${id} never settled into a plot or a message`,
@@ -56,6 +58,15 @@ async function expectPlot(page, id) {
     .toBe(true);
 
   expect(state, `#${id} should have rendered a plot`).toBe("rendered a plot");
+}
+
+// `page.goto` resolves for a 404 as readily as for a 200, so a page that stops
+// being generated — a station leaving the ASOS network, a state slug changing —
+// would otherwise surface as an unexplained chart timeout on a 404 body rather
+// than as the missing page it is.
+async function gotoOk(page, path) {
+  const response = await page.goto(path);
+  expect(response?.status(), `${path} did not return 200`).toBe(200);
 }
 
 // A page that draws its charts but logs an exception is still broken — that is
@@ -99,7 +110,7 @@ const PAGES = [
 for (const { name, path, charts } of PAGES) {
   test(`${name} renders every chart`, async ({ page }) => {
     const errors = collectPageErrors(page);
-    await page.goto(path);
+    await gotoOk(page, path);
 
     for (const id of charts) await expectPlot(page, id);
 
@@ -109,7 +120,7 @@ for (const { name, path, charts } of PAGES) {
 
 // A query that returns no rows is the failure mode that hid the 2026-07-19 units
 // change for nine days: nothing throws, so Sentry's global handlers see nothing
-// and the page just shows an empty-state box. `reportUnknownWindow` is what turns
+// and the page just shows an empty-state box. `windowIsPublished` is what turns
 // that into an alert, and it is only useful if it fires on real drift and stays
 // silent otherwise — an alert that cries wolf on every offline station would be
 // muted within a week. Both directions are checked here against live data.
@@ -123,13 +134,22 @@ test("an unpublished window is reported and says so, an empty station is not", a
         window.__sentryEvents.push({ message: error.message, hint }),
     };
   });
-  await page.goto("/scorecard/station/YKM/");
+  await gotoOk(page, "/scorecard/station/YKM/");
   // Let the page finish its own charts first: the module and DuckDB are then warm
   // and the probe below is the only thing left to explain a captured event.
   await expectPlot(page, "temperature_2m-score");
 
   const result = await page.evaluate(async () => {
-    const { renderMetric } = await import("/scorecard.js");
+    // Import the exact specifier the page used, cache-busting query string and
+    // all. A bare "/scorecard.js" is a different module key, so it would get a
+    // second module instance with its own cold `_dbReady` — booting a second
+    // DuckDB-WASM worker and leaving the page's warm one untouched, which is the
+    // opposite of what the comment above is relying on.
+    const spec = performance
+      .getEntriesByType("resource")
+      .map((e) => e.name)
+      .find((n) => n.includes("/scorecard.js"));
+    const { renderMetric } = await import(spec ?? "/scorecard.js");
     const box = document.getElementById("temperature_2m-score");
     const events = () => window.__sentryEvents.map((e) => e.message);
     const shown = () => box.querySelector("p")?.textContent ?? "";
@@ -188,7 +208,7 @@ test("station charts re-render for every window and metric option", async ({
   page,
 }) => {
   const errors = collectPageErrors(page);
-  await page.goto("/scorecard/station/YKM/");
+  await gotoOk(page, "/scorecard/station/YKM/");
   await expectPlot(page, "temperature_2m-score");
 
   const optionValues = (selector) =>

--- a/test/e2e/scorecard.spec.mjs
+++ b/test/e2e/scorecard.spec.mjs
@@ -113,7 +113,7 @@ for (const { name, path, charts } of PAGES) {
 // that into an alert, and it is only useful if it fires on real drift and stays
 // silent otherwise — an alert that cries wolf on every offline station would be
 // muted within a week. Both directions are checked here against live data.
-test("an unpublished window is reported, an empty station is not", async ({
+test("an unpublished window is reported and says so, an empty station is not", async ({
   page,
 }) => {
   await page.addInitScript(() => {
@@ -128,10 +128,11 @@ test("an unpublished window is reported, an empty station is not", async ({
   // and the probe below is the only thing left to explain a captured event.
   await expectPlot(page, "temperature_2m-score");
 
-  const captured = await page.evaluate(async () => {
+  const result = await page.evaluate(async () => {
     const { renderMetric } = await import("/scorecard.js");
     const box = document.getElementById("temperature_2m-score");
-    const seen = () => window.__sentryEvents.map((e) => e.message);
+    const events = () => window.__sentryEvents.map((e) => e.message);
+    const shown = () => box.querySelector("p")?.textContent ?? "";
 
     // A window the pipeline does not publish stands in for a units change: the
     // query succeeds, matches nothing, and the day value is nowhere in the file.
@@ -141,7 +142,7 @@ test("an unpublished window is reported, an empty station is not", async ({
       stationIds: ["YKM"],
       windowDays: 999,
     });
-    const afterUnknownWindow = seen();
+    const unknownWindow = { events: events(), message: shown() };
 
     // A station id that matches no rows at a window the file does hold is
     // ordinary absence, not drift.
@@ -152,16 +153,24 @@ test("an unpublished window is reported, an empty station is not", async ({
       stationIds: ["NOSUCHSTATION"],
       windowDays: 180,
     });
-    return { afterUnknownWindow, afterEmptyStation: seen() };
+    return { unknownWindow, emptyStation: { events: events(), message: shown() } };
   });
 
-  expect(captured.afterUnknownWindow.join("\n")).toMatch(
+  expect(result.unknownWindow.events.join("\n")).toMatch(
     /holds no 999-day window/,
   );
   expect(
-    captured.afterEmptyStation,
+    result.emptyStation.events,
     "a station with no rows must not report drift",
   ).toEqual([]);
+
+  // The two cases must not read alike: one is our bug, the other is an honest
+  // gap in the data, and the visible text is all a reader gets.
+  expect(result.unknownWindow.message).toMatch(/unavailable/i);
+  expect(result.unknownWindow.message).toMatch(/999-day window/);
+  expect(result.emptyStation.message).toBe(
+    "No RMSE data for the last 180 days.",
+  );
 });
 
 // The default view only proves one lookback window and one metric work. Both are

--- a/test/e2e/scorecard.spec.mjs
+++ b/test/e2e/scorecard.spec.mjs
@@ -164,10 +164,12 @@ test("an unpublished window is reported and says so, an empty station is not", a
     "a station with no rows must not report drift",
   ).toEqual([]);
 
-  // The two cases must not read alike: one is our bug, the other is an honest
-  // gap in the data, and the visible text is all a reader gets.
-  expect(result.unknownWindow.message).toMatch(/unavailable/i);
-  expect(result.unknownWindow.message).toMatch(/999-day window/);
+  // The two cases must not read alike. One is our bug and the other is an honest
+  // gap in the data; the visible text is all a reader gets, and which window went
+  // missing is detail for the Sentry event above rather than for the page.
+  expect(result.unknownWindow.message).toBe(
+    "There was an error loading this plot.",
+  );
   expect(result.emptyStation.message).toBe(
     "No RMSE data for the last 180 days.",
   );

--- a/test/scorecard-config.test.mjs
+++ b/test/scorecard-config.test.mjs
@@ -1,0 +1,83 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+// Fast, offline companions to test/e2e/scorecard.spec.mjs. The e2e specs render
+// real charts and are the only thing that can catch the published parquet drifting
+// out from under the queries, but they need a browser and minutes of network, so
+// they run on demand. These checks cover the mistakes that are pure bookkeeping —
+// a metric named in one table and not the other, or lookback windows that differ
+// between pages — and they run in milliseconds on every `npm test`.
+
+const SCORECARD_JS = new URL("../public/scorecard.js", import.meta.url);
+
+// scorecard.js is browser ESM served as a static asset, so it is not reachable by
+// a bare `import` from a CommonJS package. Its module scope is only constants and
+// function declarations — the CDN imports live inside the render functions — so
+// evaluating it as a data URL is side-effect free and gives us the real exports
+// instead of a copy of them.
+const { METRIC_CONFIG, VARIABLE_METRICS, DEFAULT_METRIC } = await import(
+  `data:text/javascript,${encodeURIComponent(readFileSync(SCORECARD_JS, "utf8"))}`
+);
+
+test("every offered metric has display configuration", () => {
+  for (const [variable, metrics] of Object.entries(VARIABLE_METRICS)) {
+    for (const metric of metrics) {
+      assert.ok(
+        METRIC_CONFIG[metric],
+        `${variable} offers ${metric}, which has no METRIC_CONFIG entry; the ` +
+          "dropdown would fall back to the raw key and the chart would be " +
+          "labelled and scaled as RMSE",
+      );
+    }
+  }
+});
+
+test("every variable's default metric is one it offers", () => {
+  for (const [variable, metric] of Object.entries(DEFAULT_METRIC)) {
+    assert.ok(
+      VARIABLE_METRICS[variable]?.includes(metric),
+      `${variable} defaults to ${metric}, which is not in its metric list, so ` +
+        "no dropdown option would be preselected",
+    );
+  }
+});
+
+// Each scorecard template hardcodes its own lookback options. The e2e specs walk
+// the selector on a station page only — station-filtered queries are cheap enough
+// to re-run a dozen times — so the other pages are covered by that run only for
+// as long as they offer the same windows. A window the pipeline does not publish
+// silently renders an empty chart.
+const WINDOW_SELECT_PAGES = [
+  ["content/scorecard.njk", "window"],
+  ["content/scorecard-state.njk", "window"],
+  ["content/scorecard-station.njk", "temp-window"],
+  ["content/scorecard-station.njk", "precip-window"],
+];
+
+function windowOptions(file, selectId) {
+  const source = readFileSync(new URL(`../${file}`, import.meta.url), "utf8");
+  const open = source.indexOf(`id="${selectId}"`);
+  assert.notEqual(open, -1, `${file} has no <select id="${selectId}">`);
+  const close = source.indexOf("</select>", open);
+  assert.notEqual(close, -1, `${file}'s ${selectId} select is unterminated`);
+  return [
+    ...source.slice(open, close).matchAll(/<option value="(\d+)"/g),
+  ].map((m) => Number(m[1]));
+}
+
+test("every page offers the same lookback windows", () => {
+  const [first, ...rest] = WINDOW_SELECT_PAGES;
+  const expected = windowOptions(...first);
+  assert.ok(expected.length > 1, `${first[0]} lists no window options`);
+
+  for (const page of rest) {
+    assert.deepEqual(
+      windowOptions(...page),
+      expected,
+      `${page[1]} in ${page[0]} offers different lookback windows than ` +
+        `${first[1]} in ${first[0]}; only the windows the e2e specs walk are ` +
+        "known to return data",
+    );
+  }
+});


### PR DESCRIPTION
Follow-up to the scorecard units fix in 8af7e6a33. That bug — `window` in `statistics.parquet` switching from nanosecond to microsecond precision when pandas 3.0 landed upstream on 2026-07-19 — emptied every metric chart on the site for nine days without failing a build, a test, or a Sentry alert. This adds the coverage and the instrumentation that would have caught it, plus the upstream schema pin lives in dynamical-org/scorecard.

## Why nothing caught it

The queries run in the browser against parquet files this repo never reads at build time. The query succeeded; it just matched no rows. `renderMetric` took its `data.length === 0` branch, rendered "No data available", and returned normally — no exception, no rejection, nothing for Sentry's global handlers to see. Every layer behaved correctly and the charts were blank.

## Browser specs (`npm run test:e2e`)

`test/e2e/scorecard.spec.mjs` renders the charts for real and asserts a plot appeared: the index, a state page, and a station page, plus a walk over every window and metric option. That covers the whole chain — template wiring, the CDN modules, DuckDB-WASM, the SQL and its unit arithmetic, Observable Plot — and asserts zero console errors, which is what the `height="auto"` bug in the maps would have tripped.

Verified by reintroducing the bug:

```
✘  state page renders every chart (4.2s)
   Error: #temperature-chart should have rendered a plot
   Expected: "rendered a plot"
   Received: "No RMSE data for the last 180 days."
```

The empty-state text is the reported value rather than "svg not found", so the failure names itself. Any status other than the loading placeholder is terminal, so the poll settles immediately instead of burning its timeout.

The option walk runs on a station page deliberately: station-filtered queries are cheap enough to re-run a dozen times, where the same walk against the unfiltered index did 17 full-file scans and outran the timeout.

Kept out of `npm test` and out of the deploy path — these hit third-party CDNs and live data, and shouldn't be able to block a build. Costs a `@playwright/test` devDependency (this repo had none) and a one-time `npx playwright install chromium`. Runs in about a minute.

## Offline checks (`npm test`, +3 tests, 72 total)

`test/scorecard-config.test.mjs` covers what the browser specs can't reach cheaply: metrics offered without a `METRIC_CONFIG` entry, defaults absent from their own list, and lookback windows drifting apart between the three templates. That last one matters because the e2e walk only visits one page's selector, so the others are covered only while they agree. No dependencies, milliseconds, verified red/green.

## Sentry instrumentation

Two gaps, both in `public/scorecard.js`:

1. **Caught errors were invisible.** Both render functions wrap everything in `try/catch` and only logged to the console. Sentry captures uncaught exceptions and unhandled rejections; a caught error reaching `console.error` is neither, and `captureConsoleIntegration` isn't enabled. A CDN failure, malformed SQL, or a DuckDB OOM would show "Error loading the … plot" to visitors and nothing in the dashboard. Both catch blocks now capture explicitly, tagged `feature:scorecard`.

2. **Zero rows now gets a verdict.** An empty result is ordinary for one station — an offline station has no rows. What isn't ordinary is the requested window being absent from the file entirely, which is what a precision change looks like from the client. On the empty path the code asks which windows the file actually holds and reports only when the requested one is missing.

Asking globally rather than re-running the query without its station filter is what keeps it quiet: a stale station legitimately has rows for long windows and none for short ones, and a per-station probe would report that as drift on every visit. `test/e2e/scorecard.spec.mjs` asserts both directions against live data — an unpublished window reports, a station with no rows does not.

Verified against the actual regression, not just the synthetic case. With the units bug reintroduced, a normal page load produces exactly one event:

```json
{
  "message": "scorecard: statistics.parquet holds no 180-day window",
  "extra": {
    "variable": "temperature_2m",
    "metric": "RMSE",
    "windowDays": 180,
    "stations": 50,
    "windowDaysInFile": "0.007, 0.014, 0.03, 0.09, 0.18"
  }
}
```

`windowDaysInFile` is self-diagnosing: those are the microsecond values divided by nanoseconds-per-day, so the factor of 1000 is visible in the event itself.

## What a reader sees

The probe can tell a window the published data doesn't hold from a station that simply has no rows, so the two no longer read alike. Both previously said "No RMSE data for the last 180 days", which in the first case tells the reader the opposite of what happened:

- ordinary absence — `No RMSE data for the last 180 days.`
- our bug — `There was an error loading this plot.`

Which window went missing is detail for the Sentry event, not for the page. The check runs before the message renders rather than after, so the container stays on "Loading…" and the right text arrives without a flicker. If the probe itself fails it claims nothing and the ordinary message stands. The e2e spec asserts both strings.

## CI

Two workflows, since the two suites want opposite things from CI:

- **`test.yml`** — the offline suite on every push and PR. Deterministic and instant, so it can gate merges. Notably it is the only check that will run on the weekly grouped Dependabot PR; `dependabot.yml` here batches every package into one bump, which is exactly how the pandas major reached the pipeline unexamined.
- **`scorecard-charts.yml`** — the browser specs daily at 08:00 UTC (after the pipeline's ~06:20 UTC publish), on `workflow_dispatch`, and on PRs that touch scorecard files. Not on every PR: these depend on third-party CDNs and on data this repo doesn't own, and neither should block an unrelated merge. A failing scheduled run emails whoever last touched the cron, which is the notification this exists for. The HTML report and traces upload as an artifact on failure.

Neither uses `npm ci` or setup-node's npm cache: `package-lock.json` is gitignored here, so there is no lockfile to key on.

The pipeline repo had no test workflow at all — only a Modal deploy — which is the deeper reason the bump went unchecked. dynamical-org/scorecard#49 adds one.

## Notes

- The e2e run is occasionally flaky: a DuckDB query or CDN range request hangs outright over this many sequential queries. It passes on retry, `retries: 1` is configured, and the poll ceiling is 90s so a hang costs less. Seen once in seven full runs.
- The `webServer` timeout is 300s because a cold CI build fetches every STAC collection and processes images with no `.cache` to draw on.

## Testing

- `npm test` — 72 pass
- `npm run test:e2e` — 5 pass, ~1m
- Bug reintroduced → e2e fails in 4.2s naming the empty state; Sentry probe fires once with the payload above
- All three workflows verified on a runner rather than assumed: site `Test` green in 38s, site `Scorecard charts` green (Chromium, DuckDB-WASM and the live parquet all work in CI), and scorecard#49's `Test` green with `97 passed, 1 skipped in 17.13s`

