### PR TITLE
Fix migration guide code blocks and sunset notice styling

### DIFF
--- a/content/catalog-pages.njk
+++ b/content/catalog-pages.njk
@@ -192,6 +192,16 @@ eleventyComputed:
       padding: 0 9px;
     }
   }
+  /* data.dynamical.org sunset notice. The only <aside> on the site, so it needs
+     no class. Amber is the site's warning color (the status page's degraded
+     state); --link-color would have read as navigation, not as a deprecation. */
+  aside {
+    margin: 2rem 0;
+    padding: 1rem 1.2rem;
+    border-left: 4px solid var(--pill-degraded-bg);
+    border-radius: var(--radius-sm);
+    background: var(--surface-muted);
+  }
 </style>
 <script type="application/ld+json">{{ entry.jsonld | dump | safe }}</script>
 {% macro variableTable(variables, groupName) %}
@@ -240,7 +250,7 @@ eleventyComputed:
     &gt; {{ entry.title }}
   </div>
   {% if entry.id in ["noaa-gfs-forecast", "noaa-gfs-analysis", "noaa-gefs-forecast-35-day", "noaa-gefs-analysis", "noaa-hrrr-forecast-48-hour", "noaa-hrrr-analysis", "noaa-mrms-conus-analysis-hourly", "ecmwf-ifs-ens-forecast-15-day-0-25-degree", "ecmwf-aifs-single-forecast", "dwd-icon-eu-forecast-5-day"] %}
-    <aside aria-label="data.dynamical.org migration" style="border-left: 4px solid var(--link-color); padding: 0.75rem 1rem; margin: 2rem 0;">
+    <aside aria-label="data.dynamical.org migration">
       <strong><code>data.dynamical.org</code> access ends August 31, 2026.</strong>
       If you use a <code>data.dynamical.org</code> URL for this dataset,
       <a href="/migration-2026/">migrate to a supported access pattern</a>.

--- a/content/migration-2026.njk
+++ b/content/migration-2026.njk
@@ -53,7 +53,7 @@ permalink: /migration-2026/
   <h2>Recommended: dynamical-catalog</h2>
   <p>
     Use Python 3.12 or newer and install <code>dynamical-catalog&gt;=0.7.0</code>.
-    Pass the replacement dataset ID, derived from your URL as described below.
+    Pass the dataset ID from its <a href="/catalog/">catalog page</a>.
   </p>
   {% frameHighlight "py" %}import dynamical_catalog
 
@@ -76,20 +76,6 @@ asset = collection.assets["icechunk-https"]
 repo = icechunk.Repository.open(icechunk.http_storage(asset.href))
 session = repo.readonly_session("main")
 ds = xr.open_zarr(session.store, consolidated=False, chunks=None){% endframeHighlight %}
-
-  <h2>Finding the replacement dataset ID</h2>
-  <p>
-    Drop the host and join the path with hyphens:
-    <code>data.dynamical.org/noaa/gfs/forecast/latest.zarr</code> becomes
-    <code>noaa-gfs-forecast</code>. Every ID is listed in the
-    <a href="https://stac.dynamical.org/catalog.json">STAC catalog</a> and has a
-    <a href="/catalog/">catalog page</a>.
-  </p>
-  <p>
-    One path does not convert: <code>/noaa/gfs/analysis-hourly/</code> was a
-    retired four-variable archive with no current equivalent. Use
-    <a href="/catalog/noaa-gfs-analysis/"><code>noaa-gfs-analysis</code></a> instead.
-  </p>
 
   <h2>Have an agent do it</h2>
   <p>Paste this into a coding agent running in your repository.</p>

--- a/content/migration-2026.njk
+++ b/content/migration-2026.njk
@@ -6,6 +6,36 @@ description: Replace data.dynamical.org Zarr URLs with our supported access patt
 permalink: /migration-2026/
 ---
 
+<style>
+  /* The agent prompt is text you hand to a tool, not source we highlight — a
+     readonly field rather than a <pre>, so it selects and copies as one unit. */
+  .agent-prompt textarea {
+    display: block;
+    width: 100%;
+    height: 34rem;
+    padding: 1em;
+    border: 1px solid var(--border-muted-color);
+    border-radius: var(--radius-sm);
+    background: var(--surface-muted);
+    color: inherit;
+    font: inherit;
+    font-size: 1.4rem;
+    line-height: 1.5;
+    resize: vertical;
+  }
+  /* A link, not a button: it copies text, it doesn't submit anything. */
+  .agent-prompt button {
+    margin-top: 0.5rem;
+    padding: 0;
+    border: 0;
+    background: none;
+    color: var(--link-color);
+    font: inherit;
+    text-decoration: underline;
+    cursor: pointer;
+  }
+</style>
+
 <div class="content">
   <h1 style="margin-top: 4rem; margin-bottom: 1rem;">Migrate from data.dynamical.org</h1>
 
@@ -23,11 +53,11 @@ permalink: /migration-2026/
   <h2>Recommended: dynamical-catalog</h2>
   <p>
     Use Python 3.12 or newer and install <code>dynamical-catalog&gt;=0.7.0</code>.
