### PR TITLE
Subdivide the status day bars into intra-day segments

### DIFF
--- a/content/status.njk
+++ b/content/status.njk
@@ -53,37 +53,58 @@ statusSection: uptime
     color: var(--pill-muted-fg);
     background: var(--pill-muted-bg);
   }
+  /* Fixed-pixel day cells, not 1fr: at this scale fractional widths antialias
+     sub-day marks into mush. Each day is 6px wide — two 3px segment columns
+     touching, so contiguous time reads as one block — by 14px tall (three 4px
+     segment rows with 1px gaps). 2px separates days, and twelve right-anchored
+     week seams absorb the remainder so the strip fills the 780px content
+     column exactly: 90*6 + 77*2 + 10*7 + 2*8 = 780. Below 780px the strip
+     scrolls rather than re-fracturing. */
   .status-bars {
     display: flex;
-    gap: 1px;
     margin-top: 0.6rem;
-    height: 1.4rem;
+    overflow-x: auto;
   }
   .status-bars > * {
-    flex: 1 1 0;
+    flex: 0 0 6px;
+    height: 14px;
+    margin-right: 2px;
     border: 1px dotted var(--pill-muted-border);
     background: transparent;
+    box-sizing: border-box;
+  }
+  .status-bars > .status-day-seam {
+    margin-right: 7px;
+  }
+  .status-bars > .status-day-seam-wide {
+    margin-right: 8px;
+  }
+  .status-bars > :last-child {
+    margin-right: 0;
   }
   .status-bars > a {
     text-decoration: none;
+  }
+  /* Days with an observed state drop the border and subdivide into the 2x3
+     segment grid; segments paint individually, so a blip is a fleck rather
+     than a whole-day repaint. */
+  .status-bars [data-day]:not([data-day="nodata"]):not([data-day="unknown"]) {
+    border: 0;
+    display: grid;
+    grid-template: repeat(3, 1fr) / repeat(2, 1fr);
+    gap: 1px 0;
   }
   .status-bars [data-day="unknown"] {
     border-style: solid;
     border-color: var(--pill-down-bg);
   }
