### PR TITLE
Label planned outages on the status page

### DIFF
--- a/public/status.mjs
+++ b/public/status.mjs
@@ -86,13 +86,19 @@ export function summarizeOverallStatus(data) {
   return { status, incidents };
 }
 
-function statusLabel(status) {
+export function statusLabel(entry) {
+  if (
+    entry.status === "down" &&
+    entry.maintenance?.kind === "planned"
+  ) {
+    return "Planned outage";
+  }
   return {
     operational: "Operational",
     degraded: "Degraded",
     down: "Down",
     unknown: "Unknown",
-  }[status];
+  }[entry.status];
 }
 
 function formatTimestamp(timestamp, local, includeZone = true) {
@@ -204,7 +210,7 @@ function renderGroup(list, entries, bars, uptime, emptyCells) {
     state.className = "status-label";
     mark.setAttribute("aria-hidden", "true");
     mark.textContent = statusMark(entry.status);
-    state.append(mark, ` ${statusLabel(entry.status)}`);
+    state.append(mark, ` ${statusLabel(entry)}`);
     header.append(name, state);
     item.append(header);
 

--- a/test/status.test.mjs
+++ b/test/status.test.mjs
@@ -9,6 +9,7 @@ import {
   isHistoryCurrent,
   isStatusDataStale,
   overlappingEntries,
+  statusLabel,
   STALE_MESSAGE,
   summarizeOverallStatus,
   uptimeDescription,
@@ -153,6 +154,29 @@ test("keeps rendering when a visible component has an unrecognized state", () =>
     status: "degraded",
     incidents: [{ name: "Future tool", status: "unknown" }],
   });
+});
+
+test("labels a planned down component without changing its health state", () => {
+  const entry = {
+    id: "wxopticon-pipeline",
+    name: "pipeline detection",
+    group: "tool",
+    status: "down",
+    maintenance: {
+      kind: "planned",
+      started_at: "2026-08-05T19:58:53Z",
+      summary: "HRRR history migration",
+    },
+  };
+
+  assert.equal(statusLabel(entry), "Planned outage");
+  assert.deepEqual(
+    summarizeOverallStatus({ ...operationalData, endpoints: [entry] }),
+    {
+      status: "down",
+      incidents: [{ name: "pipeline detection", status: "down" }],
+    },
+  );
 });
 
 test("rejects a mismatched event-log revision", () => {


### PR DESCRIPTION
## Goal

Render planned maintenance from the public status feed as Planned outage while preserving down for overall health and uptime accounting.

## Success criteria

- [x] A focused test defines the planned-outage label and unchanged overall health.
- [x] A down component with planned maintenance metadata renders as Planned outage.
- [x] Unplanned, degraded, operational, and unknown labels remain unchanged.
- [x] The full Node test suite and production build pass.

## Implementation

The label helper now receives the full entry and recognizes only status down plus maintenance kind planned. Feeds without maintenance metadata keep their current behavior.

## Validation

- npm test: 91 passed
- npm run build: 2,805 files written

## Rollout

Merge after dynamical.org-data PR 22 is deployed and the live feed contains maintenance metadata.

### 2026-08-05 — retro

Making only the label entry-aware kept the change surgical: health aggregation, history, colors, and uptime calculations remain untouched.