### PR TITLE
Prune scorecard window queries directly

### DIFF
--- a/public/scorecard.js
+++ b/public/scorecard.js
@@ -17,10 +17,20 @@ const CHART_MARGINS = { marginLeft: 60, marginBottom: 30, marginRight: 20 };
 const METRIC_HEIGHT = 360;
 const OBS_HEIGHT = 300;
 
-// Durations in statistics.parquet are integers, but the columns don't share a
-// precision: lead_time is nanoseconds and "window" is microseconds.
-const LEAD_TIME_PER_DAY = 86_400_000_000_000;
-const WINDOW_PER_DAY = 86_400_000_000;
+// DuckDB exposes parquet durations as their encoded integers. The writer now
+// pins both durations to nanoseconds; accept the prior microsecond window
+// encoding as well so publishing the new file and deploying this query can
+// happen in either order.
+const MICROSECONDS_PER_DAY = 86_400_000_000n;
+const NANOSECONDS_PER_DAY = 86_400_000_000_000n;
+
+export function encodedWindowValues(windowDays) {
+  const window = BigInt(windowDays);
+  return [
+    window * MICROSECONDS_PER_DAY,
+    window * NANOSECONDS_PER_DAY,
+  ];
+}
 
 // Per-metric display configuration.
 export const METRIC_CONFIG = {
@@ -159,7 +169,11 @@ async function windowIsPublished(windowDays, context) {
     let inventory = _windowDaysInFile;
     if (!inventory) {
       inventory = query(
-        `SELECT DISTINCT "window" / ${WINDOW_PER_DAY} AS days FROM '${STATS_URL}'`
+        `SELECT DISTINCT CASE
+          WHEN "window" > ${365n * MICROSECONDS_PER_DAY}
+            THEN "window" / ${NANOSECONDS_PER_DAY}
+          ELSE "window" / ${MICROSECONDS_PER_DAY}
+        END AS days FROM '${STATS_URL}'`
       );
       inventory.catch(() => {
         if (_windowDaysInFile === inventory) _windowDaysInFile = null;
@@ -207,6 +221,7 @@ export async function renderMetric(
   showStatus(container, METRIC_HEIGHT, "Loading…");
   try {
     const Plot = await getPlot();
+    const encodedWindows = encodedWindowValues(windowDays).join(",");
 
     let stationFilter = "";
     if (stationIds && stationIds.length > 0) {
@@ -216,13 +231,13 @@ export async function renderMetric(
 
     const data = await query(`
       SELECT
-        CAST(lead_time / ${LEAD_TIME_PER_DAY} AS INTEGER) AS lead_time_days,
+        CAST(lead_time / ${NANOSECONDS_PER_DAY} AS INTEGER) AS lead_time_days,
         model,
         AVG(value) AS value
       FROM '${STATS_URL}'
       WHERE variable = '${variable}'
         AND metric = '${resolvedMetric}'
-        AND "window" / ${WINDOW_PER_DAY} = ${windowDays}
+        AND "window" IN (${encodedWindows})
         ${stationFilter}
       GROUP BY lead_time_days, model
       ORDER BY lead_time_days, model

--- a/test/scorecard-config.test.mjs
+++ b/test/scorecard-config.test.mjs
@@ -16,7 +16,12 @@ const SCORECARD_JS = new URL("../public/scorecard.js", import.meta.url);
 // function declarations — the CDN imports live inside the render functions — so
 // evaluating it as a data URL is side-effect free and gives us the real exports
 // instead of a copy of them.
-const { METRIC_CONFIG, VARIABLE_METRICS, DEFAULT_METRIC } = await import(
+const {
+  METRIC_CONFIG,
+  VARIABLE_METRICS,
+  DEFAULT_METRIC,
+  encodedWindowValues,
+} = await import(
   `data:text/javascript,${encodeURIComponent(readFileSync(SCORECARD_JS, "utf8"))}`
 );
 
@@ -41,6 +46,13 @@ test("every variable's default metric is one it offers", () => {
         "no dropdown option would be preselected",
     );
   }
+});
+
+test("window filters accept both published duration encodings", () => {
+  assert.deepEqual(encodedWindowValues(180), [
+    15_552_000_000_000n,
+    15_552_000_000_000_000n,
+  ]);
 });
 
 // Each scorecard template hardcodes its own lookback options. The e2e specs walk


### PR DESCRIPTION
## What changed

- compare the scorecard `window` column against its exact encoded values so DuckDB can prune parquet row groups
- accept both the currently published microsecond encoding and the scorecard writer's canonical nanosecond encoding
- normalize both encodings in the missing-window diagnostic
- add an offline unit test covering both encoded values

## Why

The live parquet still stores `window` as microseconds, while scorecard `main` now pins it to nanoseconds. The compatibility predicate makes the deploy and the next parquet publish safe in either order. It also replaces division in the filter with direct equality, which substantially reduces HTTP range work.

Measured on the current 50k-row-group layout, the directly filterable predicate reduced the national query from 4.61 MB / 73 requests to 1.41 MB / 27 requests and the YKM query from 1.91 MB / 36 requests to 0.94 MB / 20 requests.

## Validation

- `npm test`: 73 passed
- Playwright scorecard suite: all 5 DuckDB-WASM cases passed against the live microsecond parquet
- exact DuckDB query returned data from both the live microsecond parquet and fresh nanosecond writer output
- `git diff --check`