### PR TITLE
Give delays incident-history entries and link every colored day to its story

### DIFF
--- a/content/status.njk
+++ b/content/status.njk
@@ -93,19 +93,25 @@ statusSection: uptime
     justify-content: space-between;
     gap: 1rem;
   }
+  /* Rides the shared .index-list skeleton (reset, row padding, separators,
+     focus ring) like the component lists above; only density and the row
+     border are ours. */
   .status-incident-log {
-    margin: 0;
-    padding: 0;
-    list-style: none;
+    --index-row-padding: 1rem;
+    --index-row-border: 1px solid var(--border-color);
   }
   .status-incident {
     scroll-margin-top: 1rem;
-    padding: 1rem 0;
-    border-bottom: 1px solid var(--border-color);
   }
   .status-incident:target {
     background: var(--pill-muted-bg);
     outline: 0.4rem solid var(--pill-muted-bg);
+  }
+  /* The skeleton's link reset is for row-level anchors; the "coincided with"
+     cross-references are inline copy and must still read as links. */
+  .status-incident-summary a {
+    color: var(--link-color);
+    text-decoration: underline;
   }
   .status-incident h3,
   .status-incident p {
@@ -192,7 +198,7 @@ statusSection: uptime
       <a href="{{ statusIncidentFeed }}">RSS</a>
     </header>
     <p id="status-incident-empty">Loading incident history…</p>
-    <ol class="status-incident-log" id="status-incident-log"></ol>
+    <ol class="index-list status-incident-log" id="status-incident-log"></ol>
   </section>
 
   <noscript>

--- a/content/status.njk
+++ b/content/status.njk
@@ -115,6 +115,24 @@ statusSection: uptime
     margin-top: 0.4rem;
     color: var(--muted-text);
   }
