### PR TITLE
Note the legacy Zarr example in the 2025-03-12 update is going away

### DIFF
--- a/content/updates/2025-03-12.md
+++ b/content/updates/2025-03-12.md
@@ -33,6 +33,8 @@ import xarray as xr
 ds = xr.open_dataset("https://data.dynamical.org/noaa/gefs/forecast-35-day/latest.zarr?email=optional@email.com")
 ```
 
+**Note, added 2026-08-06:** the `data.dynamical.org` URL above stops working after **August 31, 2026**. This dataset is still public and still updating — it is now an Icechunk repository, opened as `dynamical_catalog.open("noaa-gefs-forecast-35-day")`. See the [migration guide](/migration-2026/) for the supported access patterns.
+
 We are already using this new dataset for R&D at Upstream Tech, and we **can’t wait to hear how you use it!** We've included [documentation and example notebooks](https://dynamical.org/catalog) in the catalog entry to get you started. If you hit snags or have feedback, drop us a line at [feedback@dynamical.org](mailto:feedback@dynamical.org).
 
 We’ll be holding our first dynamical.org office hours Thursday Mar 20, 2025 at 10-11am PDT / 1-2pm EDT / 5-6pm UTC. Join [this Google Meet](https://meet.google.com/wtc-jhff-bxn) to ask questions or give feedback.


### PR DESCRIPTION
Closes the last open item on [meta#175](https://github.com/dynamical-org/meta/issues/175)'s second success criterion — "Dynamical-owned docs, examples, notebooks, and repositories no longer advertise \`data.dynamical.org/**/latest.zarr\`."

After #178, https://dynamical.org/updates/2025-03-12/ is the only remaining dynamical-owned surface with a copy-pasteable legacy URL. Verified today across all 19 org repos and an org-wide code search: every other hit is worker implementation, ops planning, meeting minutes, security/support reference, or usage analytics. `_data/catalog.js`, STAC, and the AWS open-data-registry entries are clean.

The published snippet stays as-is — it is what the post said in March 2025. The note above it is dated, states the August 31, 2026 cutoff in the future tense that is still correct today, names the replacement dataset ID, and links `/migration-2026/`.

`npm test` passes (113/113).