### PR TITLE
Mention Zarr-Python 3.3.0 in latest update

### DIFF
--- a/content/updates/2026-07-30.md
+++ b/content/updates/2026-07-30.md
@@ -49,11 +49,11 @@ This is a good time to remind everyone still accessing data products via `data.d
 
 ## Faster reads with Zarr-Python 3.3.0
 
-[Zarr-Python 3.3.0](https://github.com/zarr-developers/zarr-python/releases/tag/v3.3.0) is out. [Alden's partial-shard read optimization](https://github.com/zarr-developers/zarr-python/pull/3004) replaces serial requests for chunks within a shard with one `Store.get_ranges()` call, letting stores fetch ranges concurrently and coalesce nearby ranges into fewer requests. [The coalescing controls](https://github.com/zarr-developers/zarr-python/pull/3987) are tunable, but the optimization is on by default.
+[Zarr-Python 3.3.0](https://github.com/zarr-developers/zarr-python/releases/tag/v3.3.0) is out. Among many awesome improvements, [Alden's partial-shard read optimization](https://github.com/zarr-developers/zarr-python/pull/3004) replaces serial requests for chunks within a shard with one `Store.get_ranges()` call, letting stores fetch ranges concurrently and coalesce nearby ranges into fewer requests. [The coalescing controls](https://github.com/zarr-developers/zarr-python/pull/3987) are tunable, but the optimization is now on by default.
 
-Every materialized dynamical.org dataset is sharded, so they all stand to benefit. The biggest gains should appear when a read spans multiple chunks within each shard, especially on remote storage; whole-shard and single-chunk reads take different paths.
+Every materialized dynamical.org dataset is sharded, so they all stand to benefit. The biggest gains should appear when a read spans multiple chunks within each shard, especially on remote storage.
 
-People are saying "four times faster!" [One real-world benchmark](https://github.com/zarr-developers/zarr-python/pull/3004#issuecomment-4479912961) of regional reads from a sharded weather reforecast cut the median from 10.8 seconds to 2.75 seconds -- about 3.9x faster -- with a similar result for a global tile. Your mileage will vary with your storage backend, chunk and shard layout, and access pattern.
+People are saying "four times faster!" [One real-world benchmark](https://github.com/zarr-developers/zarr-python/pull/3004#issuecomment-4479912961) of regional reads from a sharded weather reforecast cut the median from 10.8 seconds to 2.75 seconds (that's 3.9x faster!).
 
 ## When is a forecast late?
 

--- a/content/updates/2026-07-30.md
+++ b/content/updates/2026-07-30.md
@@ -1,7 +1,7 @@
 ---
-title: "OMGIMERG, analyzing forecast rollouts cont., NVIDIA Earth-2"
+title: "OMGIMERG, Zarr-Python 3.3.0, analyzing forecast rollouts cont., NVIDIA Earth-2"
 date: 2026-07-30
-description: "NASA IMERG Early and Late precipitation analyses join the catalog, STAC gets direct Icechunk examples, we expand our research on forecast dissemination timing, and NVIDIA Earth2Studio adds dynamical.org data sources."
+description: "NASA IMERG Early and Late precipitation analyses join the catalog, Zarr-Python 3.3.0 speeds up sharded reads, we expand our research on forecast dissemination timing, and NVIDIA Earth2Studio adds dynamical.org data sources."
 ---
 
 Who's the acronym artist at NASA responsible for this tomfoolery? Yes, IMERG is constructed from **I**ntegrated **M**ulti-satellit**E** (!!!) **R**etrievals for **G**PM. Next level.
@@ -46,6 +46,14 @@ ds = xr.open_zarr(session.store, chunks=None)
 One request: don't copy the asset URL out of STAC and hard-code it into your application. We may move or version stores in the future. Resolve the current location from STAC when you open the dataset, or let `dynamical-catalog` do that for you.
 
 This is a good time to remind everyone still accessing data products via `data.dynamical.org`: that endpoint is deprecated and will be **discontinued at the end of August**.
+
+## Faster reads with Zarr-Python 3.3.0
+
+[Zarr-Python 3.3.0](https://github.com/zarr-developers/zarr-python/releases/tag/v3.3.0) is out. [Alden's partial-shard read optimization](https://github.com/zarr-developers/zarr-python/pull/3004) replaces serial requests for chunks within a shard with one `Store.get_ranges()` call, letting stores fetch ranges concurrently and coalesce nearby ranges into fewer requests. [The coalescing controls](https://github.com/zarr-developers/zarr-python/pull/3987) are tunable, but the optimization is on by default.
+
+Every materialized dynamical.org dataset is sharded, so they all stand to benefit. The biggest gains should appear when a read spans multiple chunks within each shard, especially on remote storage; whole-shard and single-chunk reads take different paths.
+
+People are saying "four times faster!" [One real-world benchmark](https://github.com/zarr-developers/zarr-python/pull/3004#issuecomment-4479912961) of regional reads from a sharded weather reforecast cut the median from 10.8 seconds to 2.75 seconds -- about 3.9x faster -- with a similar result for a global tile. Your mileage will vary with your storage backend, chunk and shard layout, and access pattern.
 
 ## When is a forecast late?
 


### PR DESCRIPTION
## Summary

- add Zarr-Python 3.3.0 to the July 30 update title and description
- explain Alden's default-on partial-shard read optimization and coalescing controls
- ground the approximately 4× performance claim in a real-world sharded weather-data benchmark and qualify it by access pattern

## Why

All materialized dynamical.org datasets are sharded, so Zarr-Python 3.3.0's concurrent and coalesced partial-shard reads are directly relevant to catalog users.

## Impact

Readers learn which workloads stand to benefit, see the upstream release and implementation links, and get a concrete benchmark without treating it as a universal result.

## Validation

- `git diff --check`
- Test suite not run: Node/npm are not installed in the current environment.