-    Pass the replacement dataset ID from the table below.
+    Pass the replacement dataset ID, derived from your URL as described below.
   </p>
-  <pre><code class="language-python">import dynamical_catalog
+  {% frameHighlight "py" %}import dynamical_catalog
 
-ds = dynamical_catalog.open("noaa-gfs-forecast", chunks=None)</code></pre>
+ds = dynamical_catalog.open("noaa-gfs-forecast", chunks=None){% endframeHighlight %}
 
   <h2>Direct STAC and Icechunk</h2>
   <p>
@@ -35,7 +65,7 @@ ds = dynamical_catalog.open("noaa-gfs-forecast", chunks=None)</code></pre>
     application opens a repository. Do not copy and permanently hard-code the
     asset URL.
   </p>
-  <pre><code class="language-python">import icechunk
+  {% frameHighlight "py" %}import icechunk
 import pystac
 import xarray as xr
 
@@ -45,7 +75,7 @@ asset = collection.assets["icechunk-https"]
 
 repo = icechunk.Repository.open(icechunk.http_storage(asset.href))
 session = repo.readonly_session("main")
-ds = xr.open_zarr(session.store, consolidated=False, chunks=None)</code></pre>
+ds = xr.open_zarr(session.store, consolidated=False, chunks=None){% endframeHighlight %}
 
   <h2>Finding the replacement dataset ID</h2>
   <p>
@@ -63,7 +93,8 @@ ds = xr.open_zarr(session.store, consolidated=False, chunks=None)</code></pre>
 
   <h2>Have an agent do it</h2>
   <p>Paste this into a coding agent running in your repository.</p>
-  <pre><code>Replace every data.dynamical.org URL in this repository with dynamical.org's
+  <div class="agent-prompt">
+    <textarea readonly rows="24" aria-label="Migration prompt for a coding agent">Replace every data.dynamical.org URL in this repository with dynamical.org's
 supported access, and leave no hard-coded storage locations behind.
 
 Context to read first:
@@ -87,7 +118,28 @@ Rules:
   assumes a specific chunk shape.
 
 Report every URL you could not map, and every place a dataset ID had to be
-chosen rather than derived.</code></pre>
+chosen rather than derived.</textarea>
+    <button type="button">copy to clipboard</button>
+  </div>
+  <script>
+    (() => {
+      const prompt = document.querySelector(".agent-prompt textarea");
+      const button = document.querySelector(".agent-prompt button");
+      const label = button.textContent;
+      button.addEventListener("click", async () => {
+        // Selecting first means the fallback below has something to copy, and
+        // leaves the text visibly selected if even that is unavailable.
+        prompt.select();
+        try {
+          await navigator.clipboard.writeText(prompt.value);
+        } catch {
+          document.execCommand("copy");
+        }
+        button.textContent = "copied";
+        setTimeout(() => { button.textContent = label; }, 2000);
+      });
+    })();
+  </script>
 
   <h2>What changes</h2>
   <ul>


### PR DESCRIPTION
Follow-up to #178.

## Problem

`content/migration-2026.njk` hand-wrote its code blocks as `<pre><code class="language-python">` — the language class on the `<code>`, not the `<pre>`. Both stylesheets key off the `<pre>`:

- `public/prism-atom-dark.css`: `pre[class*="language-"]` → padding, `overflow: auto`, radius, font
- `public/main.css:660`: `.content pre[class*="language-"]` → `--code-bg`

So the blocks rendered as bare unstyled text, and nothing was tokenized. Every other code block on the site goes through the `highlight` filter or the `frameHighlight` shortcode (`.eleventy.js:262`), which emit `<pre class="language-py">`.

## Changes

- Both Python samples now use `{% frameHighlight "py" %}`, matching `catalog-pages.njk`. Output is `<pre class="language-py"><code class="language-py">` with Prism tokens.
- The agent prompt is a readonly `<textarea>` with a `copy to clipboard` link, instead of a `<pre>`. It is text you hand to a tool, not source we highlight — and it now selects and copies as one unit. Uses `navigator.clipboard` with an `execCommand` fallback; the field is selected first either way.
- The catalog-page sunset notice takes an amber left rule (`--pill-degraded-bg`, the same color the status page uses for a degraded service) rather than `--link-color`, which read as navigation. Its inline styles moved into the page's `<style>` block, and it needs no class — it is the only `<aside>` on the site.
- Dropped a stale "from the table below" reference left over from #178, where the table was removed.

## Verification

- `npm test`: 113 passed.
- `npm run build`: rendered output confirmed — `<pre class="language-py">` with Prism token spans on the guide, `<aside>` with no inline styles on all 10 affected catalog pages.

### 2026-08-06 — feedback

- Removed the "Finding the replacement dataset ID" section. The derivation rule and the `analysis-hourly` exception remain in the agent prompt, which is where they get acted on. The `dynamical-catalog` section's "as described below" now points at the catalog instead.
- Page is now: Recommended · Direct STAC and Icechunk · Have an agent do it · What changes · Help.
