### PR TITLE
AWS registry YAML: emit markdown Description, not HTML

### DIFF
--- a/content/aws-open-data-registry.njk
+++ b/content/aws-open-data-registry.njk
@@ -12,15 +12,19 @@ permalink: 'aws/dynamical-{{model.id}}.yaml'
   {%- endif -%}
 {%- endfor -%}
 {%- set bucket = "dynamical-" ~ model.id -%}
+{#- The registry renders Description as markdown, not HTML: 1176 of 1177 dataset
+    entries use markdown, and an AWS maintainer hand-converted our HTML back
+    (awslabs/open-data-registry@78a7166, "dynamical markdown fix"). Emit the
+    house style — blank-line separated blocks, `- [Title](url) - description`
+    rows — so regenerated YAML matches what's already upstream. -#}
 Name: {{model.name}} - dynamical.org Icechunk Zarr
 Description: |
-    {{ model.description | markdown | safe | trim }}
-    <p>These datasets have been translated to cloud-optimized Icechunk Zarr format by <a href="https://dynamical.org">dynamical.org</a>.</p>
-    <ul>
-    {%- for entry in entries %}
-      <li><a href="https://dynamical.org/catalog/{{ entry.id | slugify }}/">{{ entry.title }}</a> - {{ entry.description | safe }}</li>
-    {%- endfor %}
-    </ul>
+    {{ model.description | safe | trim }}
+
+    These datasets have been translated to cloud-optimized Icechunk Zarr format by [dynamical.org](https://dynamical.org).
+{% for entry in entries %}
+    - [{{ entry.title }}](https://dynamical.org/catalog/{{ entry.id | slugify }}/) - {{ entry.description | safe }}
+{%- endfor %}
 Documentation: https://dynamical.org/catalog/
 Contact: feedback@dynamical.org
 ManagedBy: "[dynamical.org](https://dynamical.org)"


### PR DESCRIPTION
`docs/aws/dynamical-*.yaml` has been generating an HTML `Description` (`<p>`/`<ul>`/`<li>`) since the template was first written. The Open Data Registry renders that field as **markdown**: 1176 of the 1177 dataset entries upstream use markdown, and the one exception is our own `dynamical-nasa-imerg.yaml`.

An AWS maintainer already caught this and hand-converted our HTML back in [awslabs/open-data-registry@78a7166](https://github.com/awslabs/open-data-registry/commit/78a7166) ("dynamical markdown fix"), four days after our last `noaa-hrrr` regeneration pushed the HTML. Every regeneration since re-proposes a revert of their fix — which is exactly what [awslabs/open-data-registry#3277](https://github.com/awslabs/open-data-registry/pull/3277) did before this change.

Emits the upstream house style: blank-line separated blocks, `- [Title](url) - description` rows, clean `[dynamical.org](https://dynamical.org)` link.

**Verification** — regenerated all nine `dynamical-*.yaml` and diffed against `upstream/main`:

| File | Diff |
|---|---|
| `dwd-icon-eu`, `ecmwf-aifs-single`, `ecmwf-ifs-ens`, `noaa-gefs`, `noaa-gfs`, `noaa-mrms` | **byte-identical** |
| `noaa-hrrr` | the intended 18-hour-virtual addition, plus converging off the maintainer's hastier conversion (`<br><br>`, 6-space list indent, a `[dynamical.org]("https://dynamical.org")` quoting typo) onto the same style as the other seven |
| `nasa-imerg` | HTML → markdown; worth its own upstream PR to fix the one remaining HTML entry in the registry |
| `ecmwf-aifs-ens` | 1 line of **pre-existing, unrelated** drift — upstream says "AIFS-ENS", our STAC `description_model` says "AIFS ENS". Not touched here. |

`npm test` 90/90.

Follow-on from dynamical-org/meta#172.