### PR TITLE
Rework migration guide per review feedback

### DIFF
--- a/content/migration-2026.njk
+++ b/content/migration-2026.njk
@@ -39,43 +39,55 @@ permalink: /migration-2026/
 <div class="content">
   <h1 style="margin-top: 4rem; margin-bottom: 1rem;">Migrate from data.dynamical.org</h1>
 
-  <p>
-    <strong><code>data.dynamical.org</code> stops serving datasets after August 31, 2026.</strong>
-    The datasets remain public and continue updating; only this access route goes away.
-  </p>
+  <ul>
+    <li><strong><code>data.dynamical.org</code> is going away</strong> — plan on August 31, 2026. In practice we will turn URLs off dataset by dataset over the following months rather than all at once, so nothing breaks the morning of September 1.</li>
+    <li><strong>The replacement datasets are stored as Icechunk Zarr repositories.</strong> Both access patterns below read the Icechunk 2.0 version of a dataset, which makes Icechunk 2 a required dependency.</li>
+    <li><strong>Only how they are opened needs to change.</strong> The Icechunk versions are identical in structure, naming, attributes, chunking/sharding, and content — drop-in replacements for the deprecated Zarrs.</li>
+  </ul>
   <p>
     Replace each hard-coded <code>https://data.dynamical.org/.../latest.zarr</code>
-    URL with one of the supported access patterns below. Both resolve the current
-    repository from our <a href="https://stac.dynamical.org/catalog.json">STAC catalog</a>,
-    so your code does not need to track storage locations or version changes.
+    URL with one of the two supported ways to open a dataset. Both need Python 3.12
+    or newer, and both resolve the current repository from our
+    <a href="https://stac.dynamical.org/catalog.json">STAC catalog</a>, so your code
+    does not need to track storage locations or version changes.
   </p>
 
-  <h2>Recommended: dynamical-catalog</h2>
+  <h2>dynamical-catalog</h2>
   <p>
-    Use Python 3.12 or newer and install <code>dynamical-catalog&gt;=0.7.0</code>.
-    Pass the dataset ID from its <a href="/catalog/">catalog page</a>.
+    A thin STAC and Icechunk wrapper that ensures minimum dependency versions.
+    Install <code>dynamical-catalog&gt;=0.7.0</code> and pass the dataset ID from
+    its <a href="/catalog/">catalog page</a>.
   </p>
   {% frameHighlight "py" %}import dynamical_catalog
 
 ds = dynamical_catalog.open("noaa-gfs-forecast", chunks=None){% endframeHighlight %}
 
-  <h2>Direct STAC and Icechunk</h2>
+  <h2>STAC and Icechunk</h2>
   <p>
-    Resolve the <code>icechunk-https</code> asset from STAC each time your
-    application opens a repository. Do not copy and permanently hard-code the
-    asset URL.
+    Resolve the <code>icechunk-https</code> asset from the dataset's STAC Collection
+    each time your application opens a repository. Do not copy and permanently
+    hard-code the asset URL. Any HTTP client can read the Collection — the example
+    below uses <code>httpx</code>, and <code>pystac</code> works too, but neither
+    is required.
   </p>
-  {% frameHighlight "py" %}import icechunk
-import pystac
+  {% frameHighlight "py" %}import httpx
+import icechunk
 import xarray as xr
 
-catalog = pystac.Catalog.from_file("https://stac.dynamical.org/catalog.json")
-collection = catalog.get_child("noaa-gfs-forecast")
-asset = collection.assets["icechunk-https"]
+url = "https://stac.dynamical.org/noaa-gfs-forecast/collection.json"
+href = httpx.get(url).json()["assets"]["icechunk-https"]["href"]
 
-repo = icechunk.Repository.open(icechunk.http_storage(asset.href))
+repo = icechunk.Repository.open(icechunk.http_storage(href))
 session = repo.readonly_session("main")
-ds = xr.open_zarr(session.store, consolidated=False, chunks=None){% endframeHighlight %}
+ds = xr.open_zarr(session.store, chunks=None){% endframeHighlight %}
+  <p>
+    Python is not a requirement either. Icechunk publishes a
+    <a href="https://icechunk.io/en/latest/reference/icechunk-js/">JavaScript/TypeScript client</a>
+    (<code>@earthmover/icechunk</code>, paired with <code>zarrita</code>) and a
+    <a href="https://icechunk.io/en/latest/reference/icechunk-rust/">Rust crate</a>
+    (<code>icechunk</code>), both of which open the same <code>icechunk-https</code>
+    asset over plain HTTP.
+  </p>
 
   <h2>Have an agent do it</h2>
   <p>Paste this into a coding agent running in your repository.</p>
