### PR TITLE
Group related status incidents and clean up components

### DIFF
--- a/content/status.njk
+++ b/content/status.njk
@@ -48,6 +48,10 @@ statusSection: uptime
     color: var(--pill-down-fg);
     background: var(--pill-down-bg);
   }
+  .status-list [data-kind="planned"] .status-label {
+    color: var(--pill-degraded-fg);
+    background: var(--pill-degraded-bg);
+  }
   .status-list [data-status="unknown"] .status-label {
     border: 1px solid var(--pill-muted-border);
     color: var(--pill-muted-fg);
@@ -85,6 +89,11 @@ statusSection: uptime
     border-style: solid;
     border-color: var(--pill-down-bg);
     background: var(--pill-down-bg);
+  }
+  .status-bars [data-day="planned"] {
+    border-style: solid;
+    border-color: var(--pill-degraded-bg);
+    background: var(--pill-degraded-bg);
   }
   .status-incident-heading,
   .status-incident header {
@@ -137,6 +146,10 @@ statusSection: uptime
   .status-incident[data-kind="outage"] header strong {
     color: var(--pill-down-fg);
     background: var(--pill-down-bg);
+  }
+  .status-incident[data-kind="planned"] header strong {
+    color: var(--pill-degraded-fg);
+    background: var(--pill-degraded-bg);
   }
   .status-incident[data-kind="delay"] header strong {
     color: var(--pill-degraded-fg);

--- a/public/pipeline.mjs
+++ b/public/pipeline.mjs
@@ -384,10 +384,15 @@ export function detailRows(product, now, local) {
   const running = product.recent_inits.findLast(
     (init) => init.status === "in_flight",
   );
-  const groups = running?.lead_groups ?? [];
-  const initMs = running ? Date.parse(running.init_time) : 0;
+  const displayed = running ?? product.recent_inits.at(-1);
+  const groups = displayed?.lead_groups ?? [];
+  const initMs = displayed ? Date.parse(displayed.init_time) : 0;
   return {
-    header: running ? initShort(running.init_time, local) : "waiting for next init",
+    header: running
+      ? initShort(running.init_time, local)
+      : displayed
+        ? `${initShort(displayed.init_time, local)} · previous init`
+        : "waiting for next init",
     rows: product.lead_group_stats.map((stats, index) => {
       const live = groups[index];
       let time = "—";

--- a/public/status-health.mjs
+++ b/public/status-health.mjs
@@ -10,6 +10,14 @@ export function systemHealth(data) {
   }
   const statuses = new Set(data.endpoints.map(({ status }) => status));
   if (statuses.has("down")) {
+    const down = data.endpoints.filter(({ status }) => status === "down");
+    if (down.every(({ maintenance }) => maintenance?.kind === "planned")) {
+      return {
+        state: "advisory",
+        label: "systems",
+        value: "planned outage",
+      };
+    }
     return { state: "down", label: "systems", value: "disrupted" };
   }
   if ([...statuses].some((status) => status !== "operational")) {

--- a/public/status.mjs
+++ b/public/status.mjs
@@ -50,6 +50,18 @@ function isIncidentGroup(group) {
   );
 }
 
+function isComponentAliases(aliases) {
+  return (
+    aliases &&
+    typeof aliases === "object" &&
+    !Array.isArray(aliases) &&
+    Object.entries(aliases).every(
+      ([alias, target]) =>
+        typeof alias === "string" && typeof target === "string",
+    )
+  );
+}
+
 // Preserve the rest of the page when a separately deployed publisher adds a state.
 function normalizeEntry(entry) {
   return PUBLIC_STATUSES.has(entry.status)
@@ -72,6 +84,12 @@ export function validateStatusData(data) {
   }
   if (![...data.datasets, ...data.endpoints].every(isStatusEntry)) {
     throw new TypeError("Invalid status entry");
+  }
+  if (
+    data.component_aliases != null &&
+    !isComponentAliases(data.component_aliases)
+  ) {
+    throw new TypeError("Invalid component aliases");
   }
   if (!data.endpoints.every((entry) => PUBLIC_GROUPS.has(entry.group))) {
     throw new TypeError("Invalid status entry group");
@@ -172,7 +190,7 @@ export function uptimeDescription(measured, days) {
 // state did to the thing you use. A component the publisher adds before this
 // page learns it falls back to generic phrasing rather than rendering nothing.
 const IMPACT = {
-  "dynamical-org": { outage: "The website was unreachable" },
+  "dynamical-org": { outage: "The status page was unreachable" },
   "stac-catalog": { outage: "The STAC catalog API was unreachable" },
   "data-product-reads": {
     outage: "Reads of dynamical.org data failed their canary checks",
@@ -186,8 +204,8 @@ const IMPACT = {
     delay: "Pipeline webhook delivery ran behind",
   },
   "wxopticon-arrivals": {
-    outage: "The pipeline status page stopped updating",
-    delay: "The pipeline status page updated late",
+    outage: "Pipeline observability stopped updating",
+    delay: "Pipeline observability updated late",
   },
   scorecard: {
     outage: "The scorecard stopped refreshing",
@@ -532,11 +550,13 @@ function incidentName(incident, names) {
 }
 
 function groupedIncidentDescription(incident, names, end) {
-  const affected = sentenceList(
-    incident.components
-      .map((component) => names.get(component))
-      .filter(Boolean),
-  );
+  const affected = sentenceList([
+    ...new Set(
+      incident.components
+        .map((component) => names.get(component))
+        .filter(Boolean),
+    ),
+  ]);
   const impact =
     incident.kind === "planned"
       ? `Planned work affected ${affected}`
@@ -557,6 +577,9 @@ function renderIncidentLog(root, history, data, local) {
   }
 
   const names = new Map(data.endpoints.map(({ id, name }) => [id, name]));
+  for (const [alias, target] of Object.entries(data.component_aliases ?? {})) {
+    if (names.has(target)) names.set(alias, names.get(target));
+  }
   const visible = history.incidents
     .filter((incident) =>
       incident.components

--- a/public/status.mjs
+++ b/public/status.mjs
@@ -35,6 +35,21 @@ function hasUtcOffset(timestamp) {
   );
 }
 
+function isIncidentGroup(group) {
+  return (
+    group &&
+    typeof group.id === "string" &&
+    ["outage", "planned"].includes(group.kind) &&
+    typeof group.summary === "string" &&
+    hasUtcOffset(group.started_at) &&
+    hasUtcOffset(group.ended_at) &&
+    Date.parse(group.ended_at) > Date.parse(group.started_at) &&
+    Array.isArray(group.components) &&
+    group.components.length > 0 &&
+    group.components.every((component) => typeof component === "string")
+  );
+}
+
 // Preserve the rest of the page when a separately deployed publisher adds a state.
 function normalizeEntry(entry) {
   return PUBLIC_STATUSES.has(entry.status)
@@ -60,6 +75,13 @@ export function validateStatusData(data) {
   }
   if (!data.endpoints.every((entry) => PUBLIC_GROUPS.has(entry.group))) {
     throw new TypeError("Invalid status entry group");
+  }
+  if (
+    data.incident_groups != null &&
+    (!Array.isArray(data.incident_groups) ||
+      !data.incident_groups.every(isIncidentGroup))
+  ) {
+    throw new TypeError("Invalid incident group");
   }
   return {
     ...data,
@@ -130,8 +152,11 @@ function formatDuration(start, end) {
   return `${days}d${remainingHours ? ` ${remainingHours}h` : ""}`;
 }
 
-function statusMark(status) {
-  return { operational: "●", degraded: "▲", down: "×", unknown: "?" }[status];
+function statusMark(entry) {
+  if (entry.status === "down" && entry.maintenance?.kind === "planned") {
+    return "▲";
+  }
+  return { operational: "●", degraded: "▲", down: "×", unknown: "?" }[entry.status];
 }
 
 export function uptimeDescription(measured, days) {
@@ -170,6 +195,87 @@ const IMPACT = {
   },
 };
 
+// Explicit publisher metadata, not time overlap alone, determines which events
+// share an incident.
+export function applyIncidentGroups(history, incidentGroups = []) {
+  if (!history || incidentGroups.length === 0) return history;
+
+  let ungrouped = [...history.incidents];
+  const grouped = [];
+  const aliases = new Map();
+  const plannedMembers = new Set();
+
+  for (const configured of incidentGroups) {
+    const windowStart = Date.parse(configured.started_at);
+    const windowEnd = Date.parse(configured.ended_at);
+    const components = new Set(configured.components);
+    const matches = ungrouped.filter(
+      (incident) =>
+        components.has(incident.component) &&
+        windowStart <= incident.start &&
+        incident.start < windowEnd,
+    );
+    if (matches.length === 0) continue;
+
+    const matched = new Set(matches);
+    ungrouped = ungrouped.filter((incident) => !matched.has(incident));
+    const id = `incident-group-${configured.id}`;
+    const memberIds = matches.map((incident) => incident.id);
+    for (const memberId of memberIds) {
+      aliases.set(memberId, id);
+      if (configured.kind === "planned") plannedMembers.add(memberId);
+    }
+    const allEnded = matches.every((incident) => incident.end != null);
+    grouped.push({
+      id,
+      kind: configured.kind,
+      summary: configured.summary,
+      components: configured.components.filter((component) =>
+        matches.some((incident) => incident.component === component),
+      ),
+      memberIds,
+      start: Math.min(...matches.map((incident) => incident.start)),
+      end: allEnded
+        ? Math.max(...matches.map((incident) => incident.end))
+        : null,
+      ending:
+        allEnded && matches.every((incident) => incident.ending === "resolved")
+          ? "resolved"
+          : allEnded
+            ? "observation-ended"
+            : null,
+    });
+  }
+
+  const cells = new Map(
+    [...history.cells.entries()].map(([component, componentCells]) => [
+      component,
+      componentCells.map((cell) => {
+        if (!cell.incidentIds?.length) return { ...cell };
+        const incidentIds = [
+          ...new Set(cell.incidentIds.map((id) => aliases.get(id) ?? id)),
+        ];
+        const displayState = cell.incidentIds.every((id) =>
+          plannedMembers.has(id),
+        )
+          ? "planned"
+          : cell.displayState;
+        return {
+          ...cell,
+          ...(displayState ? { displayState } : {}),
+          incidentIds,
+        };
+      }),
+    ]),
+  );
+
+  return {
+    ...history,
+    cells,
+    incidents: [...ungrouped, ...grouped].sort((a, b) => a.start - b.start),
+  };
+}
+
 // Entries whose intervals overlap this one's, for the "coincided with" clause.
 // Correlation is the context a status page can derive honestly: it claims two
 // things happened together, never that one caused the other.
@@ -206,10 +312,11 @@ function renderGroup(list, entries, bars, uptime, emptyCells) {
     const mark = document.createElement("span");
 
     item.dataset.status = entry.status;
+    if (entry.maintenance?.kind) item.dataset.kind = entry.maintenance.kind;
     name.textContent = entry.name;
     state.className = "status-label";
     mark.setAttribute("aria-hidden", "true");
-    mark.textContent = statusMark(entry.status);
+    mark.textContent = statusMark(entry);
     state.append(mark, ` ${statusLabel(entry)}`);
     header.append(name, state);
     item.append(header);
@@ -227,7 +334,12 @@ function renderGroup(list, entries, bars, uptime, emptyCells) {
 }
 
 export function barDescription(cells) {
-  const down = cells.filter((cell) => cell.state === "down").length;
+  const planned = cells.filter(
+    (cell) => cell.displayState === "planned",
+  ).length;
+  const down = cells.filter(
+    (cell) => cell.state === "down" && cell.displayState !== "planned",
+  ).length;
   const degraded = cells.filter((cell) => cell.state === "degraded").length;
   const unknown = cells.filter((cell) => cell.state === "unknown").length;
   const uncovered = cells.filter((cell) => cell.state === "nodata").length;
@@ -238,6 +350,9 @@ export function barDescription(cells) {
       ? `No outages recorded in the last ${days} ${plural(days)}`
       : `${down} of the last ${days} ${plural(days)} had an outage`,
   ];
+  if (planned > 0) {
+    parts.push(`${planned} ${plural(planned)} had a planned outage`);
+  }
   if (degraded > 0) parts.push(`${degraded} ${plural(degraded)} degraded`);
   if (unknown > 0) parts.push(`${unknown} ${plural(unknown)} had an unknown state`);
   if (uncovered > 0) parts.push(`${uncovered} ${plural(uncovered)} not monitored`);
@@ -251,14 +366,21 @@ function barStrip(cells) {
   strip.setAttribute("aria-label", barDescription(cells));
   for (const cell of cells) {
     const anchor = cell.incidentIds?.[0] ?? cell.delayIds?.[0];
+    const dayState = cell.displayState ?? cell.state;
+    const dayLabel =
+      dayState === "nodata"
+        ? "not monitored"
+        : dayState === "planned"
+          ? "planned outage"
+          : dayState;
     const day = document.createElement(anchor ? "a" : "span");
-    day.dataset.day = cell.state;
-    day.title = `${cell.date}: ${cell.state === "nodata" ? "not monitored" : cell.state}`;
+    day.dataset.day = dayState;
+    day.title = `${cell.date}: ${dayLabel}`;
     if (anchor) {
       day.href = `#${anchor}`;
       day.setAttribute(
         "aria-label",
-        `${cell.date}: ${cell.incidentIds?.length ? "outage" : "delay"}; view details`,
+        `${cell.date}: ${dayLabel}; view details`,
       );
     } else {
       day.setAttribute("aria-hidden", "true");
@@ -357,10 +479,14 @@ function renderStatus(root, data, loadedHistory, local) {
     );
     updated.replaceChildren("As of ", generatedTime);
   }
-  const history =
+  const currentHistory =
     loadedHistory && isHistoryCurrent(loadedHistory.asOf, data.generated_at)
       ? loadedHistory
       : null;
+  const history = applyIncidentGroups(
+    currentHistory,
+    data.incident_groups ?? [],
+  );
   const emptyCells = dailyBars(new Map([["", []]]), {
     asOf: history?.asOf ?? new Date(data.generated_at),
     days: BAR_DAYS,
@@ -395,6 +521,31 @@ function setHistoryNotice(element, message) {
   element.textContent = message ?? "";
 }
 
+function sentenceList(items) {
+  if (items.length < 2) return items.join("");
+  if (items.length === 2) return items.join(" and ");
+  return `${items.slice(0, -1).join(", ")}, and ${items.at(-1)}`;
+}
+
+function incidentName(incident, names) {
+  return incident.summary ?? names.get(incident.component);
+}
+
+function groupedIncidentDescription(incident, names, end) {
+  const affected = sentenceList(
+    incident.components
+      .map((component) => names.get(component))
+      .filter(Boolean),
+  );
+  const impact =
+    incident.kind === "planned"
+      ? `Planned work affected ${affected}`
+      : `Related outages affected ${affected}`;
+  return incident.end
+    ? `${impact} for ${formatDuration(incident.start, incident.end)}.`
+    : `${impact} — ongoing for ${formatDuration(incident.start, end)}.`;
+}
+
 function renderIncidentLog(root, history, data, local) {
   const list = root.querySelector("#status-incident-log");
   const empty = root.querySelector("#status-incident-empty");
@@ -407,7 +558,11 @@ function renderIncidentLog(root, history, data, local) {
 
   const names = new Map(data.endpoints.map(({ id, name }) => [id, name]));
   const visible = history.incidents
-    .filter((incident) => names.has(incident.component))
+    .filter((incident) =>
+      incident.components
+        ? incident.components.some((component) => names.has(component))
+        : names.has(incident.component),
+    )
     .reverse();
   empty.textContent = "No incidents or delays recorded.";
   empty.hidden = visible.length > 0;
@@ -420,6 +575,7 @@ function renderIncidentLog(root, history, data, local) {
     const summary = document.createElement("p");
     const timing = document.createElement("p");
     const kind = incident.kind ?? "outage";
+    const label = kind === "planned" ? "planned outage" : kind;
     const end = incident.end ?? history.asOf.getTime();
 
     item.id = incident.id;
@@ -429,19 +585,18 @@ function renderIncidentLog(root, history, data, local) {
     // :target — arriving from a day cell lights up the header rather than
     // boxing the whole entry.
     const highlight = document.createElement("mark");
-    highlight.textContent = names.get(incident.component);
+    highlight.textContent = incidentName(incident, names);
     name.append(highlight);
-    state.textContent = `${kind} · ${
+    state.textContent = `${label} · ${
       incident.ending === "resolved"
         ? "resolved"
         : incident.ending === "observation-ended"
           ? "observation ended"
           : "ongoing"
     }`;
-    summary.textContent = incidentDescription(
-      incident,
-      names.get(incident.component),
-    );
+    summary.textContent = incident.components
+      ? groupedIncidentDescription(incident, names, end)
+      : incidentDescription(incident, names.get(incident.component));
     const overlapping = overlappingEntries(
       incident,
       visible,
@@ -452,7 +607,9 @@ function renderIncidentLog(root, history, data, local) {
       overlapping.forEach((other, index) => {
         const link = document.createElement("a");
         link.href = `#${other.id}`;
-        link.textContent = `the ${names.get(other.component)} ${other.kind ?? "outage"}`;
+        const otherKind =
+          other.kind === "planned" ? "planned outage" : other.kind ?? "outage";
+        link.textContent = `the ${incidentName(other, names)} ${otherKind}`;
         if (index > 0) summary.append(", ");
         summary.append(link);
       });

--- a/test/fixtures/status.json
+++ b/test/fixtures/status.json
@@ -86,12 +86,6 @@
   ],
   "endpoints": [
     {
-      "id": "dynamical-org",
-      "name": "dynamical.org website",
-      "group": "endpoint",
-      "status": "operational"
-    },
-    {
       "id": "stac-catalog",
       "name": "STAC catalog",
       "group": "endpoint",
@@ -104,16 +98,31 @@
       "status": "down"
     },
     {
-      "id": "wxopticon",
-      "name": "wxopticon",
-      "group": "tool",
-      "status": "operational"
-    },
-    {
       "id": "scorecard",
       "name": "scorecard",
       "group": "tool",
       "status": "operational"
+    },
+    {
+      "id": "wxopticon-arrivals",
+      "name": "pipeline observability",
+      "group": "tool",
+      "status": "operational"
+    },
+    {
+      "id": "wxopticon-webhooks",
+      "name": "pipeline webhooks",
+      "group": "tool",
+      "status": "operational"
+    },
+    {
+      "id": "dynamical-org",
+      "name": "status page",
+      "group": "tool",
+      "status": "operational"
     }
-  ]
+  ],
+  "component_aliases": {
+    "wxopticon-pipeline": "wxopticon-arrivals"
+  }
 }

--- a/test/pipeline.test.mjs
+++ b/test/pipeline.test.mjs
@@ -96,6 +96,21 @@ test("summarizes shared system and agency health", () => {
     }),
     { state: "down", label: "systems", value: "disrupted" },
   );
+  assert.deepEqual(
+    systemHealth({
+      endpoints: [
+        {
+          status: "down",
+          maintenance: { kind: "planned" },
+        },
+      ],
+    }),
+    {
+      state: "advisory",
+      label: "systems",
+      value: "planned outage",
+    },
+  );
   assert.deepEqual(systemHealth({ endpoints: [{ status: "new-state" }] }), {
     state: "degraded",
     label: "some systems",
@@ -216,6 +231,44 @@ test("retains live horizon status, time, and duration in details", () => {
         },
       ],
     },
+  );
+});
+
+test("shows the previous init details while waiting for the next init", () => {
+  const product = {
+    recent_inits: [
+      {
+        init_time: "2026-07-26T06:00:00Z",
+        status: "complete",
+        lead_groups: [
+          { status: "complete", latency_s: 1200 },
+          { status: "complete", latency_s: 2700 },
+        ],
+      },
+    ],
+    lead_group_stats: [
+      { label: "1d", p50_s: 1200, p95_s: 1800, p99_s: 2400 },
+      { label: "3d", p50_s: 2400, p95_s: 3600, p99_s: 4800 },
+    ],
+  };
+
+  const details = detailRows(
+    product,
+    Date.parse("2026-07-26T07:00:00Z"),
+    false,
+  );
+
+  assert.equal(details.header, "07-26 06z · previous init");
+  assert.deepEqual(
+    details.rows.map(({ status, time, duration }) => ({
+      status,
+      time,
+      duration,
+    })),
+    [
+      { status: "complete", time: "06:20", duration: "20m" },
+      { status: "complete", time: "06:45", duration: "45m" },
+    ],
   );
 });
 

--- a/test/status.test.mjs
+++ b/test/status.test.mjs
@@ -3,6 +3,7 @@ import { readFileSync } from "node:fs";
 import test from "node:test";
 
 import {
+  applyIncidentGroups,
   barDescription,
   buildHistory,
   incidentDescription,
@@ -179,6 +180,122 @@ test("labels a planned down component without changing its health state", () => 
   );
 });
 
+test("groups explicitly related outages and remaps day links", () => {
+  const detection = {
+    id: "incident-wxopticon-pipeline-1785960026",
+    component: "wxopticon-pipeline",
+    kind: "outage",
+    start: Date.parse("2026-08-05T20:00:26Z"),
+    end: Date.parse("2026-08-05T21:20:15Z"),
+    ending: "resolved",
+  };
+  const arrivals = {
+    id: "incident-wxopticon-arrivals-1785960311",
+    component: "wxopticon-arrivals",
+    kind: "outage",
+    start: Date.parse("2026-08-05T20:05:11Z"),
+    end: Date.parse("2026-08-05T21:10:15Z"),
+    ending: "resolved",
+  };
+  const webhooks = {
+    id: "incident-wxopticon-webhooks-1785960311",
+    component: "wxopticon-webhooks",
+    kind: "outage",
+    start: Date.parse("2026-08-05T20:05:11Z"),
+    end: Date.parse("2026-08-05T21:40:11Z"),
+    ending: "resolved",
+  };
+  const history = {
+    asOf: new Date("2026-08-05T21:45:00Z"),
+    incidents: [detection, arrivals, webhooks],
+    cells: new Map([
+      [
+        "wxopticon-pipeline",
+        [{ date: "2026-08-05", state: "down", incidentIds: [detection.id] }],
+      ],
+      [
+        "wxopticon-arrivals",
+        [{ date: "2026-08-05", state: "down", incidentIds: [arrivals.id] }],
+      ],
+      [
+        "wxopticon-webhooks",
+        [{ date: "2026-08-05", state: "down", incidentIds: [webhooks.id] }],
+      ],
+    ]),
+  };
+  const incidentGroups = [
+    {
+      id: "hrrr-history-migration",
+      kind: "planned",
+      summary: "HRRR history migration",
+      started_at: "2026-08-05T19:58:53Z",
+      ended_at: "2026-08-05T21:40:11Z",
+      components: [
+        "wxopticon-pipeline",
+        "wxopticon-arrivals",
+        "wxopticon-webhooks",
+      ],
+    },
+  ];
+
+  const grouped = applyIncidentGroups(history, incidentGroups);
+
+  assert.deepEqual(grouped.incidents, [
+    {
+      id: "incident-group-hrrr-history-migration",
+      kind: "planned",
+      summary: "HRRR history migration",
+      components: incidentGroups[0].components,
+      memberIds: [detection.id, arrivals.id, webhooks.id],
+      start: detection.start,
+      end: webhooks.end,
+      ending: "resolved",
+    },
+  ]);
+  for (const cells of grouped.cells.values()) {
+    assert.deepEqual(cells[0], {
+      date: "2026-08-05",
+      state: "down",
+      displayState: "planned",
+      incidentIds: ["incident-group-hrrr-history-migration"],
+    });
+  }
+});
+
+test("explicit unplanned incident groups retain outage severity", () => {
+  const incident = {
+    id: "incident-api-1",
+    component: "api",
+    kind: "outage",
+    start: Date.parse("2026-08-05T20:00:00Z"),
+    end: Date.parse("2026-08-05T20:10:00Z"),
+    ending: "resolved",
+  };
+  const grouped = applyIncidentGroups(
+    {
+      incidents: [incident],
+      cells: new Map([
+        ["api", [{ date: "2026-08-05", state: "down", incidentIds: [incident.id] }]],
+      ]),
+    },
+    [
+      {
+        id: "api-deploy",
+        kind: "outage",
+        summary: "API deploy rollback",
+        started_at: "2026-08-05T19:59:00Z",
+        ended_at: "2026-08-05T20:10:00Z",
+        components: ["api"],
+      },
+    ],
+  );
+
+  assert.equal(grouped.incidents[0].kind, "outage");
+  assert.equal(grouped.cells.get("api")[0].displayState, undefined);
+  assert.deepEqual(grouped.cells.get("api")[0].incidentIds, [
+    "incident-group-api-deploy",
+  ]);
+});
 test("rejects a mismatched event-log revision", () => {
   const events = `${JSON.stringify({
     ts: "2026-07-24T19:00:00Z",
@@ -382,6 +499,15 @@ test("bar descriptions count degraded days apart from outages", () => {
   assert.match(description, /1 day degraded/i);
 });
 
+test("bar descriptions separate planned work from outages", () => {
+  const description = barDescription([
+    { state: "down", displayState: "planned" },
+    { state: "down" },
+  ]);
+  assert.match(description, /1 of the last 2 days had an outage/i);
+  assert.match(description, /1 day had a planned outage/i);
+});
+
 test("uptime description surfaces degraded time without calling it downtime", () => {
   assert.equal(
     uptimeDescription({ uptime: 100, coverage: 50, delayed: 0.007 }, 90),
@@ -416,6 +542,18 @@ test("status page passes its timestamp into the shared subnav row", () => {
     /\.status-bars > \*\s*{[^}]*border: 1px dotted/s,
   );
   assert.doesNotMatch(template, /\.status-bars \+ p/);
+  assert.match(
+    template,
+    /\.status-list \[data-kind="planned"\][^}]*var\(--pill-degraded-bg\)/s,
+  );
+  assert.match(
+    template,
+    /\.status-bars \[data-day="planned"\][^}]*var\(--pill-degraded-bg\)/s,
+  );
+  assert.match(
+    template,
+    /\.status-incident\[data-kind="planned"\][^}]*var\(--pill-degraded-bg\)/s,
+  );
   assert.doesNotMatch(script, /textContent = "Today"|day.*ago/);
   assert.doesNotMatch(
     template,

--- a/test/status.test.mjs
+++ b/test/status.test.mjs
@@ -34,8 +34,8 @@ const operationalData = {
   endpoints: [
     {
       id: "dynamical-org",
-      name: "dynamical.org website",
-      group: "endpoint",
+      name: "status page",
+      group: "tool",
       status: "operational",
       uptime: 99.9,
       uptime_since: "2026-04-26T19:55:00Z",
@@ -49,16 +49,17 @@ test("accepts the published feed shape", () => {
   // 14, matching the collections in stac.dynamical.org/catalog.json — the
   // publisher deliberately excludes contrib datasets and source archivers.
   assert.equal(fixture.datasets.length, 14);
-  // Five endpoints across the page's two sections, plus the 14 datasets the feed
-  // still carries even though the page does not render them yet.
+  // Core resources followed by the reader-facing tools; datasets remain in the
+  // feed even though the page does not render them yet.
   assert.deepEqual(
     fixture.endpoints.map((entry) => [entry.id, entry.group]),
     [
-      ["dynamical-org", "endpoint"],
       ["stac-catalog", "endpoint"],
       ["data-product-reads", "endpoint"],
-      ["wxopticon", "tool"],
       ["scorecard", "tool"],
+      ["wxopticon-arrivals", "tool"],
+      ["wxopticon-webhooks", "tool"],
+      ["dynamical-org", "tool"],
     ],
   );
   assert.deepEqual(summarizeOverallStatus(fixture), {
@@ -81,7 +82,7 @@ test("summarizes only the components this page renders", () => {
 
   assert.deepEqual(summarizeOverallStatus(data), {
     status: "down",
-    incidents: [{ name: "dynamical.org website", status: "down" }],
+    incidents: [{ name: "status page", status: "down" }],
   });
 });
 
@@ -409,8 +410,8 @@ test("incident descriptions say what the state did to the thing you use", () => 
     end: Date.parse("2026-07-29T17:20:00Z"),
   };
   assert.equal(
-    incidentDescription(tenMinutes, "Arrivals dashboard"),
-    "The pipeline status page updated late for 10 minutes.",
+    incidentDescription(tenMinutes, "pipeline observability"),
+    "Pipeline observability updated late for 10 minutes.",
   );
   assert.equal(
     incidentDescription(


### PR DESCRIPTION
## Summary

- group related component incidents in status history using explicit publisher metadata
- render planned outages with quieter amber treatment while unexpected outages remain red
- show the latest observed pipeline initialization while waiting for the next run
- consume component aliases so legacy pipeline-detection history follows pipeline observability
- update Tools & resources to scorecard, pipeline observability, pipeline webhooks, and status page

Related to dynamical-org/meta#162. Paired with dynamical-org/dynamical.org-data#24.

## Plan

- [x] Add previous-initialization fallback in pipeline detail tables.
- [x] Validate and render explicit general incident groups.
- [x] Give planned live states and grouped history entries an amber treatment.
- [x] Keep ordinary grouped outages at normal red severity.
- [x] Point day cells to grouped incident entries.
- [x] Retain compatibility with legacy feeds and component IDs.
- [ ] Add API after the publisher has a real detector.
- [x] Run the full Node suite and production build.

## Validation

- `npm test` — 113 passed
- `npm run build`