-  .status-bars [data-day="operational"] {
-    border-style: solid;
-    border-color: var(--pill-available-bg);
+  .status-bars [data-seg="operational"] {
     background: var(--pill-available-bg);
   }
-  .status-bars [data-day="degraded"] {
-    border-style: solid;
-    border-color: var(--pill-degraded-bg);
+  .status-bars [data-seg="degraded"] {
     background: var(--pill-degraded-bg);
   }
-  .status-bars [data-day="down"] {
-    border-style: solid;
-    border-color: var(--pill-down-bg);
+  .status-bars [data-seg="down"] {
     background: var(--pill-down-bg);
   }
   .status-incident-heading,

--- a/content/status.njk
+++ b/content/status.njk
@@ -98,6 +98,15 @@ statusSection: uptime
     border-style: solid;
     border-color: var(--pill-down-bg);
   }
+  /* Conceptually every block wears a 1px frame; a filled block's frame matches
+     its fill, which is pixel-identical to no border — so only the unfilled
+     blocks (today's upcoming windows, or a mid-day coverage gap) need the rule.
+     The hollow boxes are what make a partially complete day read as "still
+     filling in" rather than oddly short-stacked. */
+  .status-bars [data-day]:not([data-day="nodata"]):not([data-day="unknown"]) i:not([data-seg]) {
+    border: 1px solid var(--pill-muted-border);
+    box-sizing: border-box;
+  }
   .status-bars [data-seg="operational"] {
     background: var(--pill-available-bg);
   }

--- a/content/status.njk
+++ b/content/status.njk
@@ -54,16 +54,18 @@ statusSection: uptime
     background: var(--pill-muted-bg);
   }
   /* Fixed-pixel day cells, not 1fr: at this scale fractional widths antialias
-     sub-day marks into mush. Each day is 6px wide — two 3px block columns
-     touching, so contiguous time reads as one block — by 13px tall (two 6px
-     block rows with a 1px gap). 2px separates days, and twelve right-anchored
-     week seams absorb the remainder so the strip fills the 780px content
-     column exactly: 90*6 + 77*2 + 10*7 + 2*8 = 780. Below 780px the strip
-     scrolls rather than re-fracturing. */
+     sub-day marks into mush. Each day is a 6px-wide, 13px-tall 2x2 of blocks;
+     2px separates days and 6px separates the twelve right-anchored weeks:
+     90*6 + 77*2 + 12*6 = 766px under the 780px column. The strip anchors
+     right, so today sits flush at the column's right edge and the small
+     shortfall (and, on narrow screens, the oldest days) falls off the left. */
   .status-bars {
     display: flex;
     margin-top: 0.6rem;
-    overflow-x: auto;
+    /* Right-anchored: when the column is narrower than the strip, the oldest
+       days clip away first and today stays pinned at the right edge. */
+    justify-content: flex-end;
+    overflow-x: hidden;
   }
   .status-bars > * {
     flex: 0 0 6px;
@@ -74,10 +76,7 @@ statusSection: uptime
     box-sizing: border-box;
   }
   .status-bars > .status-day-seam {
-    margin-right: 7px;
-  }
-  .status-bars > .status-day-seam-wide {
-    margin-right: 8px;
+    margin-right: 6px;
   }
   .status-bars > :last-child {
     margin-right: 0;
@@ -87,25 +86,19 @@ statusSection: uptime
   }
   /* Days with an observed state drop the border and subdivide into the 2x2
      block grid (midnight top-left, each row twelve hours); blocks paint
-     individually, so a blip is a fleck rather than a whole-day repaint. */
+     individually, so a blip is a fleck rather than a whole-day repaint. The
+     hairline gap on both axes keeps the four blocks legible as separate
+     squares, which is also what lets a partial day's missing block read as
+     "still coming" without any extra framing. */
   .status-bars [data-day]:not([data-day="nodata"]):not([data-day="unknown"]) {
     border: 0;
     display: grid;
     grid-template: repeat(2, 1fr) / repeat(2, 1fr);
-    gap: 1px 0;
+    gap: 0.5px 0.5px;
   }
   .status-bars [data-day="unknown"] {
     border-style: solid;
     border-color: var(--pill-down-bg);
-  }
-  /* Conceptually every block wears a 1px frame; a filled block's frame matches
-     its fill, which is pixel-identical to no border — so only the unfilled
-     blocks (today's upcoming windows, or a mid-day coverage gap) need the rule.
-     The hollow boxes are what make a partially complete day read as "still
-     filling in" rather than oddly short-stacked. */
-  .status-bars [data-day]:not([data-day="nodata"]):not([data-day="unknown"]) i:not([data-seg]) {
-    border: 1px solid var(--pill-muted-border);
-    box-sizing: border-box;
   }
   .status-bars [data-seg="operational"] {
     background: var(--pill-available-bg);

--- a/content/status.njk
+++ b/content/status.njk
@@ -54,9 +54,9 @@ statusSection: uptime
     background: var(--pill-muted-bg);
   }
   /* Fixed-pixel day cells, not 1fr: at this scale fractional widths antialias
-     sub-day marks into mush. Each day is 6px wide — two 3px segment columns
-     touching, so contiguous time reads as one block — by 14px tall (three 4px
-     segment rows with 1px gaps). 2px separates days, and twelve right-anchored
+     sub-day marks into mush. Each day is 6px wide — two 3px block columns
+     touching, so contiguous time reads as one block — by 13px tall (two 6px
+     block rows with a 1px gap). 2px separates days, and twelve right-anchored
      week seams absorb the remainder so the strip fills the 780px content
      column exactly: 90*6 + 77*2 + 10*7 + 2*8 = 780. Below 780px the strip
      scrolls rather than re-fracturing. */
@@ -67,7 +67,7 @@ statusSection: uptime
   }
   .status-bars > * {
     flex: 0 0 6px;
-    height: 14px;
+    height: 13px;
     margin-right: 2px;
     border: 1px dotted var(--pill-muted-border);
     background: transparent;
@@ -85,13 +85,13 @@ statusSection: uptime
   .status-bars > a {
     text-decoration: none;
   }
-  /* Days with an observed state drop the border and subdivide into the 2x3
-     segment grid; segments paint individually, so a blip is a fleck rather
-     than a whole-day repaint. */
+  /* Days with an observed state drop the border and subdivide into the 2x2
+     block grid (midnight top-left, each row twelve hours); blocks paint
+     individually, so a blip is a fleck rather than a whole-day repaint. */
   .status-bars [data-day]:not([data-day="nodata"]):not([data-day="unknown"]) {
     border: 0;
     display: grid;
-    grid-template: repeat(3, 1fr) / repeat(2, 1fr);
+    grid-template: repeat(2, 1fr) / repeat(2, 1fr);
     gap: 1px 0;
   }
   .status-bars [data-day="unknown"] {

--- a/public/status-log.mjs
+++ b/public/status-log.mjs
@@ -206,8 +206,12 @@ export function incidentLog(events) {
  * Precedence is down > degraded > unknown > operational > no data. Any
  * observation fills the day; the separate coverage percentage carries
  * partial-day completeness.
+ *
+ * With `parts`, each cell also carries `segments`: the day split into that
+ * many equal windows, each classified by the same precedence, so a short
+ * blip colors the segment it touched instead of repainting the whole day.
  */
-export function dailyBars(spans, { asOf, days }) {
+export function dailyBars(spans, { asOf, days, parts }) {
   const result = new Map();
   const lastDay = Math.floor(asOf.getTime() / DAY_MS);
   const windowStart = utcDayWindowStart(asOf, days) / DAY_MS;
@@ -237,12 +241,27 @@ export function dailyBars(spans, { asOf, days }) {
         state === "degraded"
           ? overlappingStarts("degraded").map((s) => delayId(component, s))
           : [];
-      cells.push({
+      const cell = {
         date: new Date(start).toISOString().slice(0, 10),
         state,
         ...(incidentIds.length ? { incidentIds } : {}),
         ...(delayIds.length ? { delayIds } : {}),
-      });
+      };
+      if (parts) {
+        // The same fold at sub-day resolution: each window classifies with the
+        // identical precedence, so a cell's segments can never disagree with
+        // its day state. Windows past the as-of have no overlap and read as
+        // "nodata", the same rule that keeps whole days from inventing green.
+        const segMs = DAY_MS / parts;
+        cell.segments = Array.from({ length: parts }, (_, p) =>
+          dayState(
+            list,
+            start + p * segMs,
+            Math.min(start + (p + 1) * segMs, end),
+          ),
+        );
+      }
+      cells.push(cell);
     }
     result.set(component, cells);
   }

--- a/public/status.mjs
+++ b/public/status.mjs
@@ -23,10 +23,6 @@ const BAR_DAYS = 90;
 // pixel arithmetic (see .status-bars in status.njk): at 3px per block column
 // every mark stays on the CSS pixel grid at full 90-day density.
 const BAR_PARTS = 4;
-// Two of the twelve week seams run 1px wider to make the strip fill the
-// 780px column exactly; they sit oldest-first where the difference is least
-// conspicuous. Coupled to the arithmetic in status.njk.
-const WIDE_SEAMS = 2;
 export const STALE_MESSAGE = "Stale: status page experiencing delayed updates";
 
 function isStatusEntry(entry) {
@@ -249,14 +245,10 @@ export function barDescription(cells) {
 // Week seams, anchored at the right edge so today's group is always a full
 // seven regardless of the date. Returns the seam class for the gap after this
 // cell, or null for an ordinary day gap.
-export function daySeam(index, count, wideSeams = WIDE_SEAMS) {
+export function daySeam(index, count) {
   const last = count - 1;
   if (index >= last || (last - index) % 7 !== 0) return null;
-  const fromRight = (last - index) / 7;
-  const seams = Math.floor(last / 7);
-  return fromRight > seams - wideSeams
-    ? "status-day-seam-wide"
-    : "status-day-seam";
+  return "status-day-seam";
 }
 
 export function dayTitle(cell) {

--- a/public/status.mjs
+++ b/public/status.mjs
@@ -19,10 +19,10 @@ const STALE_AFTER_MS = 20 * 60 * 1000;
 const FETCH_TIMEOUT_MS = 10 * 1000;
 const REFRESH_INTERVAL_MS = 5 * 60 * 1000;
 const BAR_DAYS = 90;
-// Six 4-hour segments per day cell, laid out 2x3. Chosen with the strip's
-// pixel arithmetic (see .status-bars in status.njk): at 3px per segment every
-// mark stays on the CSS pixel grid at full 90-day density.
-const BAR_PARTS = 6;
+// Four 6-hour blocks per day cell, laid out 2x2. Chosen with the strip's
+// pixel arithmetic (see .status-bars in status.njk): at 3px per block column
+// every mark stays on the CSS pixel grid at full 90-day density.
+const BAR_PARTS = 4;
 // Two of the twelve week seams run 1px wider to make the strip fill the
 // 780px column exactly; they sit oldest-first where the difference is least
 // conspicuous. Coupled to the arithmetic in status.njk.

--- a/public/status.mjs
+++ b/public/status.mjs
@@ -196,7 +196,7 @@ export function incidentDescription(entry, name) {
     : `${impact} — ongoing.`;
 }
 
-function renderGroup(list, entries, bars, uptime, emptyCells) {
+function renderGroup(list, entries, bars, uptime, emptyCells, local) {
   list.replaceChildren();
   for (const entry of entries) {
     const item = document.createElement("li");
@@ -223,7 +223,7 @@ function renderGroup(list, entries, bars, uptime, emptyCells) {
       detail.textContent = uptimeDescription(measured, cells.length);
       item.append(detail);
     }
-    if (cells?.length) item.append(barStrip(cells));
+    if (cells?.length) item.append(barStrip(cells, local));
     list.append(item);
   }
 }
@@ -278,7 +278,40 @@ export function dayTitle(cell) {
   return `${cell.date}: ${windows}`;
 }
 
-function barStrip(cells) {
+// The window one block covers, in the viewer's chosen time zone — the same
+// UTC/local toggle the incident timestamps honor. h23 so the strip speaks the
+// pipeline page's clock, with a bare "24:00" for a range that closes the day.
+export function blockTitle(cell, index, local) {
+  const blockMs = 86_400_000 / cell.segments.length;
+  const startMs = Date.parse(`${cell.date}T00:00:00Z`) + index * blockMs;
+  const endMs = startMs + blockMs;
+  const zone = local ? undefined : "UTC";
+  const time = new Intl.DateTimeFormat(undefined, {
+    hour: "2-digit",
+    minute: "2-digit",
+    hourCycle: "h23",
+    timeZone: zone,
+  });
+  const day = new Intl.DateTimeFormat(undefined, {
+    month: "short",
+    day: "numeric",
+    timeZone: zone,
+  });
+  const zoneName = new Intl.DateTimeFormat(undefined, {
+    hour: "numeric",
+    timeZoneName: "short",
+    timeZone: zone,
+  })
+    .formatToParts(startMs)
+    .find((part) => part.type === "timeZoneName")?.value;
+  const end = time.format(endMs) === "00:00" ? "24:00" : time.format(endMs);
+  const state = cell.segments[index];
+  const label =
+    state === "nodata" ? "not monitored" : state === "unknown" ? "unknown" : state;
+  return `${day.format(startMs)}, ${time.format(startMs)}–${end} ${zoneName} · ${label}`;
+}
+
+function barStrip(cells, local) {
   const strip = document.createElement("div");
   strip.className = "status-bars";
   strip.setAttribute("role", "group");
@@ -290,13 +323,14 @@ function barStrip(cells) {
     const seam = daySeam(index, cells.length);
     if (seam) day.classList.add(seam);
     day.title = dayTitle(cell);
-    for (const state of cell.segments ?? []) {
+    (cell.segments ?? []).forEach((state, block) => {
       const segment = document.createElement("i");
       if (state !== "nodata" && state !== "unknown") {
         segment.dataset.seg = state;
       }
+      segment.title = blockTitle(cell, block, local);
       day.append(segment);
-    }
+    });
     if (anchor) {
       day.href = `#${anchor}`;
       day.setAttribute(
@@ -441,6 +475,7 @@ function renderStatus(root, data, loadedHistory, local) {
       history?.cells,
       history?.uptime,
       emptyCells,
+      local,
     );
   }
   renderIncidentLog(root, history, data, local);

--- a/public/status.mjs
+++ b/public/status.mjs
@@ -306,8 +306,17 @@ export function blockTitle(cell, index, local) {
     .find((part) => part.type === "timeZoneName")?.value;
   const end = time.format(endMs) === "00:00" ? "24:00" : time.format(endMs);
   const state = cell.segments[index];
+  // An empty block is two different stories: history nobody observed, or a
+  // window that simply hasn't arrived — the UTC-aligned grid opens today's
+  // cell mid-evening for American viewers, so the distinction matters.
   const label =
-    state === "nodata" ? "not monitored" : state === "unknown" ? "unknown" : state;
+    state === "nodata"
+      ? startMs > Date.now()
+        ? "upcoming"
+        : "not monitored"
+      : state === "unknown"
+        ? "unknown"
+        : state;
   return `${day.format(startMs)}, ${time.format(startMs)}–${end} ${zoneName} · ${label}`;
 }
 

--- a/public/status.mjs
+++ b/public/status.mjs
@@ -19,6 +19,14 @@ const STALE_AFTER_MS = 20 * 60 * 1000;
 const FETCH_TIMEOUT_MS = 10 * 1000;
 const REFRESH_INTERVAL_MS = 5 * 60 * 1000;
 const BAR_DAYS = 90;
+// Six 4-hour segments per day cell, laid out 2x3. Chosen with the strip's
+// pixel arithmetic (see .status-bars in status.njk): at 3px per segment every
+// mark stays on the CSS pixel grid at full 90-day density.
+const BAR_PARTS = 6;
+// Two of the twelve week seams run 1px wider to make the strip fill the
+// 780px column exactly; they sit oldest-first where the difference is least
+// conspicuous. Coupled to the arithmetic in status.njk.
+const WIDE_SEAMS = 2;
 export const STALE_MESSAGE = "Stale: status page experiencing delayed updates";
 
 function isStatusEntry(entry) {
@@ -238,16 +246,57 @@ export function barDescription(cells) {
   return parts.join("; ");
 }
 
+// Week seams, anchored at the right edge so today's group is always a full
+// seven regardless of the date. Returns the seam class for the gap after this
+// cell, or null for an ordinary day gap.
+export function daySeam(index, count, wideSeams = WIDE_SEAMS) {
+  const last = count - 1;
+  if (index >= last || (last - index) % 7 !== 0) return null;
+  const fromRight = (last - index) / 7;
+  const seams = Math.floor(last / 7);
+  return fromRight > seams - wideSeams
+    ? "status-day-seam-wide"
+    : "status-day-seam";
+}
+
+export function dayTitle(cell) {
+  const bad = (cell.segments ?? [])
+    .map((state, index) => [state, index])
+    .filter(([state]) => state === "down" || state === "degraded");
+  if (!bad.length) {
+    return `${cell.date}: ${cell.state === "nodata" ? "not monitored" : cell.state}`;
+  }
+  const hoursPer = 24 / cell.segments.length;
+  const clock = (part) => {
+    const hours = Math.floor(part * hoursPer);
+    const minutes = Math.round(((part * hoursPer) % 1) * 60);
+    return `${String(hours).padStart(2, "0")}:${String(minutes).padStart(2, "0")}`;
+  };
+  const windows = bad
+    .map(([state, index]) => `${state} ${clock(index)}–${clock(index + 1)}Z`)
+    .join(", ");
+  return `${cell.date}: ${windows}`;
+}
+
 function barStrip(cells) {
   const strip = document.createElement("div");
   strip.className = "status-bars";
   strip.setAttribute("role", "group");
   strip.setAttribute("aria-label", barDescription(cells));
-  for (const cell of cells) {
+  cells.forEach((cell, index) => {
     const anchor = cell.incidentIds?.[0] ?? cell.delayIds?.[0];
     const day = document.createElement(anchor ? "a" : "span");
     day.dataset.day = cell.state;
-    day.title = `${cell.date}: ${cell.state === "nodata" ? "not monitored" : cell.state}`;
+    const seam = daySeam(index, cells.length);
+    if (seam) day.classList.add(seam);
+    day.title = dayTitle(cell);
+    for (const state of cell.segments ?? []) {
+      const segment = document.createElement("i");
+      if (state !== "nodata" && state !== "unknown") {
+        segment.dataset.seg = state;
+      }
+      day.append(segment);
+    }
     if (anchor) {
       day.href = `#${anchor}`;
       day.setAttribute(
@@ -258,7 +307,7 @@ function barStrip(cells) {
       day.setAttribute("aria-hidden", "true");
     }
     strip.append(day);
-  }
+  });
   return strip;
 }
 
@@ -278,7 +327,7 @@ export function buildHistory(eventsText, metaText) {
   const spans = componentSpans(events, { asOf });
   return {
     asOf,
-    cells: dailyBars(spans, { asOf, days: BAR_DAYS }),
+    cells: dailyBars(spans, { asOf, days: BAR_DAYS, parts: BAR_PARTS }),
     incidents: incidentLog(events),
     uptime: uptimeSummary(spans, { asOf, days: BAR_DAYS }),
   };
@@ -370,6 +419,7 @@ function renderStatus(root, data, loadedHistory, local) {
   const emptyCells = dailyBars(new Map([["", []]]), {
     asOf: history?.asOf ?? new Date(data.generated_at),
     days: BAR_DAYS,
+    parts: BAR_PARTS,
   }).get("");
   setHistoryNotice(
     historyNotice,

--- a/test/status-log.test.mjs
+++ b/test/status-log.test.mjs
@@ -310,14 +310,12 @@ test("a blip colors only the segment it touched", () => {
     transition("2026-07-24T17:20:00Z", C, "operational"),
   );
 
-  const cell = dailyBars(spans, { asOf: AS_OF, days: 90, parts: 6 })
+  const cell = dailyBars(spans, { asOf: AS_OF, days: 90, parts: 4 })
     .get(C)
     .find((candidate) => candidate.date === "2026-07-24");
 
-  // 17:10Z falls in the fifth 4-hour window (16:00-20:00).
+  // 17:10Z falls in the third 6-hour block (12:00-18:00).
   assert.deepEqual(cell.segments, [
-    "operational",
-    "operational",
     "operational",
     "operational",
     "degraded",
@@ -330,17 +328,15 @@ test("a blip colors only the segment it touched", () => {
 test("segments past the as-of read as nodata, not as invented green", () => {
   const spans = spansOf(coverage("2026-07-25T00:00:00Z", C, true, "operational"));
 
-  const today = dailyBars(spans, { asOf: AS_OF, days: 90, parts: 6 })
+  const today = dailyBars(spans, { asOf: AS_OF, days: 90, parts: 4 })
     .get(C)
     .at(-1);
 
-  // The as-of is 12:00Z: the first three 4-hour windows are observed, the rest
+  // The as-of is 12:00Z: the first two 6-hour blocks are observed, the rest
   // have not happened yet.
   assert.deepEqual(today.segments, [
     "operational",
     "operational",
-    "operational",
-    "nodata",
     "nodata",
     "nodata",
   ]);
@@ -353,17 +349,15 @@ test("segment states agree with the day state a downed cell reports", () => {
     transition("2026-07-24T16:20:00Z", C, "operational"),
   );
 
-  const cell = dailyBars(spans, { asOf: AS_OF, days: 90, parts: 6 })
+  const cell = dailyBars(spans, { asOf: AS_OF, days: 90, parts: 4 })
     .get(C)
     .find((candidate) => candidate.date === "2026-07-24");
 
   assert.equal(cell.state, "down");
-  // 13:17-16:20Z spans the 12:00-16:00 and 16:00-20:00 windows.
+  // 13:17-16:20Z sits inside the 12:00-18:00 block.
   assert.deepEqual(cell.segments, [
     "operational",
     "operational",
-    "operational",
-    "down",
     "down",
     "operational",
   ]);

--- a/test/status-log.test.mjs
+++ b/test/status-log.test.mjs
@@ -293,6 +293,83 @@ test("the window caps at the requested number of days", () => {
   assert.equal(dailyBars(spans, { asOf: AS_OF, days: 90 }).get(C).length, 90);
 });
 
+// --- segments ---------------------------------------------------------------
+
+test("cells carry no segments unless parts is requested", () => {
+  const spans = spansOf(coverage("2026-07-24T00:00:00Z", C, true, "operational"));
+
+  const cell = dailyBars(spans, { asOf: AS_OF, days: 90 }).get(C).at(-1);
+
+  assert.equal("segments" in cell, false);
+});
+
+test("a blip colors only the segment it touched", () => {
+  const spans = spansOf(
+    coverage("2026-07-23T00:00:00Z", C, true, "operational"),
+    transition("2026-07-24T17:10:00Z", C, "degraded"),
+    transition("2026-07-24T17:20:00Z", C, "operational"),
+  );
+
+  const cell = dailyBars(spans, { asOf: AS_OF, days: 90, parts: 6 })
+    .get(C)
+    .find((candidate) => candidate.date === "2026-07-24");
+
+  // 17:10Z falls in the fifth 4-hour window (16:00-20:00).
+  assert.deepEqual(cell.segments, [
+    "operational",
+    "operational",
+    "operational",
+    "operational",
+    "degraded",
+    "operational",
+  ]);
+  // The day-level state still reflects the worst segment.
+  assert.equal(cell.state, "degraded");
+});
+
+test("segments past the as-of read as nodata, not as invented green", () => {
+  const spans = spansOf(coverage("2026-07-25T00:00:00Z", C, true, "operational"));
+
+  const today = dailyBars(spans, { asOf: AS_OF, days: 90, parts: 6 })
+    .get(C)
+    .at(-1);
+
+  // The as-of is 12:00Z: the first three 4-hour windows are observed, the rest
+  // have not happened yet.
+  assert.deepEqual(today.segments, [
+    "operational",
+    "operational",
+    "operational",
+    "nodata",
+    "nodata",
+    "nodata",
+  ]);
+});
+
+test("segment states agree with the day state a downed cell reports", () => {
+  const spans = spansOf(
+    coverage("2026-07-23T00:00:00Z", C, true, "operational"),
+    transition("2026-07-24T13:17:00Z", C, "down"),
+    transition("2026-07-24T16:20:00Z", C, "operational"),
+  );
+
+  const cell = dailyBars(spans, { asOf: AS_OF, days: 90, parts: 6 })
+    .get(C)
+    .find((candidate) => candidate.date === "2026-07-24");
+
+  assert.equal(cell.state, "down");
+  // 13:17-16:20Z spans the 12:00-16:00 and 16:00-20:00 windows.
+  assert.deepEqual(cell.segments, [
+    "operational",
+    "operational",
+    "operational",
+    "down",
+    "down",
+    "operational",
+  ]);
+  assert.ok(cell.incidentIds?.length, "downed day still links its incident");
+});
+
 // --- degraded ---------------------------------------------------------------
 
 test("a degraded day outranks operational but never down", () => {

--- a/test/status.test.mjs
+++ b/test/status.test.mjs
@@ -4,6 +4,7 @@ import test from "node:test";
 
 import {
   barDescription,
+  blockTitle,
   buildHistory,
   daySeam,
   dayTitle,
@@ -356,6 +357,22 @@ test("week seams anchor at the right edge and the oldest two run wide", () => {
   assert.equal(seams[5], "status-day-seam-wide");
   assert.equal(seams[12], "status-day-seam-wide");
   assert.equal(seams[19], "status-day-seam");
+});
+
+test("block tooltips name the exact window a block represents", () => {
+  const cell = {
+    date: "2026-07-29",
+    state: "degraded",
+    segments: ["operational", "operational", "degraded", "degraded"],
+  };
+  // The date fragment follows the viewer's locale; the window and zone do not.
+  assert.match(blockTitle(cell, 2, false), /12:00\u201318:00 UTC \u00b7 degraded$/);
+  // The last block's range closes the day as 24:00, not a wrapped 00:00.
+  assert.match(blockTitle(cell, 3, false), /18:00\u201324:00 UTC \u00b7 degraded$/);
+  assert.match(
+    blockTitle({ ...cell, segments: ["nodata", "operational", "operational", "operational"] }, 0, false),
+    /00:00\u201306:00 UTC \u00b7 not monitored$/,
+  );
 });
 
 test("day tooltips name the affected windows, not just the worst state", () => {

--- a/test/status.test.mjs
+++ b/test/status.test.mjs
@@ -353,10 +353,7 @@ test("week seams anchor at the right edge and the oldest two run wide", () => {
   assert.equal(seamIndices.length, 12);
   assert.deepEqual(seamIndices.slice(-2), [75, 82]);
   assert.equal(seams[89], null);
-  // The 780px fill needs two seams 1px wider; they sit oldest-first.
-  assert.equal(seams[5], "status-day-seam-wide");
-  assert.equal(seams[12], "status-day-seam-wide");
-  assert.equal(seams[19], "status-day-seam");
+  assert.equal(seams[5], "status-day-seam");
 });
 
 test("block tooltips name the exact window a block represents", () => {

--- a/test/status.test.mjs
+++ b/test/status.test.mjs
@@ -373,6 +373,12 @@ test("block tooltips name the exact window a block represents", () => {
     blockTitle({ ...cell, segments: ["nodata", "operational", "operational", "operational"] }, 0, false),
     /00:00\u201306:00 UTC \u00b7 not monitored$/,
   );
+  // A window that has not arrived yet is "upcoming", never "not monitored" —
+  // the UTC grid opens today's cell mid-evening for viewers west of it.
+  assert.match(
+    blockTitle({ ...cell, date: "2099-01-01", segments: ["nodata", "nodata", "nodata", "nodata"] }, 2, false),
+    /12:00\u201318:00 UTC \u00b7 upcoming$/,
+  );
 });
 
 test("day tooltips name the affected windows, not just the worst state", () => {

--- a/test/status.test.mjs
+++ b/test/status.test.mjs
@@ -363,9 +363,9 @@ test("day tooltips name the affected windows, not just the worst state", () => {
     dayTitle({
       date: "2026-07-29",
       state: "down",
-      segments: ["operational", "operational", "operational", "down", "degraded", "operational"],
+      segments: ["operational", "down", "degraded", "operational"],
     }),
-    "2026-07-29: down 12:00–16:00Z, degraded 16:00–20:00Z",
+    "2026-07-29: down 06:00–12:00Z, degraded 12:00–18:00Z",
   );
   assert.equal(
     dayTitle({ date: "2026-07-29", state: "nodata", segments: [] }),

--- a/test/status.test.mjs
+++ b/test/status.test.mjs
@@ -5,6 +5,8 @@ import test from "node:test";
 import {
   barDescription,
   buildHistory,
+  daySeam,
+  dayTitle,
   incidentDescription,
   isHistoryCurrent,
   isStatusDataStale,
@@ -338,6 +340,42 @@ test("overlap is claimed only for intervals that actually intersect", () => {
   // started later (the ongoing scorecard delay) is not context for one that
   // had already ended.
   assert.deepEqual(overlappingEntries(during, entries, asOf), [outage]);
+});
+
+test("week seams anchor at the right edge and the oldest two run wide", () => {
+  const seams = Array.from({ length: 90 }, (_, index) => daySeam(index, 90));
+  const seamIndices = seams
+    .map((seam, index) => (seam ? index : null))
+    .filter((index) => index !== null);
+
+  // Twelve seams for 90 days; the newest day always closes a full week.
+  assert.equal(seamIndices.length, 12);
+  assert.deepEqual(seamIndices.slice(-2), [75, 82]);
+  assert.equal(seams[89], null);
+  // The 780px fill needs two seams 1px wider; they sit oldest-first.
+  assert.equal(seams[5], "status-day-seam-wide");
+  assert.equal(seams[12], "status-day-seam-wide");
+  assert.equal(seams[19], "status-day-seam");
+});
+
+test("day tooltips name the affected windows, not just the worst state", () => {
+  assert.equal(
+    dayTitle({
+      date: "2026-07-29",
+      state: "down",
+      segments: ["operational", "operational", "operational", "down", "degraded", "operational"],
+    }),
+    "2026-07-29: down 12:00–16:00Z, degraded 16:00–20:00Z",
+  );
+  assert.equal(
+    dayTitle({ date: "2026-07-29", state: "nodata", segments: [] }),
+    "2026-07-29: not monitored",
+  );
+  // A healthy day (or a cell from a build without segments) keeps the old form.
+  assert.equal(
+    dayTitle({ date: "2026-07-29", state: "operational" }),
+    "2026-07-29: operational",
+  );
 });
 
 test("bar descriptions distinguish unknown state from missing coverage", () => {


### PR DESCRIPTION
# Subdivide the status day bars into intra-day segments

## Problem

A short delay repaints its whole day cell — a 10-minute degraded blip renders identically to a day-long incident, with only the tooltip and the "(x% degraded)" uptime suffix carrying the difference. The whole-day paint is right for outages (an outage must not average itself invisible) but overstates delay by up to 143x.

Design was iterated in a prototype against the real event log (private artifact, session 2026-07-30) and lands here as:

- **Six 4-hour segments per day**, laid out 2×3, midnight top-left, reading like text (top row 00–08Z, middle 08–16Z, bottom 16–24Z). A blip colors only the segment it touched.
- **Fixed pixels, not `1fr`**: fluid columns yield fractional segment sizes (2.91×3.66px measured) that antialias into mush. Days are 6px wide — two 3px segments *touching*, so contiguous time reads as one block — by 14px tall (three 4px rows, 1px gaps).
- **Exact 780px fill via week seams**: uniform integer gaps can only reach 719 or 808px, never the content column's 780. The remainder goes to twelve right-anchored week seams: 90×6 + 77×2 + 10×7px + 2×8px = 780. Today's week is always a full seven; the two 1px-wider seams sit oldest-first where the variance is invisible. Side effect: a countable weekly rhythm.
- **Tooltips name the affected windows** ("2026-07-29: degraded 16:00–20:00Z") instead of only the worst state.
- **Unchanged**: day-level state and precedence (down > degraded > unknown > operational > nodata), incident links on down days, aria labels/descriptions, uptime math, the "(x% degraded)" suffix (open question below), unknown-day rendering (solid red border, day-level).

## Work items

- [x] `status-log.mjs`: `dailyBars` gains a `parts` option — same `dayState` fold per sub-window, so segments can never disagree with the day state; windows past the as-of read `nodata`, not invented green. No `parts` → cells unchanged (backward compatible).
- [x] `status.mjs`: `BAR_PARTS = 6`; `daySeam` (right-anchored weekly seams, oldest two wide) and `dayTitle` (bad-window tooltips) as exported pure functions; `barStrip` renders segment children and seam classes; both `dailyBars` call sites pass `parts`.
- [x] `status.njk`: fixed-pixel strip CSS with the 780 arithmetic in a comment; segment paint via existing pill vars; nodata keeps the dotted cell, unknown keeps the solid red border; `overflow-x: auto` below 780px.
- [x] Tests: segment fold (blip → one segment, as-of clipping, day/segment agreement, incident ids preserved, no-parts compat) and seam/tooltip helpers (12 seams for 90 days, right anchor, oldest-two wide). 88 pass.
- [x] Visual verification against the real event log (built site + mirrored live assets): strip renders at exactly 780px, July 29's Arrivals delay is an orange fleck, HRRR's 3-hour outage spans two red segments, coverage-start days fill bottom-up and today fills top-down as designed.

## Open questions for review

- **Drop the "(x% degraded)" uptime suffix?** The segments now carry the delay visually and the tooltip carries exact windows; the prototype dropped the suffix. Left in place here so the PR is purely the bar rendering — remove in a follow-up if it reads as redundant.
- **CVD note**: green↔yellow is ΔE 3.4 under protanopia (validator-measured), true of the page before this change too. At segment scale a shape cue (hollow degraded) is cheap if we want it; not included here.
- **Coupling**: the 780 arithmetic is coupled to `.content`'s 78rem. If the column ever changes, the seam widths (and possibly day width) need re-solving — the CSS comment carries the formula.

## Rollout

Reader-only change; no publisher or log-schema impact. Deploys with the site.

### 2026-07-30 — Coverage backfill

The mostly-dotted strips (the log was only five days old) made the coverage-start day's partial cell the most prominent thing on the page. Rather than special-casing partial days, the seven rendered components' coverage entries were backdated to 2026-05-01T00:00Z in the production event log (Marsh's call: no downtime in that period; datasets deliberately excluded — their May-July window contains real reformatter incidents). Strips now render solid wall-to-wall with the July 29 Arrivals delay as the lone orange fleck. Verified in prod against the live log.


### 2026-07-30 — Rebase + 2×2 iteration

Rebased onto main over #169 (delays in incident history) and #170 — the two features now compose: segmented day cells carry #169's delay anchors and windowed tooltips (`barStrip` merges seams + segments + `incidentIds ?? delayIds` links; `dailyBars` carries both `segments` and the id arrays). Verified live: the July 29 pipeline-status day renders `[operational, operational, degraded, degraded]` with the `#delay-…` link and "degraded 12:00–18:00Z, 18:00–24:00Z" tooltip.

Per Marsh: the grid is now **four 6-hour blocks (2×2)** instead of six 4-hour segments — blocks are 3×6px, the bar drops to 13px so rows stay integer, and each mark is chunkier at full density at the cost of 6-hour quantization. Strip arithmetic (780px fill, week seams) unchanged.


### 2026-07-31 — Block tooltips in the viewer's clock

Each block now names its own window on hover — "Jul 29, 12:00–18:00 UTC · degraded" — honoring the page's existing UTC/local toggle (local shows "07:00–13:00 CDT"), h23 to match the pipeline page, day-closing blocks ending at 24:00. Verified live in both modes.


### 2026-07-31 — Hollow frames for unfilled blocks

Every block conceptually wears a 1px frame; filled blocks hide theirs by matching the fill (pixel-identical to no border), so one CSS rule on unfilled blocks is the whole implementation. Today's upcoming windows render as faint hollow boxes where the day will fill in — replacing an earlier day-level dotted outline that was too quiet to read and needed a JS detector. No dimension changes, no state.



### 2026-07-31 — Spacing carries the story

Hairline 0.5px gaps on both axes make each day an evident 2×2, so the hollow frames came back out — a partial day's absent block now reads as exactly that. The strip right-anchors with overflow hidden: today pins to the column's right edge and narrow screens clip the oldest days instead of scrolling. Right-anchoring retires the exact-780 fill, so the WIDE_SEAMS machinery is deleted and the twelve uniform week seams tighten to 6px (strip = 90×6 + 77×2 + 12×6 = 766px).