@@ -96,12 +108,14 @@ Rules:
 - Prefer dynamical_catalog.open("&lt;dataset-id&gt;"). It needs Python 3.12+ and
   dynamical-catalog&gt;=0.7.0.
 - If a new dependency is not an option, resolve the "icechunk-https" asset from
-  the dataset's STAC Collection at open time. Do not hard-code the asset href,
-  the S3 bucket, or a version number.
+  the dataset's STAC Collection at open time. Any HTTP client can read the
+  Collection; pystac is not required. Do not hard-code the asset href, the S3
+  bucket, or a version number.
 - Drop any ?email= query argument. It is no longer used.
-- Opened datasets are Icechunk 2 repositories read through xarray. Chunking and
-  variable names may differ from the legacy archive, so check any code that
-  assumes a specific chunk shape.
+- Opened datasets are Icechunk 2 repositories, so Icechunk 2 is a required
+  dependency. They are identical to the legacy archive in structure, naming,
+  attributes, chunking/sharding, and content — only the open call changes, so
+  leave the surrounding analysis code alone.
 
 Report every URL you could not map, and every place a dataset ID had to be
 chosen rather than derived.</textarea>
@@ -131,8 +145,9 @@ chosen rather than derived.</textarea>
   <ul>
     <li>Opening requires Icechunk 2 and Python 3.12 or newer.</li>
     <li>The public STAC Collection is the source of truth for the current repository.</li>
-    <li>Dataset IDs replace <code>data.dynamical.org</code> paths; dimensions and variable coverage are documented on each catalog page.</li>
+    <li>Dataset IDs replace <code>data.dynamical.org</code> paths.</li>
     <li>The optional <code>?email=</code> query argument is no longer used.</li>
+    <li>Nothing about the data itself. Variables, attributes, chunking, and values are unchanged.</li>
   </ul>
 
   <h2>Help</h2>


### PR DESCRIPTION
Applies [Alden's review](https://dynamical-org.slack.com/archives/C0BEKLYNU5P/p1786046054364039) of `/migration-2026/`.

## Framing

- [x] Restructure the top around the three-line frame: `data.dynamical.org` is going away → the replacements are Icechunk Zarrs → only how they are opened needs to change.
- [x] Present both access patterns as equally good. Dropped "Recommended:"; `dynamical-catalog` is now described as "a thin STAC and Icechunk wrapper that ensures minimum dependency versions."
- [x] State the drop-in compatibility promise up front: identical in structure, naming, attributes, chunking/sharding, and content.
- [x] Call out Icechunk 2 as a required dependency for both paths.

## Cuts

- [x] "The datasets remain public and continue updating" — no one accesses them another way.
- [x] "Chunking and variable names may differ from the legacy archive…" — contradicts the drop-in promise.
- [x] "; dimensions and variable coverage are documented on each catalog page" — implies checking is needed.
- [x] `consolidated=False` — no longer needed.
- [x] "read through xarray" from the agent notes — readable from any client.

## Other changes

- [x] pystac is not required; any HTTP client can read the STAC Collection. Fixed both in the page copy and in the agent prompt.
- [x] "Python 3.12 or newer" moved out of the `dynamical-catalog` section — it applies to both paths, since Icechunk 2 requires it.
- [x] Added a note on the Icechunk [JS/TS client](https://icechunk.io/en/latest/reference/icechunk-js/) (`@earthmover/icechunk`) and [Rust crate](https://icechunk.io/en/latest/reference/icechunk-rust/).
- [x] Kept **August 31, 2026** as the stated date, softened to rolling per-dataset turn-offs over the following months.

## Verification

Both examples were run against live data before shipping:

- `dynamical_catalog.open("noaa-gfs-forecast", chunks=None)` → 25 vars, `init_time: 7696, lead_time: 209, latitude: 721, longitude: 1440`
- stdlib `urllib` + `icechunk.http_storage` → same

`npm test` 113 pass, `npm run build` clean.

## Resolved: Cloudflare was 403ing stdlib `urllib`

The STAC example originally used `urllib.request.urlopen` and failed — `stac.dynamical.org` returned **403 / `error code: 1010`** to the default `Python-urllib/3.x` User-Agent. That code is Cloudflare's **Browser Integrity Check**, which was on zone-wide and hit every host (`stac`, `api`, `mcp`, `data`, and the apex).

BIC has since been turned off for `stac.dynamical.org`, `api.dynamical.org`, and `data.dynamical.org`, so the example is back to dependency-free stdlib — which is the cleanest statement of "any HTTP client works."

Still on BIC, tracked separately from this PR:

- `dynamical.org` (apex) — including `/llms.txt`, `/llms-full.txt`, and `/feed/feed.xml`. Note the agent prompt on this very page tells agents to read `https://dynamical.org/llms.txt` first, so a stdlib-based agent 403s on step one.
- `mcp.dynamical.org`