+  /* The summary is the entry's headline sentence; only the timing line below
+     it is secondary. */
+  .status-incident .status-incident-summary {
+    color: inherit;
+  }
+  .status-incident header strong {
+    flex: 0 0 auto;
+    padding: 0.1rem 0.5rem;
+    font-size: 1.2rem;
+  }
+  .status-incident[data-kind="outage"] header strong {
+    color: var(--pill-down-fg);
+    background: var(--pill-down-bg);
+  }
+  .status-incident[data-kind="delay"] header strong {
+    color: var(--pill-degraded-fg);
+    background: var(--pill-degraded-bg);
+  }
   @media (max-width: 680px) {
     .status-list header {
       flex-direction: column;

--- a/content/status.njk
+++ b/content/status.njk
@@ -103,9 +103,12 @@ statusSection: uptime
   .status-incident {
     scroll-margin-top: 1rem;
   }
-  .status-incident:target {
-    background: var(--pill-muted-bg);
-    outline: 0.4rem solid var(--pill-muted-bg);
+  /* Navigation highlight: the header's <mark> is dormant until this entry is
+     the :target, where the UA's native mark styling takes over — no invented
+     color, and it adapts to dark mode and forced-colors on its own. */
+  .status-incident:not(:target) mark {
+    background: transparent;
+    color: inherit;
   }
   /* The skeleton's link reset is for row-level anchors; the "coincided with"
      cross-references are inline copy and must still read as links. */

--- a/content/status.njk
+++ b/content/status.njk
@@ -112,7 +112,7 @@ statusSection: uptime
   }
   /* The skeleton's link reset is for row-level anchors; the "coincided with"
      cross-references are inline copy and must still read as links. */
-  .status-incident-summary a {
+  .status-incident p a {
     color: var(--link-color);
     text-decoration: underline;
   }
@@ -124,9 +124,9 @@ statusSection: uptime
     margin-top: 0.4rem;
     color: var(--muted-text);
   }
-  /* The summary is the entry's headline sentence; only the timing line below
-     it is secondary. */
-  .status-incident .status-incident-summary {
+  /* The summary (the paragraph after the header) is the entry's headline
+     sentence; only the timing line below it is secondary. */
+  .status-incident header + p {
     color: inherit;
   }
   .status-incident header strong {

--- a/public/status-log.mjs
+++ b/public/status-log.mjs
@@ -134,6 +134,19 @@ export function incidentId(component, start) {
   return `incident-${component}-${Math.floor(start / 1000)}`;
 }
 
+export function delayId(component, start) {
+  return `delay-${component}-${Math.floor(start / 1000)}`;
+}
+
+// Which history class a state opens: outages for down, delays for degraded.
+// Operational and unknown open nothing and close whatever is open — a state
+// we could not read cannot substantiate that trouble is continuing.
+function historyKind(state) {
+  if (state === "down") return "outage";
+  if (state === "degraded") return "delay";
+  return null;
+}
+
 export function incidentLog(events) {
   const coverage = new Map();
   const open = new Map();
@@ -155,7 +168,7 @@ export function incidentLog(events) {
     };
 
     if (event.kind === COVERAGE && event.monitored === false) {
-      if (current.monitored && current.state === "down") {
+      if (current.monitored && historyKind(current.state)) {
         close(component, at, "observation-ended");
       }
       coverage.set(component, { monitored: false, state: null });
@@ -165,12 +178,15 @@ export function incidentLog(events) {
 
     const state =
       event.kind === COVERAGE ? publicState(event.state) : publicState(event.to);
-    if (current.monitored && current.state === "down" && state !== "down") {
-      close(component, at, "resolved");
-    }
-    if ((!current.monitored || current.state !== "down") && state === "down") {
+    const kind = historyKind(state);
+    const openKind = current.monitored ? historyKind(current.state) : null;
+    // An outage that decays to degraded is over — the delay that follows is
+    // its own entry, so the record says both what broke and what lingered.
+    if (openKind && openKind !== kind) close(component, at, "resolved");
+    if (kind && openKind !== kind) {
       open.set(component, {
-        id: incidentId(component, at),
+        id: (kind === "outage" ? incidentId : delayId)(component, at),
+        kind,
         component,
         start: at,
       });
@@ -202,20 +218,30 @@ export function dailyBars(spans, { asOf, days }) {
       const start = day * DAY_MS;
       const end = Math.min(start + DAY_MS, asOf.getTime());
       const state = dayState(list, start, end);
+      // Anchor ids for the day's history entries: outage links on down days,
+      // delay links on degraded days. A down day links only its outages —
+      // the worse story is the one the click should tell.
+      const overlappingStarts = (spanState) =>
+        list
+          .filter(
+            (span) =>
+              span.state === spanState &&
+              Math.min(span.end, end) - Math.max(span.start, start) > 0,
+          )
+          .map((span) => span.start);
       const incidentIds =
         state === "down"
-          ? list
-              .filter(
-                (span) =>
-                  span.state === "down" &&
-                  Math.min(span.end, end) - Math.max(span.start, start) > 0,
-              )
-              .map((span) => incidentId(component, span.start))
+          ? overlappingStarts("down").map((s) => incidentId(component, s))
+          : [];
+      const delayIds =
+        state === "degraded"
+          ? overlappingStarts("degraded").map((s) => delayId(component, s))
           : [];
       cells.push({
         date: new Date(start).toISOString().slice(0, 10),
         state,
         ...(incidentIds.length ? { incidentIds } : {}),
+        ...(delayIds.length ? { delayIds } : {}),
       });
     }
     result.set(component, cells);

--- a/public/status.mjs
+++ b/public/status.mjs
@@ -444,7 +444,6 @@ function renderIncidentLog(root, history, data, local) {
           ? "observation ended"
           : "ongoing"
     }`;
-    summary.className = "status-incident-summary";
     summary.textContent = incidentDescription(
       incident,
       names.get(incident.component),

--- a/public/status.mjs
+++ b/public/status.mjs
@@ -431,7 +431,12 @@ function renderIncidentLog(root, history, data, local) {
     item.id = incident.id;
     item.className = "status-incident";
     item.dataset.kind = kind;
-    name.textContent = names.get(incident.component);
+    // The name wears a <mark> that stays invisible until this entry is the
+    // :target — arriving from a day cell lights up the header rather than
+    // boxing the whole entry.
+    const highlight = document.createElement("mark");
+    highlight.textContent = names.get(incident.component);
+    name.append(highlight);
     state.textContent = `${kind} · ${
       incident.ending === "resolved"
         ? "resolved"
@@ -474,7 +479,11 @@ function renderIncidentLog(root, history, data, local) {
     const target = document.getElementById(
       decodeURIComponent(location.hash.slice(1)),
     );
-    if (target) requestAnimationFrame(() => target.scrollIntoView());
+    // Re-run the fragment navigation rather than scrollIntoView: the entry
+    // rendered after the page navigated, so :target never matched and the
+    // header's <mark> would stay dormant on a shared link. replace() scrolls
+    // and re-evaluates :target without adding a history entry.
+    if (target) requestAnimationFrame(() => location.replace(location.hash));
   }
 }
 

--- a/public/status.mjs
+++ b/public/status.mjs
@@ -136,6 +136,58 @@ export function uptimeDescription(measured, days) {
   return measured.delayed > 0 ? `${window} (${measured.delayed}% degraded)` : window;
 }
 
+// What an entry means for a reader, keyed by component id. The impact language
+// is the page's job, not the log's: the log records states; this says what the
+// state did to the thing you use. A component the publisher adds before this
+// page learns it falls back to generic phrasing rather than rendering nothing.
+const IMPACT = {
+  "dynamical-org": { outage: "The website was unreachable" },
+  "stac-catalog": { outage: "The STAC catalog API was unreachable" },
+  "data-product-reads": {
+    outage: "Reads of dynamical.org data failed their canary checks",
+  },
+  "wxopticon-pipeline": {
+    outage: "Forecast arrival detection stopped",
+    delay: "Forecast arrival detection ran behind",
+  },
+  "wxopticon-webhooks": {
+    outage: "Webhook delivery stopped",
+    delay: "Webhook delivery ran behind",
+  },
+  "wxopticon-arrivals": {
+    outage: "The arrivals dashboard stopped updating",
+    delay: "The arrivals dashboard updated late",
+  },
+  scorecard: {
+    outage: "The scorecard stopped refreshing",
+    delay: "The scorecard refreshed late",
+  },
+};
+
+// Entries whose intervals overlap this one's, for the "coincided with" clause.
+// Correlation is the context a status page can derive honestly: it claims two
+// things happened together, never that one caused the other.
+export function overlappingEntries(entry, entries, asOf) {
+  const endOf = (candidate) => candidate.end ?? asOf;
+  return entries.filter(
+    (candidate) =>
+      candidate !== entry &&
+      candidate.component !== entry.component &&
+      candidate.start < endOf(entry) &&
+      entry.start < endOf(candidate),
+  );
+}
+
+export function incidentDescription(entry, name) {
+  const kind = entry.kind ?? "outage";
+  const impact =
+    IMPACT[entry.component]?.[kind] ??
+    (kind === "delay" ? `${name} ran behind` : `${name} was down`);
+  return entry.end
+    ? `${impact} for ${formatDuration(entry.start, entry.end)}.`
+    : `${impact} — ongoing.`;
+}
+
 function renderGroup(list, entries, bars, uptime, emptyCells) {
   list.replaceChildren();
   for (const entry of entries) {
@@ -192,15 +244,15 @@ function barStrip(cells) {
   strip.setAttribute("role", "group");
   strip.setAttribute("aria-label", barDescription(cells));
   for (const cell of cells) {
-    const incident = cell.incidentIds?.[0];
-    const day = document.createElement(incident ? "a" : "span");
+    const anchor = cell.incidentIds?.[0] ?? cell.delayIds?.[0];
+    const day = document.createElement(anchor ? "a" : "span");
     day.dataset.day = cell.state;
     day.title = `${cell.date}: ${cell.state === "nodata" ? "not monitored" : cell.state}`;
-    if (incident) {
-      day.href = `#${incident}`;
+    if (anchor) {
+      day.href = `#${anchor}`;
       day.setAttribute(
         "aria-label",
-        `${cell.date}: outage; view incident details`,
+        `${cell.date}: ${cell.incidentIds?.length ? "outage" : "delay"}; view details`,
       );
     } else {
       day.setAttribute("aria-hidden", "true");
@@ -363,7 +415,7 @@ function renderIncidentLog(root, history, data, local) {
   const visible = history.incidents
     .filter((incident) => names.has(incident.component))
     .reverse();
-  empty.textContent = "No incidents recorded.";
+  empty.textContent = "No incidents or delays recorded.";
   empty.hidden = visible.length > 0;
 
   for (const incident of visible) {
@@ -371,18 +423,43 @@ function renderIncidentLog(root, history, data, local) {
     const header = document.createElement("header");
     const name = document.createElement("h3");
     const state = document.createElement("strong");
+    const summary = document.createElement("p");
     const timing = document.createElement("p");
+    const kind = incident.kind ?? "outage";
     const end = incident.end ?? history.asOf.getTime();
 
     item.id = incident.id;
     item.className = "status-incident";
+    item.dataset.kind = kind;
     name.textContent = names.get(incident.component);
-    state.textContent =
+    state.textContent = `${kind} · ${
       incident.ending === "resolved"
-        ? "Resolved"
+        ? "resolved"
         : incident.ending === "observation-ended"
-          ? "Observation ended"
-          : "Ongoing";
+          ? "observation ended"
+          : "ongoing"
+    }`;
+    summary.className = "status-incident-summary";
+    summary.textContent = incidentDescription(
+      incident,
+      names.get(incident.component),
+    );
+    const overlapping = overlappingEntries(
+      incident,
+      visible,
+      history.asOf.getTime(),
+    );
+    if (overlapping.length) {
+      summary.append(" Coincided with ");
+      overlapping.forEach((other, index) => {
+        const link = document.createElement("a");
+        link.href = `#${other.id}`;
+        link.textContent = `the ${names.get(other.component)} ${other.kind ?? "outage"}`;
+        if (index > 0) summary.append(", ");
+        summary.append(link);
+      });
+      summary.append(".");
+    }
     timing.textContent =
       incident.ending === "observation-ended"
         ? `${formatTimestamp(incident.start, local)} – ${formatTimestamp(incident.end, local)} · ${formatDuration(incident.start, end)}. Recovery was not witnessed.`
@@ -390,7 +467,7 @@ function renderIncidentLog(root, history, data, local) {
             incident.end ? formatTimestamp(incident.end, local) : "ongoing"
           } · ${formatDuration(incident.start, end)}.`;
     header.append(name, state);
-    item.append(header, timing);
+    item.append(header, summary, timing);
     list.append(item);
   }
   if (typeof location !== "undefined" && location.hash) {

--- a/public/status.mjs
+++ b/public/status.mjs
@@ -151,12 +151,12 @@ const IMPACT = {
     delay: "Forecast arrival detection ran behind",
   },
   "wxopticon-webhooks": {
-    outage: "Webhook delivery stopped",
-    delay: "Webhook delivery ran behind",
+    outage: "Pipeline webhook delivery stopped",
+    delay: "Pipeline webhook delivery ran behind",
   },
   "wxopticon-arrivals": {
-    outage: "The arrivals dashboard stopped updating",
-    delay: "The arrivals dashboard updated late",
+    outage: "The pipeline status page stopped updating",
+    delay: "The pipeline status page updated late",
   },
   scorecard: {
     outage: "The scorecard stopped refreshing",

--- a/test/status-log.test.mjs
+++ b/test/status-log.test.mjs
@@ -342,9 +342,10 @@ test("a degraded cell links to no incident", () => {
   assert.equal(cell.incidentIds, undefined);
 });
 
-test("degraded opens no incident and resolves a down one", () => {
-  // Delay is not an outage: the incident list stays a record of downtime, and a
-  // component that goes from down to merely late has stopped being down.
+test("delays are first-class history entries beside outages", () => {
+  // A delay is not an outage, but it is a story the history should tell. An
+  // outage that decays to degraded is over — the lingering delay is its own
+  // entry, so the record says both what broke and what lingered.
   const events = parseEvents(
     jsonl(
       coverage("2026-07-24T00:00:00Z", C, true, "operational"),
@@ -355,15 +356,101 @@ test("degraded opens no incident and resolves a down one", () => {
   );
 
   assert.deepEqual(
-    incidentLog(events).map(({ start, end, ending }) => ({ start, end, ending })),
+    incidentLog(events).map(({ kind, id, start, end, ending }) => ({
+      kind,
+      id,
+      start,
+      end,
+      ending,
+    })),
     [
       {
+        kind: "delay",
+        id: `delay-${C}-${Date.parse("2026-07-24T01:00:00Z") / 1000}`,
+        start: Date.parse("2026-07-24T01:00:00Z"),
+        end: Date.parse("2026-07-24T02:00:00Z"),
+        ending: "resolved",
+      },
+      {
+        kind: "outage",
+        id: `incident-${C}-${Date.parse("2026-07-24T02:00:00Z") / 1000}`,
         start: Date.parse("2026-07-24T02:00:00Z"),
         end: Date.parse("2026-07-24T03:00:00Z"),
         ending: "resolved",
       },
+      {
+        kind: "delay",
+        id: `delay-${C}-${Date.parse("2026-07-24T03:00:00Z") / 1000}`,
+        start: Date.parse("2026-07-24T03:00:00Z"),
+        end: null,
+        ending: null,
+      },
     ],
   );
+});
+
+test("a delay ends as observation-ended when coverage stops", () => {
+  const events = parseEvents(
+    jsonl(
+      coverage("2026-07-24T00:00:00Z", C, true, "operational"),
+      transition("2026-07-24T01:00:00Z", C, "degraded"),
+      coverage("2026-07-24T02:00:00Z", C, false),
+    ),
+  );
+
+  assert.deepEqual(
+    incidentLog(events).map(({ kind, ending }) => ({ kind, ending })),
+    [{ kind: "delay", ending: "observation-ended" }],
+  );
+});
+
+test("a same-kind reassertion does not split a delay entry", () => {
+  const events = parseEvents(
+    jsonl(
+      coverage("2026-07-24T00:00:00Z", C, true, "degraded"),
+      coverage("2026-07-24T01:00:00Z", C, true, "degraded"),
+    ),
+  );
+
+  assert.equal(incidentLog(events).length, 1);
+});
+
+test("degraded days link their delay entries the way down days link incidents", () => {
+  const spans = spansOf(
+    coverage("2026-07-23T00:00:00Z", C, true, "operational"),
+    transition("2026-07-24T10:00:00Z", C, "degraded"),
+    transition("2026-07-24T10:10:00Z", C, "operational"),
+  );
+
+  const cell = dailyBars(spans, { asOf: AS_OF, days: 90 })
+    .get(C)
+    .find((candidate) => candidate.date === "2026-07-24");
+
+  assert.equal(cell.state, "degraded");
+  assert.deepEqual(cell.delayIds, [
+    `delay-${C}-${Date.parse("2026-07-24T10:00:00Z") / 1000}`,
+  ]);
+  assert.equal("incidentIds" in cell, false);
+});
+
+test("a down day links only its outages, not the day's delays", () => {
+  // The worse story is the one the click should tell.
+  const spans = spansOf(
+    coverage("2026-07-23T00:00:00Z", C, true, "operational"),
+    transition("2026-07-24T08:00:00Z", C, "degraded"),
+    transition("2026-07-24T09:00:00Z", C, "down"),
+    transition("2026-07-24T10:00:00Z", C, "operational"),
+  );
+
+  const cell = dailyBars(spans, { asOf: AS_OF, days: 90 })
+    .get(C)
+    .find((candidate) => candidate.date === "2026-07-24");
+
+  assert.equal(cell.state, "down");
+  assert.deepEqual(cell.incidentIds, [
+    `incident-${C}-${Date.parse("2026-07-24T09:00:00Z") / 1000}`,
+  ]);
+  assert.equal("delayIds" in cell, false);
 });
 
 test("a witnessed delay never rounds itself invisible", () => {

--- a/test/status.test.mjs
+++ b/test/status.test.mjs
@@ -5,8 +5,10 @@ import test from "node:test";
 import {
   barDescription,
   buildHistory,
+  incidentDescription,
   isHistoryCurrent,
   isStatusDataStale,
+  overlappingEntries,
   STALE_MESSAGE,
   summarizeOverallStatus,
   uptimeDescription,
@@ -256,6 +258,86 @@ test("history must be close to the current snapshot", () => {
     ),
     false,
   );
+});
+
+test("incident descriptions say what the state did to the thing you use", () => {
+  const tenMinutes = {
+    component: "wxopticon-arrivals",
+    kind: "delay",
+    start: Date.parse("2026-07-29T17:10:00Z"),
+    end: Date.parse("2026-07-29T17:20:00Z"),
+  };
+  assert.equal(
+    incidentDescription(tenMinutes, "Arrivals dashboard"),
+    "The arrivals dashboard updated late for 10 minutes.",
+  );
+  assert.equal(
+    incidentDescription(
+      { ...tenMinutes, component: "data-product-reads", kind: "outage" },
+      "Data product reads",
+    ),
+    "Reads of dynamical.org data failed their canary checks for 10 minutes.",
+  );
+});
+
+test("incident descriptions fall back to generic phrasing for unknown ids", () => {
+  // The publisher deploys separately: a component this page has no impact
+  // language for still reads as a sentence, not a blank.
+  const entry = {
+    component: "future-tool",
+    kind: "outage",
+    start: Date.parse("2026-07-29T17:10:00Z"),
+    end: Date.parse("2026-07-29T17:12:00Z"),
+  };
+  assert.equal(
+    incidentDescription(entry, "Future tool"),
+    "Future tool was down for 2 minutes.",
+  );
+  assert.equal(
+    incidentDescription({ ...entry, kind: "delay", end: null }, "Future tool"),
+    "Future tool ran behind — ongoing.",
+  );
+  // Entries from a history built before kinds existed read as outages.
+  assert.equal(
+    incidentDescription({ ...entry, kind: undefined }, "Future tool"),
+    "Future tool was down for 2 minutes.",
+  );
+});
+
+test("overlap is claimed only for intervals that actually intersect", () => {
+  const asOf = Date.parse("2026-07-29T21:00:00Z");
+  const outage = {
+    component: "noaa",
+    kind: "outage",
+    start: Date.parse("2026-07-29T13:00:00Z"),
+    end: Date.parse("2026-07-29T16:00:00Z"),
+  };
+  const during = {
+    component: "arrivals",
+    kind: "delay",
+    start: Date.parse("2026-07-29T14:00:00Z"),
+    end: Date.parse("2026-07-29T14:10:00Z"),
+  };
+  const after = {
+    component: "arrivals",
+    kind: "delay",
+    start: Date.parse("2026-07-29T17:00:00Z"),
+    end: Date.parse("2026-07-29T17:10:00Z"),
+  };
+  const ongoing = {
+    component: "scorecard",
+    kind: "delay",
+    start: Date.parse("2026-07-29T15:00:00Z"),
+    end: null,
+  };
+  const entries = [outage, during, after, ongoing];
+
+  assert.deepEqual(overlappingEntries(outage, entries, asOf), [during, ongoing]);
+  assert.deepEqual(overlappingEntries(after, entries, asOf), [ongoing]);
+  // Same-component entries never count as their own context, and an entry that
+  // started later (the ongoing scorecard delay) is not context for one that
+  // had already ended.
+  assert.deepEqual(overlappingEntries(during, entries, asOf), [outage]);
 });
 
 test("bar descriptions distinguish unknown state from missing coverage", () => {

--- a/test/status.test.mjs
+++ b/test/status.test.mjs
@@ -269,7 +269,7 @@ test("incident descriptions say what the state did to the thing you use", () => 
   };
   assert.equal(
     incidentDescription(tenMinutes, "Arrivals dashboard"),
-    "The arrivals dashboard updated late for 10 minutes.",
+    "The pipeline status page updated late for 10 minutes.",
   );
   assert.equal(
     incidentDescription(


### PR DESCRIPTION
# Give delays incident-history entries and link every colored day to its story

## Problem

Degraded time is visible in the bars but absent from the record beneath them: the incident list is down-only, so a delayed day has nowhere to click and no explanation, and even down days link to entries that say only "Resolved · 10 minutes" with no statement of impact.

## Design

Three connected changes, all reader-side (`status-log.mjs` + `status.mjs` + `status.njk`); the publisher and log schema are untouched.

1. **Delays become first-class history entries.** `incidentLog` runs one state machine over both severities: `down` opens an *outage* (`incident-…` anchors, as before), `degraded` opens a *delay* (`delay-…` anchors). An outage that decays to degraded closes as resolved and the lingering delay opens as its own entry — the record says both what broke and what lingered. Operational and unknown close whatever is open; coverage loss still ends entries as `observation-ended`.
2. **Every colored day links to its story.** Down days link their outage (unchanged); degraded days now link their delay. A day with both links only the outage — the worse story is the one the click should tell. In-page anchors, same `:target` highlight and scroll behavior as before. Delay cells get `aria-label "… : delay; view details"`.
3. **Automated, honest context per entry.** Each entry gets a composed headline: an *impact sentence* keyed by component id that says what the state did to the thing a reader uses ("The pipeline status page updated late for 10 minutes.", "Reads of dynamical.org data failed their canary checks for 12 minutes."), with generic fallback phrasing for component ids this page hasn't learned (the publisher deploys separately). Plus a *"coincided with"* clause linking any overlapping entries among rendered components — correlation the log can claim honestly, never causation. Entries render with a colored kind chip (`delay` in the degraded pill, `outage` in the down pill) beside the resolution word.

## What deliberately didn't change

- **The publisher RSS stays outages-only.** The feed is a subscription for "something broke"; the page is where delay granularity lives. Open question: add delay items to the RSS later if subscribers want them.
- **Impact language lives in the page**, not the log — the log records states; what a state *means* for a reader is presentation. The vocabulary echoes the publisher's own component descriptions.
- No severity inflation: delays and outages stay visually and semantically distinct end-to-end (chip color, anchor prefix, sentence verb).

## Verification

- [x] 89 tests pass: state-machine kinds (down→degraded emits resolved outage + open delay), observation-ended delays, same-kind reassertion not splitting entries, `delayIds` on degraded days / outage-only links on down days, impact sentences + fallbacks, overlap math (same-component excluded, ongoing entries clipped at as-of).
- [x] Verified against the live production log: the two 2026-07-29 Arrivals delays render as "delay · resolved" entries ("The pipeline status page updated late for 10 minutes." / "9 minutes"), and the July 29 degraded day cell is an `<a href="#delay-wxopticon-arrivals-…">` with the delay aria-label.

## Notes

- Based on main; will need a small rebase against #167 (segmented day bars) whichever merges second — both touch `barStrip`.
- The "coincided with" clause has no live example yet (needs overlapping trouble across two rendered components); covered by unit tests.

### 2026-07-30 — Vocabulary rename

Row names moved to user-facing vocabulary (dynamical.org-data#21: "pipeline status", "pipeline webhooks"); the impact sentences here now speak the same names (e1efb4935).

### 2026-07-30 — Shared list skeleton

The incident log now rides `.index-list` like the component lists (c2271ad36): duplicated reset/padding/border rules deleted, the stray trailing border under the last entry fixed, focus ring gained on inline anchors. One restoring override keeps the "coincided with" cross-references reading as links despite the skeleton's row-anchor link reset.

### 2026-07-30 — Target highlight via <mark>

The :target grey row-box is replaced by a <mark> on the entry header, dormant until targeted, styled by the UA (native semantics, dark-mode/forced-colors for free). The hash handler now re-runs fragment navigation via location.replace so shared links also light the mark — under the old treatment, :target silently never matched direct URLs because the list renders after navigation.
