### PR TITLE
Render the event log's degraded state as delay, not downtime

### DIFF
--- a/content/status.njk
+++ b/content/status.njk
@@ -76,6 +76,11 @@ statusSection: uptime
     border-color: var(--pill-available-bg);
     background: var(--pill-available-bg);
   }
+  .status-bars [data-day="degraded"] {
+    border-style: solid;
+    border-color: var(--pill-degraded-bg);
+    background: var(--pill-degraded-bg);
+  }
   .status-bars [data-day="down"] {
     border-style: solid;
     border-color: var(--pill-down-bg);

--- a/public/status-log.mjs
+++ b/public/status-log.mjs
@@ -10,7 +10,7 @@
 
 const COVERAGE = "coverage";
 const TRANSITION = "transition";
-const PUBLIC_STATES = new Set(["operational", "down"]);
+const PUBLIC_STATES = new Set(["operational", "degraded", "down"]);
 // At equal ts the order is: coverage entry, then transitions, then coverage exit.
 // Entry first because a component must be observed before a state change of it
 // means anything; exit last because a change recorded at the instant coverage
@@ -187,8 +187,9 @@ export function incidentLog(events) {
 /**
  * One cell per UTC day in the rolling window.
  *
- * Precedence is down > unknown > operational > no data. Any observation fills
- * the day; the separate coverage percentage carries partial-day completeness.
+ * Precedence is down > degraded > unknown > operational > no data. Any
+ * observation fills the day; the separate coverage percentage carries
+ * partial-day completeness.
  */
 export function dailyBars(spans, { asOf, days }) {
   const result = new Map();
@@ -222,23 +223,28 @@ export function dailyBars(spans, { asOf, days }) {
   return result;
 }
 
-// Precedence: down > unknown > operational > no data.
+// Precedence: down > degraded > unknown > operational > no data.
 //
 // "unknown" outranking "no data" matters. A state this build does not recognize
 // is something we were told and could not read, which is not the same as nobody
 // watching — and rendering it as a coverage gap would let a state the publisher
 // added hide behind "not monitored", the same direction the down-first rule
-// exists to prevent.
+// exists to prevent. "degraded" outranks "unknown" because it is a state we
+// were told and could read; a day that was both degraded and unreadable shows
+// the stronger claim.
 function dayState(spans, start, end) {
   let operational = 0;
+  let degraded = false;
   let unknown = false;
   for (const span of spans) {
     const overlap = Math.min(span.end, end) - Math.max(span.start, start);
     if (overlap <= 0) continue;
     if (span.state === "down") return "down";
-    if (span.state === "unknown") unknown = true;
+    if (span.state === "degraded") degraded = true;
+    else if (span.state === "unknown") unknown = true;
     else operational += overlap;
   }
+  if (degraded) return "degraded";
   if (unknown) return "unknown";
   return operational > 0 ? "operational" : "nodata";
 }
@@ -259,6 +265,11 @@ function dayState(spans, start, end) {
  * way: a state we could not read is no basis for a claim, the same as a coverage
  * gap. That makes them visible in `coverage` instead of silently averaged away.
  *
+ * `degraded` spans count as monitored time that was *not* down — the component
+ * was serving, late — so they leave `uptime` untouched. They surface as the
+ * separate `delayed` percentage instead, so a chronically late component cannot
+ * hide behind a green 100%.
+ *
  * Uniform method is not uniform precision. A transition's onset is only as sharp
  * as its monitor's cadence, so a daily cron's figure is inherently coarser than an
  * HTTP detector's. That is a property of the measurement, not the arithmetic.
@@ -276,18 +287,21 @@ export function uptimeSummary(spans, { asOf, days }) {
 
     let monitored = 0;
     let down = 0;
+    let degraded = 0;
     for (const span of list) {
       if (span.state === "unknown") continue;
       const overlap = Math.min(span.end, ceiling) - Math.max(span.start, from);
       if (overlap <= 0) continue;
       monitored += overlap;
       if (span.state === "down") down += overlap;
+      else if (span.state === "degraded") degraded += overlap;
     }
     if (monitored <= 0) continue;
 
     summary.set(component, {
       uptime: truncate((100 * (monitored - down)) / monitored),
       coverage: truncate((100 * monitored) / elapsed),
+      delayed: truncate((100 * degraded) / monitored),
     });
   }
   return summary;

--- a/public/status-log.mjs
+++ b/public/status-log.mjs
@@ -267,8 +267,9 @@ function dayState(spans, start, end) {
  *
  * `degraded` spans count as monitored time that was *not* down — the component
  * was serving, late — so they leave `uptime` untouched. They surface as the
- * separate `delayed` percentage instead, so a chronically late component cannot
- * hide behind a green 100%.
+ * separate `delayed` percentage instead, ceiled rather than floored so even a
+ * sub-0.001% delay cannot round itself invisible: a chronically or briefly late
+ * component must not hide behind a green 100%.
  *
  * Uniform method is not uniform precision. A transition's onset is only as sharp
  * as its monitor's cadence, so a daily cron's figure is inherently coarser than an
@@ -301,7 +302,7 @@ export function uptimeSummary(spans, { asOf, days }) {
     summary.set(component, {
       uptime: truncate((100 * (monitored - down)) / monitored),
       coverage: truncate((100 * monitored) / elapsed),
-      delayed: truncate((100 * degraded) / monitored),
+      delayed: inflate((100 * degraded) / monitored),
     });
   }
   return summary;
@@ -310,4 +311,11 @@ export function uptimeSummary(spans, { asOf, days }) {
 // Floor to three decimals. Flooring is what stops 99.9999 from presenting as 100.
 function truncate(percent) {
   return Math.floor(percent * 1000) / 1000;
+}
+
+// Ceil to three decimals: the same rule pointed the other way. Degraded time is
+// reported against ourselves, so a witnessed delay must never floor to a flat
+// 0% — the mirror of confirmed downtime never presenting as 100% uptime.
+function inflate(percent) {
+  return Math.ceil(percent * 1000) / 1000;
 }

--- a/public/status.mjs
+++ b/public/status.mjs
@@ -129,9 +129,11 @@ function statusMark(status) {
 }
 
 export function uptimeDescription(measured, days) {
-  return `${measured.uptime}% uptime over the last ${days} ${
+  const window = `${measured.uptime}% uptime over the last ${days} ${
     days === 1 ? "day" : "days"
   }`;
+  // Delay is not downtime, but it must not hide behind a green 100% either.
+  return measured.delayed > 0 ? `${window} (${measured.delayed}% degraded)` : window;
 }
 
 function renderGroup(list, entries, bars, uptime, emptyCells) {
@@ -168,6 +170,7 @@ function renderGroup(list, entries, bars, uptime, emptyCells) {
 
 export function barDescription(cells) {
   const down = cells.filter((cell) => cell.state === "down").length;
+  const degraded = cells.filter((cell) => cell.state === "degraded").length;
   const unknown = cells.filter((cell) => cell.state === "unknown").length;
   const uncovered = cells.filter((cell) => cell.state === "nodata").length;
   const days = cells.length;
@@ -177,6 +180,7 @@ export function barDescription(cells) {
       ? `No outages recorded in the last ${days} ${plural(days)}`
       : `${down} of the last ${days} ${plural(days)} had an outage`,
   ];
+  if (degraded > 0) parts.push(`${degraded} ${plural(degraded)} degraded`);
   if (unknown > 0) parts.push(`${unknown} ${plural(unknown)} had an unknown state`);
   if (uncovered > 0) parts.push(`${uncovered} ${plural(uncovered)} not monitored`);
   return parts.join("; ");

--- a/test/status-log.test.mjs
+++ b/test/status-log.test.mjs
@@ -366,6 +366,28 @@ test("degraded opens no incident and resolves a down one", () => {
   );
 });
 
+test("a witnessed delay never rounds itself invisible", () => {
+  // 30 seconds of degraded time against months of coverage is below 0.001% —
+  // flooring would present it as a flat 0 and uptimeDescription would omit it,
+  // the mirror of the confirmed-downtime-never-shows-100% rule.
+  const spans = spansOf(
+    coverage("2026-04-27T00:00:00Z", C, true, "operational"),
+    transition("2026-07-20T00:00:00Z", C, "degraded"),
+    transition("2026-07-20T00:00:30Z", C, "operational"),
+  );
+
+  const measured = uptimeSummary(spans, { asOf: AS_OF, days: 90 }).get(C);
+
+  assert.equal(measured.uptime, 100);
+  assert.equal(measured.delayed, 0.001);
+});
+
+test("a component with no degraded time reports exactly zero delayed", () => {
+  const spans = spansOf(coverage("2026-07-15T00:00:00Z", C, true, "operational"));
+
+  assert.equal(uptimeSummary(spans, { asOf: AS_OF, days: 90 }).get(C).delayed, 0);
+});
+
 test("degraded time is monitored, leaves uptime alone, and shows as delayed", () => {
   const spans = spansOf(
     coverage("2026-07-15T00:00:00Z", C, true, "operational"),

--- a/test/status-log.test.mjs
+++ b/test/status-log.test.mjs
@@ -293,6 +293,101 @@ test("the window caps at the requested number of days", () => {
   assert.equal(dailyBars(spans, { asOf: AS_OF, days: 90 }).get(C).length, 90);
 });
 
+// --- degraded ---------------------------------------------------------------
+
+test("a degraded day outranks operational but never down", () => {
+  const spans = spansOf(
+    coverage("2026-07-22T00:00:00Z", C, true, "operational"),
+    transition("2026-07-23T10:00:00Z", C, "degraded"),
+    transition("2026-07-23T10:10:00Z", C, "operational"),
+    transition("2026-07-24T10:00:00Z", C, "degraded"),
+    transition("2026-07-24T11:00:00Z", C, "down"),
+    transition("2026-07-24T12:00:00Z", C, "operational"),
+  );
+
+  const byDate = new Map(
+    dailyBars(spans, { asOf: AS_OF, days: 90 }).get(C).map((c) => [c.date, c.state]),
+  );
+
+  assert.equal(byDate.get("2026-07-22"), "operational");
+  assert.equal(byDate.get("2026-07-23"), "degraded");
+  assert.equal(byDate.get("2026-07-24"), "down");
+});
+
+test("a degraded day outranks unknown: a state we could read beats one we could not", () => {
+  const spans = spansOf(
+    coverage("2026-07-24T00:00:00Z", C, true, "maintenance"),
+    transition("2026-07-24T12:00:00Z", C, "degraded"),
+  );
+
+  const byDate = new Map(
+    dailyBars(spans, { asOf: AS_OF, days: 90 }).get(C).map((c) => [c.date, c.state]),
+  );
+
+  assert.equal(byDate.get("2026-07-24"), "degraded");
+});
+
+test("a degraded cell links to no incident", () => {
+  const spans = spansOf(
+    coverage("2026-07-23T00:00:00Z", C, true, "operational"),
+    transition("2026-07-24T10:00:00Z", C, "degraded"),
+    transition("2026-07-24T10:10:00Z", C, "operational"),
+  );
+
+  const cell = dailyBars(spans, { asOf: AS_OF, days: 90 })
+    .get(C)
+    .find((c) => c.date === "2026-07-24");
+
+  assert.equal(cell.state, "degraded");
+  assert.equal(cell.incidentIds, undefined);
+});
+
+test("degraded opens no incident and resolves a down one", () => {
+  // Delay is not an outage: the incident list stays a record of downtime, and a
+  // component that goes from down to merely late has stopped being down.
+  const events = parseEvents(
+    jsonl(
+      coverage("2026-07-24T00:00:00Z", C, true, "operational"),
+      transition("2026-07-24T01:00:00Z", C, "degraded"),
+      transition("2026-07-24T02:00:00Z", C, "down"),
+      transition("2026-07-24T03:00:00Z", C, "degraded"),
+    ),
+  );
+
+  assert.deepEqual(
+    incidentLog(events).map(({ start, end, ending }) => ({ start, end, ending })),
+    [
+      {
+        start: Date.parse("2026-07-24T02:00:00Z"),
+        end: Date.parse("2026-07-24T03:00:00Z"),
+        ending: "resolved",
+      },
+    ],
+  );
+});
+
+test("degraded time is monitored, leaves uptime alone, and shows as delayed", () => {
+  const spans = spansOf(
+    coverage("2026-07-15T00:00:00Z", C, true, "operational"),
+    transition("2026-07-20T00:00:00Z", C, "degraded"),
+    transition("2026-07-21T00:00:00Z", C, "operational"),
+  );
+
+  const measured = uptimeSummary(spans, { asOf: AS_OF, days: 90 }).get(C);
+
+  assert.equal(measured.uptime, 100);
+  // One degraded day out of ten and a half monitored.
+  assert.ok(
+    measured.delayed > 9 && measured.delayed < 10,
+    `unexpected delayed ${measured.delayed}`,
+  );
+  // Degraded time stays in the denominator: it is not a coverage gap.
+  assert.ok(
+    measured.coverage > 11 && measured.coverage < 12,
+    `unexpected coverage ${measured.coverage}`,
+  );
+});
+
 // --- uptime -----------------------------------------------------------------
 
 test("uptime is derived from the log, so it cannot contradict the bars", () => {

--- a/test/status.test.mjs
+++ b/test/status.test.mjs
@@ -270,6 +270,24 @@ test("uptime description states the fixed window without a coverage suffix", () 
   );
 });
 
+test("bar descriptions count degraded days apart from outages", () => {
+  const description = barDescription([{ state: "degraded" }, { state: "down" }]);
+  assert.match(description, /1 of the last 2 days had an outage/i);
+  assert.match(description, /1 day degraded/i);
+});
+
+test("uptime description surfaces degraded time without calling it downtime", () => {
+  assert.equal(
+    uptimeDescription({ uptime: 100, coverage: 50, delayed: 0.007 }, 90),
+    "100% uptime over the last 90 days (0.007% degraded)",
+  );
+  // A history object from before the delayed field existed must render as before.
+  assert.equal(
+    uptimeDescription({ uptime: 100, coverage: 50 }, 90),
+    "100% uptime over the last 90 days",
+  );
+});
+
 test("status page passes its timestamp into the shared subnav row", () => {
   const template = readFileSync(
     new URL("../content/status.njk", import.meta.url),


### PR DESCRIPTION
Reader half of dynamical-org/dynamical.org-data#20 — see that PR for the full plan and rationale.

The event log is gaining a third state, `degraded`, for tool-group cron components whose check-ins run late without anything failing (the 2026-07-29 Modal capacity crunch published 10-minute "Arrivals dashboard" outages that were really artifacts rebuilt a few minutes late). This PR teaches the page the new state **ahead of the writer emitting it**, so the first degraded transition renders as a yellow delayed cell rather than falling back to `unknown`.

- `status-log.mjs`: `degraded` joins `PUBLIC_STATES`; day-cell precedence becomes down > degraded > unknown > operational > no data; `uptimeSummary` counts degraded spans as monitored-but-not-down and reports a separate `delayed` percentage.
- `status.mjs`: bar aria-descriptions count degraded days apart from outages; the uptime line appends "(x% degraded)" when nonzero (and renders unchanged for pre-`delayed` history objects).
- `status.njk`: degraded day cells reuse the snapshot's degraded pill color.
- Incidents are untouched by design: degraded opens no incident and resolves a down one — delay is not an outage.

**Merge and deploy this before the publisher PR.**