### PR TITLE
Replace the pipeline status frontend with the granular wxopticon schema

### DIFF
--- a/_data/pipelineAssetsBase.js
+++ b/_data/pipelineAssetsBase.js
@@ -1,3 +1,5 @@
 module.exports =
   process.env.PIPELINE_ASSETS_BASE ||
-  "https://assets.dynamical.org/wxopticon";
+  (process.env.CF_PAGES_BRANCH && process.env.CF_PAGES_BRANCH !== "main"
+    ? "/pipeline-staging/wxopticon"
+    : "https://assets.dynamical.org/wxopticon");

--- a/content/status-pipeline.njk
+++ b/content/status-pipeline.njk
@@ -30,17 +30,18 @@ pageStylesheet: /pipeline.css
   </div>
   <div data-slot="banners" aria-live="polite"></div>
 
-  <div class="pipeline-legend" aria-label="Pipeline bar legend">
+  <div class="pipeline-legend" aria-label="Pipeline legend">
     <span>
       <span class="pipeline-legend-mark pipeline-legend-mark--pending"
         aria-hidden="true"></span>
-      forecast hours still expected
+      still expected
     </span>
     <span>
       <span class="pipeline-legend-mark pipeline-legend-mark--unobserved"
         aria-hidden="true"></span>
       no monitoring data
     </span>
+    <span>one square per run · hover a square for what it measured</span>
   </div>
 
   <div id="pipeline-history-panel" hidden>

--- a/content/status-pipeline.njk
+++ b/content/status-pipeline.njk
@@ -32,6 +32,11 @@ pageStylesheet: /pipeline.css
 
   <div class="pipeline-legend" aria-label="Pipeline legend">
     <span>
+      <span class="pipeline-legend-mark pipeline-legend-mark--partial"
+        aria-hidden="true"></span>
+      part arrived
+    </span>
+    <span>
       <span class="pipeline-legend-mark pipeline-legend-mark--pending"
         aria-hidden="true"></span>
       still expected

--- a/content/status-pipeline.njk
+++ b/content/status-pipeline.njk
@@ -46,7 +46,7 @@ pageStylesheet: /pipeline.css
         aria-hidden="true"></span>
       no monitoring data
     </span>
-    <span>one square per run · hover a square for what it measured</span>
+    <span>one square per measurement · hover a square for what it measured</span>
   </div>
 
   <div id="pipeline-history-panel" hidden>

--- a/functions/package.json
+++ b/functions/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/functions/pipeline-staging/[[path]].js
+++ b/functions/pipeline-staging/[[path]].js
@@ -1,0 +1,31 @@
+const DASHBOARD_KEY = "wxopticon/dashboard.json";
+const HISTORY_INDEX_KEY = "wxopticon/history/index.json";
+const HISTORY_SNAPSHOT_KEY =
+  /^wxopticon\/history\/\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}Z\.json$/;
+
+function isAllowed(key) {
+  return (
+    key === DASHBOARD_KEY ||
+    key === HISTORY_INDEX_KEY ||
+    HISTORY_SNAPSHOT_KEY.test(key)
+  );
+}
+
+export async function onRequestGet(context) {
+  const key = (context.params.path ?? []).join("/");
+  if (!isAllowed(key)) return new Response("Not found", { status: 404 });
+  if (!context.env.WXOPTICON_STAGING) {
+    return new Response("Staging data unavailable", { status: 503 });
+  }
+
+  const object = await context.env.WXOPTICON_STAGING.get(key);
+  if (!object) return new Response("Not found", { status: 404 });
+
+  const headers = new Headers({
+    "cache-control": "public, max-age=15",
+    "content-type": "application/json; charset=utf-8",
+    "x-content-type-options": "nosniff",
+  });
+  if (object.httpEtag) headers.set("etag", object.httpEtag);
+  return new Response(object.body, { headers });
+}

--- a/public/pipeline.css
+++ b/public/pipeline.css
@@ -155,8 +155,7 @@
   min-width: 0;
 }
 
-.pipeline-band,
-.pipeline-axis {
+.pipeline-band {
   display: grid;
   grid-template-columns: var(--band-gutter) minmax(0, max-content);
   align-items: center;
@@ -282,13 +281,6 @@
 
 .pipeline-run-label {
   color: var(--muted-text);
-}
-
-.pipeline-axis {
-  margin-top: 0.4rem;
-  color: var(--muted-text-2);
-  font-size: 1rem;
-  white-space: nowrap;
 }
 
 .pipeline-stats {

--- a/public/pipeline.css
+++ b/public/pipeline.css
@@ -154,7 +154,7 @@
 /* names a facet dimension once, where its bands start */
 .pipeline-dimension {
   margin: 0.6rem 0 0.1rem;
-  padding-left: 14.6rem;
+  padding-left: calc(var(--band-gutter, 14rem) + 0.6rem);
   color: var(--muted-text-2);
   font-size: 1rem;
   letter-spacing: 0.06em;
@@ -174,11 +174,13 @@
 
 .pipeline-clump {
   display: flex;
+  flex: none;
   gap: var(--clump-gap, 1px);
 }
 
 .pipeline-cell {
   position: relative;
+  flex: none;
   width: var(--sq, 8px);
   height: var(--sq, 8px);
   border: 1px solid var(--text-color);
@@ -218,6 +220,55 @@
 .pipeline-cell.g-pending .pipeline-cell-fill,
 .pipeline-cell.g-unobserved .pipeline-cell-fill {
   display: none;
+}
+
+/* The facet-row field: a run per block, lead groups as columns inside it */
+
+.pipeline-column-label {
+  flex: none;
+  width: var(--sq);
+  color: var(--text-color);
+  font-size: 0.9rem;
+  line-height: 1;
+  text-align: center;
+}
+
+.pipeline-band--head {
+  margin-bottom: 0.2rem;
+}
+
+.pipeline-band--foot {
+  margin-top: 0.3rem;
+}
+
+/* one per run block, exactly as wide as the block it names */
+.pipeline-run-label,
+.pipeline-run-date {
+  /* never shrink, or a label drifts out from under the blocks it names */
+  flex: none;
+  /* exactly one run block wide, so both tiers centre on the same axis */
+  width: calc(
+    var(--sq) * var(--leads, 3) + var(--clump-gap) * (var(--leads, 3) - 1)
+  );
+  font-size: 0.9rem;
+  line-height: 1.2;
+  text-align: center;
+}
+
+.pipeline-run-label {
+  color: var(--muted-text);
+}
+
+.pipeline-run-date {
+  color: var(--text-color);
+}
+
+.pipeline-band--dates {
+  margin-top: 0.1rem;
+}
+
+.pipeline-field--facets .pipeline-band-label {
+  color: var(--muted-text);
 }
 
 .pipeline-axis {
@@ -312,16 +363,5 @@ body:not(.pipeline-time-local) .pipeline-time-local-only {
 
   .pipeline-stats {
     text-align: left;
-  }
-}
-
-@media (max-width: 680px) {
-  .pipeline-band,
-  .pipeline-axis {
-    grid-template-columns: 8rem minmax(0, max-content);
-  }
-
-  .pipeline-dimension {
-    padding-left: 8.6rem;
   }
 }

--- a/public/pipeline.css
+++ b/public/pipeline.css
@@ -120,11 +120,36 @@
   min-width: 0;
 }
 
-/* The field: a band per measurement, a square per run, time to the right. */
+/* The field: a band per measurement, a square per run, time to the right.
+   Clicking it cycles which dimension owns the rows. */
+
+.pipeline-viz {
+  flex: 1;
+  min-width: 0;
+}
+
+.pipeline-viz[role="button"] {
+  cursor: pointer;
+}
+
+.pipeline-viz:focus-visible {
+  outline: 2px solid var(--link-color);
+  outline-offset: 3px;
+}
+
+.pipeline-view-hint {
+  margin-top: 0.4rem;
+  padding-left: calc(var(--band-gutter) + 0.6rem);
+  color: var(--muted-text-2);
+  font-size: 1rem;
+}
+
+.pipeline-viz:hover .pipeline-view-hint {
+  color: var(--link-color);
+}
 
 .pipeline-field {
   display: flex;
-  flex: 1;
   flex-direction: column;
   gap: 2px;
   min-width: 0;
@@ -182,8 +207,10 @@
 .pipeline-cell {
   position: relative;
   flex: none;
-  width: var(--sq);
-  height: var(--sq);
+  /* the lead dimension is proportional, so whichever axis it owns is set
+     per cell; the other axis stays one cell */
+  width: var(--cell-w, var(--sq));
+  height: var(--cell-h, var(--sq));
   border: 1px solid var(--text-color);
 }
 
@@ -227,7 +254,7 @@
 
 .pipeline-column-label {
   flex: none;
-  width: var(--sq);
+  width: var(--cell-w, var(--sq));
   font-size: 0.9rem;
   line-height: 1;
   text-align: center;

--- a/public/pipeline.css
+++ b/public/pipeline.css
@@ -299,6 +299,16 @@
   text-align: left;
 }
 
+.pipeline-facets {
+  margin-top: 1.2rem;
+}
+
+.pipeline-facets progress {
+  width: 8rem;
+  accent-color: var(--pipeline-ok);
+  vertical-align: middle;
+}
+
 .pipeline-time-local .pipeline-time-utc,
 body:not(.pipeline-time-local) .pipeline-time-local-only {
   display: none;

--- a/public/pipeline.css
+++ b/public/pipeline.css
@@ -130,9 +130,10 @@
   min-width: 0;
 }
 
-.pipeline-band {
+.pipeline-band,
+.pipeline-axis {
   display: grid;
-  grid-template-columns: var(--band-gutter, 14rem) minmax(0, max-content);
+  grid-template-columns: var(--band-gutter) minmax(0, max-content);
   align-items: center;
   gap: 0 0.6rem;
 }
@@ -154,7 +155,7 @@
 /* names a facet dimension once, where its bands start */
 .pipeline-dimension {
   margin: 0.6rem 0 0.1rem;
-  padding-left: calc(var(--band-gutter, 14rem) + 0.6rem);
+  padding-left: calc(var(--band-gutter) + 0.6rem);
   color: var(--muted-text-2);
   font-size: 1rem;
   letter-spacing: 0.06em;
@@ -163,26 +164,26 @@
 
 .pipeline-cells {
   display: flex;
-  gap: var(--run-gap, 2px);
+  gap: var(--run-gap);
 }
 
 /* a clumped band needs daylight between runs, since the squares within one run
    sit a single pixel apart */
 .pipeline-cells[data-clumped] {
-  gap: var(--clumped-run-gap, 6px);
+  gap: var(--clumped-run-gap);
 }
 
 .pipeline-clump {
   display: flex;
   flex: none;
-  gap: var(--clump-gap, 1px);
+  gap: var(--clump-gap);
 }
 
 .pipeline-cell {
   position: relative;
   flex: none;
-  width: var(--sq, 8px);
-  height: var(--sq, 8px);
+  width: var(--sq);
+  height: var(--sq);
   border: 1px solid var(--text-color);
 }
 
@@ -227,7 +228,6 @@
 .pipeline-column-label {
   flex: none;
   width: var(--sq);
-  color: var(--text-color);
   font-size: 0.9rem;
   line-height: 1;
   text-align: center;
@@ -247,9 +247,7 @@
   /* never shrink, or a label drifts out from under the blocks it names */
   flex: none;
   /* exactly one run block wide, so both tiers centre on the same axis */
-  width: calc(
-    var(--sq) * var(--leads, 3) + var(--clump-gap) * (var(--leads, 3) - 1)
-  );
+  width: var(--run-width);
   font-size: 0.9rem;
   line-height: 1.2;
   text-align: center;
@@ -259,22 +257,7 @@
   color: var(--muted-text);
 }
 
-.pipeline-run-date {
-  color: var(--text-color);
-}
-
-.pipeline-band--dates {
-  margin-top: 0.1rem;
-}
-
-.pipeline-field--facets .pipeline-band-label {
-  color: var(--muted-text);
-}
-
 .pipeline-axis {
-  display: grid;
-  grid-template-columns: var(--band-gutter, 14rem) minmax(0, max-content);
-  gap: 0 0.6rem;
   margin-top: 0.4rem;
   color: var(--muted-text-2);
   font-size: 1rem;

--- a/public/pipeline.css
+++ b/public/pipeline.css
@@ -27,16 +27,25 @@
 }
 
 .pipeline-legend-mark--pending {
-  border: 1px dotted var(--pipeline-unobserved);
+  border: 1px solid var(--pipeline-unobserved);
+}
+
+.pipeline-legend-mark--partial {
+  border: 1px solid var(--text-color);
   background: linear-gradient(
     to right,
-    var(--pipeline-ok) 0 50%,
-    transparent 50%
+    var(--pipeline-progress) 0 55%,
+    transparent 55%
   );
 }
 
 .pipeline-legend-mark--unobserved {
   border: 1px dotted var(--pipeline-unobserved);
+  background: repeating-linear-gradient(
+    135deg,
+    var(--pipeline-unobserved) 0 1px,
+    transparent 1px 4px
+  );
 }
 
 .pipeline-ribbon:not([hidden]),
@@ -140,8 +149,40 @@
 .pipeline-field {
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  gap: var(--band-gap);
+  /* every view reserves the tallest view's height, so cycling does not shift
+     the page under the reader; a view that cannot fill it sits centred */
+  justify-content: center;
+  min-height: var(--reserve, auto);
   min-width: 0;
+}
+
+/* The facet rows share out whatever height the reserved box leaves them, so a
+   view with two rows draws as much ink as one with six — capped at three cells
+   so a sparse product does not draw absurdly tall rows. */
+
+.pipeline-rows {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  gap: var(--band-gap);
+  justify-content: center;
+  min-height: 0;
+}
+
+.pipeline-rows > .pipeline-band {
+  flex: 1;
+  max-height: calc(3 * var(--sq));
+}
+
+.pipeline-rows .pipeline-cells,
+.pipeline-rows .pipeline-clump {
+  align-self: stretch;
+  height: 100%;
+}
+
+.pipeline-rows .pipeline-cell {
+  height: auto;
 }
 
 .pipeline-band {
@@ -241,9 +282,20 @@
   width: 100%;
 }
 
-.pipeline-cell.g-pending,
+/* an empty outline is "expected, nothing yet"; hatching is "no evidence either
+   way" — the two must not read the same, since one is a measurement and the
+   other is the absence of one */
+.pipeline-cell.g-pending {
+  border: 1px solid var(--pipeline-unobserved);
+}
+
 .pipeline-cell.g-unobserved {
   border: 1px dotted var(--pipeline-unobserved);
+  background: repeating-linear-gradient(
+    135deg,
+    var(--pipeline-unobserved) 0 1px,
+    transparent 1px 4px
+  );
 }
 
 .pipeline-cell.g-pending .pipeline-cell-fill,
@@ -256,8 +308,9 @@
 .pipeline-column-label {
   flex: none;
   width: var(--cell-w, var(--sq));
+  height: var(--label-h);
   font-size: 0.9rem;
-  line-height: 1;
+  line-height: var(--label-h);
   text-align: center;
 }
 
@@ -276,8 +329,9 @@
   flex: none;
   /* exactly one run block wide, so both tiers centre on the same axis */
   width: var(--run-width);
+  height: var(--label-h);
   font-size: 0.9rem;
-  line-height: 1.2;
+  line-height: var(--label-h);
   text-align: center;
 }
 
@@ -349,10 +403,30 @@
   margin-top: 1.2rem;
 }
 
+/* the bar takes the row's leftover width, and the number beside it is always
+   three characters wide, so every bar starts and ends in the same place */
+.pipeline-facets td:last-child {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  width: 100%;
+}
+
 .pipeline-facets progress {
-  width: 8rem;
+  flex: 1;
   accent-color: var(--pipeline-ok);
   vertical-align: middle;
+}
+
+.pipeline-facet-pct {
+  flex: none;
+  font-variant-numeric: tabular-nums;
+}
+
+.pipeline-facet-num {
+  display: inline-block;
+  width: 3ch;
+  text-align: right;
 }
 
 .pipeline-time-local .pipeline-time-utc,

--- a/public/pipeline.css
+++ b/public/pipeline.css
@@ -137,17 +137,6 @@
   outline-offset: 3px;
 }
 
-.pipeline-view-hint {
-  margin-top: 0.4rem;
-  padding-left: calc(var(--band-gutter) + 0.6rem);
-  color: var(--muted-text-2);
-  font-size: 1rem;
-}
-
-.pipeline-viz:hover .pipeline-view-hint {
-  color: var(--link-color);
-}
-
 .pipeline-field {
   display: flex;
   flex-direction: column;

--- a/public/pipeline.css
+++ b/public/pipeline.css
@@ -210,6 +210,15 @@
   height: var(--fill, 0%);
 }
 
+/* where lead time owns the horizontal axis, a cell fills from its left edge
+   rather than its floor, so progress reads along the same axis as the leads */
+.pipeline-field[data-fill="side"] .pipeline-cell-fill {
+  top: 0;
+  right: auto;
+  width: var(--fill, 0%);
+  height: auto;
+}
+
 .pipeline-cell.g-complete .pipeline-cell-fill {
   background: var(--pipeline-ok);
 }
@@ -226,6 +235,10 @@
 .pipeline-cell.g-failed .pipeline-cell-fill {
   height: 100%;
   background: var(--pipeline-failed);
+}
+
+.pipeline-field[data-fill="side"] .pipeline-cell.g-failed .pipeline-cell-fill {
+  width: 100%;
 }
 
 .pipeline-cell.g-pending,

--- a/public/pipeline.css
+++ b/public/pipeline.css
@@ -132,7 +132,7 @@
 
 .pipeline-band {
   display: grid;
-  grid-template-columns: 14rem minmax(0, max-content);
+  grid-template-columns: var(--band-gutter, 14rem) minmax(0, max-content);
   align-items: center;
   gap: 0 0.6rem;
 }
@@ -163,24 +163,24 @@
 
 .pipeline-cells {
   display: flex;
-  gap: 2px;
+  gap: var(--run-gap, 2px);
 }
 
 /* a clumped band needs daylight between runs, since the squares within one run
    sit a single pixel apart */
 .pipeline-cells[data-clumped] {
-  gap: 6px;
+  gap: var(--clumped-run-gap, 6px);
 }
 
 .pipeline-clump {
   display: flex;
-  gap: 1px;
+  gap: var(--clump-gap, 1px);
 }
 
 .pipeline-cell {
   position: relative;
-  width: 8px;
-  height: 8px;
+  width: var(--sq, 8px);
+  height: var(--sq, 8px);
   border: 1px solid var(--text-color);
 }
 
@@ -222,7 +222,7 @@
 
 .pipeline-axis {
   display: grid;
-  grid-template-columns: 14rem minmax(0, max-content);
+  grid-template-columns: var(--band-gutter, 14rem) minmax(0, max-content);
   gap: 0 0.6rem;
   margin-top: 0.4rem;
   color: var(--muted-text-2);

--- a/public/pipeline.css
+++ b/public/pipeline.css
@@ -166,6 +166,17 @@
   gap: 2px;
 }
 
+/* a clumped band needs daylight between runs, since the squares within one run
+   sit a single pixel apart */
+.pipeline-cells[data-clumped] {
+  gap: 6px;
+}
+
+.pipeline-clump {
+  display: flex;
+  gap: 1px;
+}
+
 .pipeline-cell {
   position: relative;
   width: 8px;

--- a/public/pipeline.css
+++ b/public/pipeline.css
@@ -137,7 +137,7 @@
   min-width: 0;
 }
 
-.pipeline-viz[role="button"] {
+.pipeline-viz[role="group"] {
   cursor: pointer;
 }
 
@@ -204,16 +204,6 @@
 
 .pipeline-band[data-kind="lead"] .pipeline-band-label {
   color: var(--text-color);
-}
-
-/* names a facet dimension once, where its bands start */
-.pipeline-dimension {
-  margin: 0.6rem 0 0.1rem;
-  padding-left: calc(var(--band-gutter) + 0.6rem);
-  color: var(--muted-text-2);
-  font-size: 1rem;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
 }
 
 .pipeline-cells {

--- a/public/pipeline.css
+++ b/public/pipeline.css
@@ -120,123 +120,103 @@
   min-width: 0;
 }
 
-.pipeline-lead-labels {
-  position: relative;
-  flex: none;
-  width: 2.6rem;
-  height: 13rem;
-  color: var(--muted-text);
-  font-size: 1rem;
-  line-height: 1;
-}
+/* The field: a band per measurement, a square per run, time to the right. */
 
-.pipeline-lead-labels span {
-  position: absolute;
-  right: 0;
-  transform: translateY(50%);
-  white-space: nowrap;
-}
-
-.pipeline-grid {
-  display: grid;
-  grid-template-columns: repeat(10, minmax(0, 1fr));
+.pipeline-field {
+  display: flex;
   flex: 1;
-  gap: 0.6rem;
+  flex-direction: column;
+  gap: 2px;
   min-width: 0;
 }
 
-.pipeline-bar {
-  display: flex;
-  flex-direction: column;
+.pipeline-band {
+  display: grid;
+  grid-template-columns: 14rem minmax(0, max-content);
   align-items: center;
-  gap: 0.4rem;
+  gap: 0 0.6rem;
 }
 
-.pipeline-bar-track {
-  position: relative;
-  width: 100%;
-  height: 13rem;
+.pipeline-band-label {
   overflow: hidden;
+  color: var(--muted-text);
+  font-size: 1rem;
+  line-height: 1;
+  text-align: right;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.pipeline-band[data-kind="lead"] .pipeline-band-label {
+  color: var(--text-color);
+}
+
+/* names a facet dimension once, where its bands start */
+.pipeline-dimension {
+  margin: 0.6rem 0 0.1rem;
+  padding-left: 14.6rem;
+  color: var(--muted-text-2);
+  font-size: 1rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.pipeline-cells {
+  display: flex;
+  gap: 2px;
+}
+
+.pipeline-cell {
+  position: relative;
+  width: 8px;
+  height: 8px;
   border: 1px solid var(--text-color);
 }
 
-.pipeline-bar-fill,
-.pipeline-bar-segment,
-.pipeline-bar-segment-fill {
+.pipeline-cell-fill {
   position: absolute;
   right: 0;
   bottom: 0;
   left: 0;
-}
-
-.pipeline-bar-fill {
   height: var(--fill, 0%);
 }
 
-.pipeline-bar-segment {
-  bottom: var(--band-bottom, 0%);
-  height: var(--band-height, 0%);
-}
-
-.pipeline-bar-segment
-  + .pipeline-bar-segment:not(:last-child, .g-pending, .g-unobserved) {
-  border-top: 1px solid var(--text-color);
-}
-
-.pipeline-bar-segment-fill {
-  height: var(--fill, 0%);
-}
-
-.pipeline-bar[data-status="complete"] .pipeline-bar-fill,
-.pipeline-bar-segment.g-complete .pipeline-bar-segment-fill {
+.pipeline-cell.g-complete .pipeline-cell-fill {
   background: var(--pipeline-ok);
 }
 
-.pipeline-bar[data-status="complete"][data-timing="delayed"] .pipeline-bar-fill,
-.pipeline-bar[data-status="in_flight"] .pipeline-bar-fill,
-.pipeline-bar-segment.g-complete[data-timing="delayed"] .pipeline-bar-segment-fill,
-.pipeline-bar-segment.g-in_flight .pipeline-bar-segment-fill {
+.pipeline-cell.g-complete[data-timing="delayed"] .pipeline-cell-fill,
+.pipeline-cell.g-in_flight .pipeline-cell-fill {
   background: var(--pipeline-progress);
 }
 
-.pipeline-bar[data-status="in_flight"][data-timing="on_time"] .pipeline-bar-fill,
-.pipeline-bar-segment.g-in_flight[data-timing="on_time"] .pipeline-bar-segment-fill {
+.pipeline-cell.g-in_flight[data-timing="on_time"] .pipeline-cell-fill {
   background: var(--pipeline-ok);
 }
 
-.pipeline-bar[data-status="failed"] .pipeline-bar-fill,
-.pipeline-bar-segment.g-failed .pipeline-bar-segment-fill {
+.pipeline-cell.g-failed .pipeline-cell-fill {
   height: 100%;
   background: var(--pipeline-failed);
 }
 
-.pipeline-bar-segment.g-pending,
-.pipeline-bar-segment.g-unobserved {
+.pipeline-cell.g-pending,
+.pipeline-cell.g-unobserved {
   border: 1px dotted var(--pipeline-unobserved);
 }
 
-.pipeline-bar[data-status="unobserved"] .pipeline-bar-track {
-  border: 1px dotted var(--pipeline-unobserved);
-}
-
-.pipeline-bar[data-status="unobserved"] .pipeline-bar-fill,
-.pipeline-bar[data-status="unobserved"] .pipeline-bar-segment,
-.pipeline-bar-segment.g-pending .pipeline-bar-segment-fill,
-.pipeline-bar-segment.g-unobserved .pipeline-bar-segment-fill {
+.pipeline-cell.g-pending .pipeline-cell-fill,
+.pipeline-cell.g-unobserved .pipeline-cell-fill {
   display: none;
 }
 
-.pipeline-bar-label {
-  min-height: 2.4em;
-  color: var(--muted-text);
+.pipeline-axis {
+  display: grid;
+  grid-template-columns: 14rem minmax(0, max-content);
+  gap: 0 0.6rem;
+  margin-top: 0.4rem;
+  color: var(--muted-text-2);
   font-size: 1rem;
-  line-height: 1.2;
-  text-align: center;
-}
-
-.pipeline-bar-label strong {
-  display: block;
-  color: var(--text-color);
+  white-space: nowrap;
 }
 
 .pipeline-stats {
@@ -325,11 +305,12 @@ body:not(.pipeline-time-local) .pipeline-time-local-only {
 }
 
 @media (max-width: 680px) {
-  .pipeline-grid {
-    gap: 0.3rem;
+  .pipeline-band,
+  .pipeline-axis {
+    grid-template-columns: 8rem minmax(0, max-content);
   }
 
-  .pipeline-bar-label {
-    font-size: 0.8rem;
+  .pipeline-dimension {
+    padding-left: 8.6rem;
   }
 }

--- a/public/pipeline.mjs
+++ b/public/pipeline.mjs
@@ -703,6 +703,8 @@ function renderFacetRows(product, local, runCount, dimension) {
     (leads.length - 1) * CLUMP_GAP_PX;
   const field = element("div", {
     class: "pipeline-field",
+    // lead time runs across here, so progress fills across too
+    "data-fill": "side",
     style: `--sq:${CELL_PX}px;--clump-gap:${CLUMP_GAP_PX}px;--clumped-run-gap:${CLUMPED_RUN_GAP_PX}px;--band-gutter:${gutterPx(facets)}px;--run-width:${runWidth}px`,
   });
 

--- a/public/pipeline.mjs
+++ b/public/pipeline.mjs
@@ -1065,21 +1065,16 @@ function hydrateRow(row, product, now, local, available) {
 
   const viz = row.querySelector('[data-slot="field"]');
   viz.replaceChildren(field);
-  // only worth announcing when there is somewhere to click to
+  // the cycle is only reachable, and only worth announcing, when a product has
+  // more than the one view
   if (views.length > 1) {
     const next = views[(index + 1) % views.length];
-    field.append(
-      element(
-        "div",
-        { class: "pipeline-view-hint" },
-        view.dimension
-          ? `rows: ${view.rows} · columns: lead time · click for ${next.rows}`
-          : `rows: lead time · columns: init · click for ${next.rows}`,
-      ),
-    );
     viz.setAttribute("role", "button");
     viz.setAttribute("tabindex", "0");
-    viz.setAttribute("aria-label", `${view.rows} by lead group; activate for ${next.rows}`);
+    viz.setAttribute(
+      "aria-label",
+      `${view.rows} by ${view.dimension ? "lead group" : "init"}; activate for ${next.rows}`,
+    );
   } else {
     viz.removeAttribute("role");
     viz.removeAttribute("tabindex");

--- a/public/pipeline.mjs
+++ b/public/pipeline.mjs
@@ -10,8 +10,14 @@ const HEALTH_REFRESH_INTERVAL_MS = 5 * 60 * 1000;
 const STALE_AFTER_MS = 10 * 60 * 1000;
 const FETCH_TIMEOUT_MS = 10_000;
 const DASHBOARD_VERSIONS = new Set([1, 2]);
-// the payload carries ten runs; the field shows the most recent few
-const RUNS_SHOWN = 4;
+// Field geometry. JS owns these because the run count is computed from them;
+// the CSS reads them back off the field as custom properties.
+const SQUARE_PX = 8;
+const CLUMP_GAP_PX = 1; // between facet squares within one run
+const RUN_GAP_PX = 2; // between runs of a single square
+const CLUMPED_RUN_GAP_PX = 6; // between runs of a clump, which needs daylight
+const BAND_GUTTER_PX = 140; // the lead/facet label column
+const RUNS_MAX = 10; // what the payload carries
 
 function hasTimestamp(value) {
   return (
@@ -329,6 +335,30 @@ export function facetsAt(product, init, leadName) {
     .filter(Boolean);
 }
 
+/* How many runs fit. A run is one square when there is no joint and a clump of
+   facet squares when there is, so the answer depends on the product, not just
+   the viewport. Falls back to everything the payload carries when the width is
+   not measurable yet. */
+
+export function runsThatFit(product, availablePx) {
+  const clumped = hasJointFacets(product);
+  const widest = clumped
+    ? Math.max(
+        1,
+        ...(product.recent_inits ?? []).flatMap((init) =>
+          bandsOf(product).map(
+            (band) => facetsAt(product, init, band.key).length,
+          ),
+        ),
+      )
+    : 1;
+  const runWidth = widest * SQUARE_PX + (widest - 1) * CLUMP_GAP_PX;
+  const gap = clumped ? CLUMPED_RUN_GAP_PX : RUN_GAP_PX;
+  const usable = availablePx - BAND_GUTTER_PX - 6; // 0.6rem band gap
+  if (!Number.isFinite(usable) || usable <= 0) return RUNS_MAX;
+  return Math.max(1, Math.min(RUNS_MAX, Math.floor((usable + gap) / (runWidth + gap))));
+}
+
 /* What one run measured for one band. A band the run never reported reads as
    unobserved rather than as a failure. */
 
@@ -406,9 +436,12 @@ function renderCell(band, init, local, measured) {
   );
 }
 
-function renderField(product, local) {
-  const runs = product.recent_inits.slice(-RUNS_SHOWN);
-  const field = element("div", { class: "pipeline-field" });
+function renderField(product, local, runCount) {
+  const runs = product.recent_inits.slice(-Math.max(1, runCount || RUNS_MAX));
+  const field = element("div", {
+    class: "pipeline-field",
+    style: `--sq:${SQUARE_PX}px;--clump-gap:${CLUMP_GAP_PX}px;--run-gap:${RUN_GAP_PX}px;--clumped-run-gap:${CLUMPED_RUN_GAP_PX}px;--band-gutter:${BAND_GUTTER_PX}px`,
+  });
   let dimension = null;
 
   for (const band of bandsOf(product)) {
@@ -725,9 +758,13 @@ function buildDetails(product, now, local) {
 }
 
 function hydrateRow(row, product, now, local) {
+  // the row body is a 1fr grid column, so its width is independent of the
+  // field it holds — measuring it cannot feed back into the fit
+  const body = row.querySelector(".pipeline-row-body");
+  const available = body?.getBoundingClientRect().width ?? 0;
   row
     .querySelector('[data-slot="field"]')
-    .replaceChildren(renderField(product, local));
+    .replaceChildren(renderField(product, local, runsThatFit(product, available)));
   hydrateEta(row, product, now, local);
 
   const button = row.querySelector('[data-slot="details-button"]');
@@ -866,6 +903,15 @@ function start(app) {
     displayedAt = now;
     renderSnapshot(app, snapshot, rows, now);
   }
+
+  // the run count comes from the measured row, so a resize has to re-fit
+  let refitTimer = null;
+  window.addEventListener("resize", () => {
+    clearTimeout(refitTimer);
+    refitTimer = setTimeout(() => {
+      if (displayedSnapshot) displaySnapshot(displayedSnapshot, Date.now());
+    }, 150);
+  });
 
   function setTimeMode(local) {
     document.body.classList.toggle("pipeline-time-local", local);

--- a/public/pipeline.mjs
+++ b/public/pipeline.mjs
@@ -22,6 +22,7 @@ const MIN_LEAD_PX = 12;
 const BAND_GAP_PX = 2; // between bands, inside a field
 const LABEL_PX = 12; // one axis-label row
 const FOOT_GAP_PX = 3; // the breath above the init tiers
+const HEAD_GAP_PX = 2; // the head band's margin under the lead labels
 const CH_PX = 6; // one monospace character at the band-label size
 const GUTTER_MAX_CH = 24; // long facet labels get room, but not unbounded
 const RUNS_MAX = 10; // what the payload carries
@@ -307,29 +308,22 @@ function leadSlices(groups) {
   });
 }
 
-/* True once a payload reports facets per lead group. An empty array is a
-   validated, supported input — a run that reported nothing yet — so it does not
-   count as a joint. Until a real one arrives the two published marginals are all
-   there is, and facets get their own bands. */
-
-export function hasJointFacets(product) {
-  return (product.recent_inits ?? []).some((init) =>
-    (init.lead_groups ?? []).some((group) => group.facets?.length),
-  );
-}
-
 /* The lead groups a product measures, shortest horizon first — the order the
    payload declares them in. History snapshots declare neither list up front,
    so both fall back to the newest run's own. */
 
 export function leadAxis(product) {
-  const newest = product.recent_inits?.at(-1);
   const labelOf = new Map(
     (product.lead_group_stats ?? []).map((stats) => [stats.name, stats.label]),
   );
+  // a snapshot's newest run can be unobserved and carry no groups at all, while
+  // the runs beside it carry full data — so take the newest that reported any
+  const reported = [...(product.recent_inits ?? [])]
+    .reverse()
+    .find((init) => init.lead_groups?.length);
   const declared = product.lead_groups?.length
     ? product.lead_groups
-    : (newest?.lead_groups ?? []);
+    : (reported?.lead_groups ?? []);
   return declared.map((group) => ({
     kind: "lead",
     key: group.name,
@@ -369,7 +363,7 @@ export function leadExtents(product) {
    measurement — which matters because the render pass writes without reading. */
 
 function chromePx(view, rows) {
-  const head = view.dimension ? LABEL_PX + BAND_GAP_PX : 0;
+  const head = view.dimension ? LABEL_PX + BAND_GAP_PX + HEAD_GAP_PX : 0;
   const tiers = FOOT_GAP_PX + 2 * (LABEL_PX + BAND_GAP_PX);
   return head + tiers + BAND_GAP_PX * Math.max(0, rows - 1);
 }
@@ -407,18 +401,19 @@ export function bandsOf(product) {
 /* The facets of one lead group in one run, in the product's declared order.
    Empty when the payload reports no joint for that group. */
 
-export function facetsAt(product, init, leadName) {
+export function facetsAt(product, init, leadName, order) {
   const group = (init?.lead_groups ?? []).find(
     (entry) => entry.name === leadName,
   );
   if (!Array.isArray(group?.facets)) return [];
-  const order = (product.facet_groups ?? []).map((facet) => facet.name);
   const measured = new Map(group.facets.map((facet) => [facet.name, facet]));
-  const ordered = order.length ? order : group.facets.map((f) => f.name);
+  // the rows come from facetRowsOf, so the cells must use that same order —
+  // ordering by facet_groups alone would leave a measured-but-undeclared facet
+  // with a row and no squares, reading as "no monitoring data" for data that
+  // did arrive
+  const names = order ?? facetRowsOf(product).map((facet) => facet.name);
   // a facet absent at this lead simply has no square
-  return ordered
-    .map((name) => measured.get(name))
-    .filter(Boolean);
+  return names.map((name) => measured.get(name)).filter(Boolean);
 }
 
 /* The label gutter is only as wide as the labels beside it. Lead-only rows read
@@ -427,12 +422,17 @@ export function facetsAt(product, init, leadName) {
    ch: CSS resolves ch against the band's inherited font, which is not the
    font these labels are set in. */
 
-/* An init column is as wide as the label beneath it: "08-12" in UTC, and the
-   zone abbreviation makes local mode wider. Main sized its bars the same way,
-   which is what lets every column carry its own timestamp. */
+/* An init column is as wide as the label beneath it. Measured from the labels
+   this product actually formats, not guessed from a mode: `en-US` renders a zone
+   without a letter abbreviation as a GMT offset, so local time is "08 CDT" in
+   Chicago but "18 GMT+5:30" in Kolkata — nearly twice as wide. */
 
-export function initColumnPx(local) {
-  return (local ? 6 : 5) * CH_PX;
+export function initColumnPx(product, zone) {
+  const widest = (product.recent_inits ?? []).reduce((max, init) => {
+    const { date, time } = initParts(init.init_time, zone);
+    return Math.max(max, date.length, time.length);
+  }, 2);
+  return Math.max(CELL_PX, widest * CH_PX);
 }
 
 export function gutterPx(labelled) {
@@ -462,7 +462,7 @@ export function runsThatFit(product, availablePx, local) {
   return runsFitting(
     availablePx,
     gutterPx(bandsOf(product)),
-    initColumnPx(local),
+    initColumnPx(product, selectedTimeZone(local)),
     RUN_GAP_PX,
   );
 }
@@ -625,16 +625,13 @@ export function viewsOf(product) {
   ];
 }
 
-export function viewAt(product, index) {
-  const views = viewsOf(product);
-  return views[((index % views.length) + views.length) % views.length];
+function wrapIndex(index, length) {
+  return ((index % length) + length) % length;
 }
 
-/* The layout only transposes when there are rows to draw. Without this a joint
-   that reports nothing would hide the lead measurements it replaced. */
-
-export function usesFacetRows(product) {
-  return hasJointFacets(product) && facetRowsOf(product).length > 0;
+export function viewAt(product, index) {
+  const views = viewsOf(product);
+  return views[wrapIndex(index, views.length)];
 }
 
 /* The init axis: the time under every column, then the date only where it turns
@@ -668,11 +665,12 @@ function initTiers(runs, local) {
    still decides, then read by name per square. */
 
 function jointIndex(product, runs, leads) {
+  const order = facetRowsOf(product).map((facet) => facet.name);
   const index = new Map();
   for (const init of runs) {
     const byLead = new Map();
     for (const lead of leads) {
-      const facets = facetsAt(product, init, lead.key);
+      const facets = facetsAt(product, init, lead.key, order);
       if (!facets.length) continue;
       byLead.set(lead.key, {
         // the lead group's own timing is more specific than the run's
@@ -713,7 +711,7 @@ function renderFacetRows(product, local, runCount, dimension) {
   const leadWidth = (lead) => extents.get(lead.key) ?? CELL_PX;
   const runWidth =
     leads.reduce((sum, lead) => sum + leadWidth(lead), 0) +
-    (leads.length - 1) * CLUMP_GAP_PX;
+    Math.max(0, leads.length - 1) * CLUMP_GAP_PX;
   const field = element("div", {
     class: "pipeline-field",
     // lead time runs across here, so progress fills across too
@@ -798,23 +796,13 @@ function renderFacetRows(product, local, runCount, dimension) {
 function renderField(product, local, runCount) {
   const runs = product.recent_inits.slice(-Math.max(1, runCount || RUNS_MAX));
   const extents = leadExtents(product);
-  const column = initColumnPx(local);
+  const column = initColumnPx(product, selectedTimeZone(local));
   const field = element("div", {
     class: "pipeline-field",
     // a cell is as wide as its init label; the lead axis keeps its own scale
     style: `--sq:${column}px;--run-gap:${RUN_GAP_PX}px;--clumped-run-gap:${RUN_GAP_PX}px;--run-width:${column}px;--band-gutter:${gutterPx(bandsOf(product))}px;--band-gap:${BAND_GAP_PX}px;--label-h:${LABEL_PX}px;--reserve:${reservedHeightPx(product)}px`,
   });
-  let dimension = null;
-
   for (const band of bandsOf(product)) {
-    // name each facet dimension once, where it starts
-    if (band.kind === "facet" && band.dimension !== dimension) {
-      field.append(
-        element("div", { class: "pipeline-dimension" }, band.dimension),
-      );
-    }
-    dimension = band.kind === "facet" ? band.dimension : null;
-
     field.append(
       bandNode({
         kind: band.kind,
@@ -1078,7 +1066,7 @@ function buildDetails(product, now, local) {
 function hydrateRow(row, product, now, local, available) {
   // the lead grid is the view a row opens on; the facet grids are a click away
   const views = viewsOf(product);
-  const index = Number(row.dataset.view ?? 0) % views.length;
+  const index = wrapIndex(Number(row.dataset.view ?? 0), views.length);
   const view = views[index];
   row.dataset.view = String(index);
 
@@ -1097,7 +1085,9 @@ function hydrateRow(row, product, now, local, available) {
   // more than the one view
   if (views.length > 1) {
     const next = views[(index + 1) % views.length];
-    viz.setAttribute("role", "button");
+    // a group, not a button: role="button" would collapse the field into one
+    // node and hide every cell's own label from assistive tech
+    viz.setAttribute("role", "group");
     viz.setAttribute("tabindex", "0");
     viz.setAttribute(
       "aria-label",

--- a/public/pipeline.mjs
+++ b/public/pipeline.mjs
@@ -9,7 +9,7 @@ const POLL_INTERVAL_MS = 15_000;
 const HEALTH_REFRESH_INTERVAL_MS = 5 * 60 * 1000;
 const STALE_AFTER_MS = 10 * 60 * 1000;
 const FETCH_TIMEOUT_MS = 10_000;
-const DASHBOARD_VERSION = 1;
+const DASHBOARD_VERSIONS = new Set([1, 2]);
 
 function hasTimestamp(value) {
   return (
@@ -22,7 +22,7 @@ function hasTimestamp(value) {
 export function validateDashboard(data) {
   if (
     !data ||
-    data.v !== DASHBOARD_VERSION ||
+    !DASHBOARD_VERSIONS.has(data.v) ||
     !hasTimestamp(data.generated_at) ||
     !Array.isArray(data.groups) ||
     data.groups.length === 0 ||
@@ -30,6 +30,7 @@ export function validateDashboard(data) {
   ) {
     throw new TypeError("Invalid pipeline dashboard");
   }
+  let hasFacetGroups = false;
   for (const group of data.groups) {
     if (
       typeof group.id !== "string" ||
@@ -48,7 +49,50 @@ export function validateDashboard(data) {
       ) {
         throw new TypeError("Invalid pipeline product");
       }
+      if (product.facet_groups != null) {
+        if (
+          data.v !== 2 ||
+          !Array.isArray(product.facet_groups) ||
+          product.facet_groups.length === 0 ||
+          !product.facet_groups.every(
+            (facet) =>
+              typeof facet.dimension === "string" &&
+              typeof facet.name === "string" &&
+              typeof facet.label === "string",
+          )
+        ) {
+          throw new TypeError("Invalid pipeline facet group");
+        }
+        hasFacetGroups = true;
+      }
+      for (const init of product.recent_inits) {
+        if (init.facets == null) continue;
+        if (
+          data.v !== 2 ||
+          !Array.isArray(init.facets) ||
+          !init.facets.every(
+            (facet) =>
+              typeof facet.dimension === "string" &&
+              typeof facet.name === "string" &&
+              typeof facet.label === "string" &&
+              Number.isInteger(facet.dependencies_available) &&
+              facet.dependencies_available >= 0 &&
+              Number.isInteger(facet.dependencies_expected) &&
+              facet.dependencies_expected > 0 &&
+              facet.dependencies_available <= facet.dependencies_expected &&
+              Number.isFinite(facet.completion_pct) &&
+              facet.completion_pct >= 0 &&
+              facet.completion_pct <= 1 &&
+              typeof facet.status === "string",
+          )
+        ) {
+          throw new TypeError("Invalid pipeline facet");
+        }
+      }
     }
+  }
+  if (data.v === 2 && !hasFacetGroups) {
+    throw new TypeError("Invalid pipeline dashboard");
   }
   return data;
 }
@@ -413,7 +457,7 @@ export function detailRows(product, now, local) {
       : displayed
         ? `${initShort(displayed.init_time, local)} · previous init`
         : "waiting for next init",
-    rows: product.lead_group_stats.map((stats, index) => {
+    rows: (product.lead_group_stats ?? []).map((stats, index) => {
       const live = groups[index];
       let time = "—";
       let duration = "—";
@@ -446,6 +490,20 @@ export function detailRows(product, now, local) {
   };
 }
 
+export function facetRows(product) {
+  const running = product.recent_inits.findLast(
+    (init) => init.status === "in_flight",
+  );
+  const displayed = running ?? product.recent_inits.at(-1);
+  return (displayed?.facets ?? []).map((facet) => ({
+    dimension: facet.dimension,
+    label: facet.label,
+    status: statusLabel(facet.status),
+    completion: facet.completion_pct,
+    count: `${facet.dependencies_available.toLocaleString("en-US")} / ${facet.dependencies_expected.toLocaleString("en-US")} files`,
+  }));
+}
+
 function buildDetails(product, now, local) {
   const details = detailRows(product, now, local);
   const groupHead = element("tr", null, [
@@ -476,10 +534,48 @@ function buildDetails(product, now, local) {
       ]),
     );
   }
-  return element("table", null, [
+  const leadTable = element("table", null, [
     element("thead", null, [groupHead, head]),
     body,
   ]);
+  const facets = facetRows(product);
+  if (facets.length === 0) return leadTable;
+
+  const facetBody = element("tbody");
+  for (const facet of facets) {
+    facetBody.append(
+      element("tr", null, [
+        element("td", null, facet.dimension),
+        element("td", null, facet.label),
+        element("td", null, facet.status),
+        element("td", null, facet.count),
+        element("td", null, [
+          element("progress", {
+            max: "1",
+            value: String(facet.completion),
+            "aria-label": `${Math.round(facet.completion * 100)}% complete`,
+          }),
+          ` ${Math.round(facet.completion * 100)}%`,
+        ]),
+      ]),
+    );
+  }
+  const facetTable = element("table", { class: "pipeline-facets" }, [
+    element("thead", null, [
+      element("tr", null, [
+        element("th", { colspan: "5" }, "file arrival coverage"),
+      ]),
+      element("tr", null, [
+        element("th", null, "dimension"),
+        element("th", null, "group"),
+        element("th", null, "status"),
+        element("th", null, "files"),
+        element("th", null, "complete"),
+      ]),
+    ]),
+    facetBody,
+  ]);
+  return element("div", null, [leadTable, facetTable]);
 }
 
 function hydrateRow(row, product, now, local) {
@@ -490,7 +586,7 @@ function hydrateRow(row, product, now, local) {
 
   const button = row.querySelector('[data-slot="details-button"]');
   const details = row.querySelector('[data-slot="details"]');
-  if (product.lead_group_stats?.length) {
+  if (product.lead_group_stats?.length || facetRows(product).length) {
     button.hidden = false;
     details.replaceChildren(buildDetails(product, now, local));
   } else {

--- a/public/pipeline.mjs
+++ b/public/pipeline.mjs
@@ -194,11 +194,6 @@ function initShort(timestamp, local) {
   return `${date} ${time}`;
 }
 
-function initLabel(timestamp, local) {
-  const { date, time } = initParts(timestamp, selectedTimeZone(local));
-  return element("span", null, [element("strong", null, date), time]);
-}
-
 function formatTime(timestamp, local, includeZone = true) {
   const options = {
     month: "short",
@@ -237,8 +232,11 @@ function timeNode(timestamp) {
   ]);
 }
 
-function groupSlices(groups) {
-  const total = groups.at(-1)?.leads_expected ?? 0;
+/* One square per measurement. Lead-group counts arrive cumulative, so a band's
+   own share is the difference from the band below it — the same arithmetic the
+   bars used for segment heights. */
+
+function leadSlices(groups) {
   let previousAvailable = 0;
   let previousExpected = 0;
   return groups.map((group) => {
@@ -247,86 +245,165 @@ function groupSlices(groups) {
     previousExpected = group.leads_expected;
     previousAvailable = group.leads_available;
     return {
-      ...group,
-      height: total ? (expected / total) * 100 : 0,
-      fill: expected ? Math.max(0, Math.min(100, (available / expected) * 100)) : 0,
+      name: group.name,
+      status: group.status,
+      timing: group.timing,
+      available,
+      expected,
+      completion: expected
+        ? Math.max(0, Math.min(1, available / expected))
+        : (group.completion_pct ?? 0),
     };
   });
 }
 
-export function barTooltip(init, local) {
-  if (init.status === "unobserved") {
-    return `${initShort(init.init_time, local)} · no probe visibility; not a publication failure`;
+/* The bands of a product's field, top row first: longest horizon down to the
+   floor, then a band per facet grouped by dimension. Bands come from the
+   product rather than a single run so the field keeps its shape as runs
+   scroll through it. */
+
+export function bandsOf(product) {
+  const newest = product.recent_inits?.at(-1);
+  // history snapshots carry the same runs but declare neither list up front
+  const labelOf = new Map(
+    (product.lead_group_stats ?? []).map((stats) => [stats.name, stats.label]),
+  );
+  const declaredLeads = product.lead_groups?.length
+    ? product.lead_groups
+    : (newest?.lead_groups ?? []);
+  const leads = declaredLeads.map((group) => ({
+    kind: "lead",
+    key: group.name,
+    label: group.label ?? labelOf.get(group.name) ?? group.name,
+  }));
+  leads.reverse();
+
+  const declaredFacets = product.facet_groups?.length
+    ? product.facet_groups
+    : (newest?.facets ?? []);
+  const facets = declaredFacets.map((facet) => ({
+    kind: "facet",
+    key: facet.name,
+    label: facet.label,
+    dimension: facet.dimension,
+  }));
+  return [...leads, ...facets];
+}
+
+/* What one run measured for one band. A band the run never reported reads as
+   unobserved rather than as a failure. */
+
+export function cellOf(band, init) {
+  if (!init) return { state: "unobserved" };
+  if (init.status === "unobserved") return { state: "unobserved" };
+
+  if (band.kind === "lead") {
+    const slice = leadSlices(init.lead_groups ?? []).find(
+      (group) => group.name === band.key,
+    );
+    if (!slice) return { state: "unobserved" };
+    return {
+      state: slice.status,
+      timing: slice.timing,
+      completion: slice.completion,
+    };
   }
-  const state = init.timing ? `${init.status} · ${init.timing}` : init.status;
-  const run = [
-    initShort(init.init_time, local),
-    state,
-    init.completion_pct == null
-      ? null
-      : `${Math.round(init.completion_pct * 100)}%`,
-    init.latency_s == null ? null : `latency ${formatLatency(init.latency_s)}`,
+
+  const facet = (init.facets ?? []).find((entry) => entry.name === band.key);
+  if (!facet) return { state: "unobserved" };
+  return {
+    state: facet.status,
+    timing: init.timing,
+    completion: facet.completion_pct ?? 0,
+    available: facet.dependencies_available,
+    expected: facet.dependencies_expected,
+  };
+}
+
+/* The hover label. What the square stands for comes first, then when, then how
+   much of it arrived — a facet names itself and its dimension. */
+
+export function cellTitle(band, init, cell, local) {
+  if (!init) return `${band.label} · not reported`;
+  const when = initShort(init.init_time, local);
+  if (cell.state === "unobserved") {
+    return `${band.label} · ${when} · no probe visibility; not a publication failure`;
+  }
+  const volume =
+    cell.expected != null
+      ? `${cell.available.toLocaleString("en-US")} / ${cell.expected.toLocaleString("en-US")} files`
+      : `${Math.round((cell.completion ?? 0) * 100)}%`;
+  return [
+    band.kind === "facet" ? `${band.label} (${band.dimension})` : `lead ${band.label}`,
+    when,
+    volume,
+    statusLabel(cell.state),
+    cell.timing ? cell.timing.replaceAll("_", " ") : null,
   ]
     .filter(Boolean)
     .join(" · ");
-  if (!init.lead_groups?.length) return run;
-  const groups = init.lead_groups.map((group) => {
-    const groupState = group.timing
-      ? `${group.status} · ${group.timing}`
-      : group.status;
-    const progress =
-      group.status === "in_flight" && group.completion_pct != null
-        ? ` ${Math.round(group.completion_pct * 100)}%`
-        : "";
-    return `${group.name} ${groupState}${progress}`;
-  });
-  return `${run}\n${groups.join(" · ")}`;
 }
 
-function renderBar(init, local) {
-  const track = element("div", { class: "pipeline-bar-track" });
-  if (init.lead_groups?.length) {
-    let bottom = 0;
-    for (const group of groupSlices(init.lead_groups)) {
-      const segment = element(
-        "div",
-        {
-          class: `pipeline-bar-segment g-${group.status}`,
-          "data-group": group.name,
-          "data-timing": group.timing,
-          style: `--band-height:${group.height}%;--band-bottom:${bottom}%;--fill:${group.fill}%`,
-        },
-        element("div", { class: "pipeline-bar-segment-fill" }),
-      );
-      track.append(segment);
-      bottom += group.height;
-    }
-  } else {
-    track.append(
-      element("div", {
-        class: "pipeline-bar-fill",
-        style: `--fill:${Math.max(0, Math.min(100, (init.completion_pct ?? 0) * 100))}%`,
-      }),
-    );
-  }
+function renderCell(band, init, local) {
+  const cell = cellOf(band, init);
   return element(
     "div",
     {
-      class: "pipeline-bar",
-      "data-init-time": init.init_time,
-      "data-status": init.status,
-      "data-timing": init.timing,
-      title: barTooltip(init, local),
+      class: `pipeline-cell g-${cell.state}`,
+      "data-init-time": init?.init_time,
+      "data-timing": cell.timing,
+      title: cellTitle(band, init, cell, local),
     },
-    [
-      track,
-      element(
-        "div",
-        { class: "pipeline-bar-label" },
-        initLabel(init.init_time, local),
-      ),
-    ],
+    element("div", {
+      class: "pipeline-cell-fill",
+      style: `--fill:${Math.max(0, Math.min(100, (cell.completion ?? 0) * 100))}%`,
+    }),
   );
+}
+
+function renderField(product, local) {
+  const runs = product.recent_inits.slice(-10);
+  const field = element("div", { class: "pipeline-field" });
+  let dimension = null;
+
+  for (const band of bandsOf(product)) {
+    // name each facet dimension once, where it starts
+    if (band.kind === "facet" && band.dimension !== dimension) {
+      field.append(
+        element("div", { class: "pipeline-dimension" }, band.dimension),
+      );
+    }
+    dimension = band.kind === "facet" ? band.dimension : null;
+
+    const cells = element("div", { class: "pipeline-cells" });
+    for (const init of runs) cells.append(renderCell(band, init, local));
+    field.append(
+      element("div", { class: "pipeline-band", "data-kind": band.kind }, [
+        element(
+          "span",
+          { class: "pipeline-band-label", title: band.label },
+          band.label,
+        ),
+        cells,
+      ]),
+    );
+  }
+
+  const first = runs[0];
+  const last = runs.at(-1);
+  if (first && last) {
+    field.append(
+      element("div", { class: "pipeline-axis" }, [
+        element("span"),
+        element(
+          "span",
+          null,
+          `${initShort(first.init_time, local)} → ${initShort(last.init_time, local)}`,
+        ),
+      ]),
+    );
+  }
+  return field;
 }
 
 function renderStructure(app, dashboard, rows) {
@@ -339,20 +416,6 @@ function renderStructure(app, dashboard, rows) {
       element("h3", null, group.label),
     ]);
     for (const product of group.products) {
-      const leadLabels = element("div", {
-        class: "pipeline-lead-labels",
-        "aria-hidden": "true",
-      });
-      for (const lead of product.lead_groups?.slice(1) ?? []) {
-        leadLabels.append(
-          element(
-            "span",
-            { style: `bottom:${lead.center_pct}%` },
-            lead.label,
-          ),
-        );
-      }
-
       const advisory = element("div", {
         class: "pipeline-row-advisory",
         "data-slot": "row-advisory",
@@ -372,8 +435,7 @@ function renderStructure(app, dashboard, rows) {
             ]),
           ]),
           element("div", { class: "pipeline-row-body" }, [
-            leadLabels,
-            element("div", { class: "pipeline-grid", "data-slot": "grid" }),
+            element("div", { "data-slot": "field" }),
           ]),
           element("div", { class: "pipeline-stats" }, [
             element("strong", { "data-slot": "eta-init" }, "—"),
@@ -579,9 +641,9 @@ function buildDetails(product, now, local) {
 }
 
 function hydrateRow(row, product, now, local) {
-  row.querySelector('[data-slot="grid"]').replaceChildren(
-    ...product.recent_inits.slice(-10).map((init) => renderBar(init, local)),
-  );
+  row
+    .querySelector('[data-slot="field"]')
+    .replaceChildren(renderField(product, local));
   hydrateEta(row, product, now, local);
 
   const button = row.querySelector('[data-slot="details-button"]');

--- a/public/pipeline.mjs
+++ b/public/pipeline.mjs
@@ -14,7 +14,7 @@ const DASHBOARD_VERSIONS = new Set([1, 2]);
 // the CSS reads them back off the field as custom properties.
 const CELL_PX = 12; // one measurement, the same size in every view
 const CLUMP_GAP_PX = 2; // between the lead columns within one run
-const RUN_GAP_PX = 2; // between runs, in the lead grid
+const RUN_GAP_PX = 6; // between init columns, as main spaced its bars
 const CLUMPED_RUN_GAP_PX = 6; // between run blocks, which need daylight
 // no lead group is thinner than its own label: "0h" is two characters, which is
 // exactly one cell, so every group can name itself
@@ -414,6 +414,14 @@ export function facetsAt(product, init, leadName) {
    ch: CSS resolves ch against the band's inherited font, which is not the
    font these labels are set in. */
 
+/* An init column is as wide as the label beneath it: "08-12" in UTC, and the
+   zone abbreviation makes local mode wider. Main sized its bars the same way,
+   which is what lets every column carry its own timestamp. */
+
+export function initColumnPx(local) {
+  return (local ? 6 : 5) * CH_PX;
+}
+
 export function gutterPx(labelled) {
   const widest = labelled.reduce(
     (max, entry) => Math.max(max, (entry.label ?? "").length),
@@ -437,11 +445,11 @@ function runsFitting(availablePx, gutter, runWidth, gap) {
   );
 }
 
-export function runsThatFit(product, availablePx) {
+export function runsThatFit(product, availablePx, local) {
   return runsFitting(
     availablePx,
     gutterPx(bandsOf(product)),
-    CELL_PX,
+    initColumnPx(local),
     RUN_GAP_PX,
   );
 }
@@ -616,6 +624,32 @@ export function usesFacetRows(product) {
   return hasJointFacets(product) && facetRowsOf(product).length > 0;
 }
 
+/* The init axis: the time under every column, then the date only where it turns
+   over, so a date lines up with the first timestamp it covers. */
+
+function initTiers(runs, local) {
+  const zone = selectedTimeZone(local);
+  let previousDate = null;
+  return [
+    labelTier({
+      bandClass: "pipeline-band pipeline-band--foot",
+      spanClass: "pipeline-run-label",
+      runs,
+      textOf: (init) => initParts(init.init_time, zone).time,
+    }),
+    labelTier({
+      spanClass: "pipeline-run-date",
+      runs,
+      textOf: (init) => {
+        const { date } = initParts(init.init_time, zone);
+        const turned = date !== previousDate;
+        previousDate = date;
+        return turned ? date : "";
+      },
+    }),
+  ];
+}
+
 /* The joint, indexed once per render: which facets a run reported under a lead
    group, and that group's timing. Built from `facetsAt` so the declared order
    still decides, then read by name per square. */
@@ -738,39 +772,18 @@ function renderFacetRows(product, local, runCount, dimension) {
     );
   }
 
-  // the init time under every block, then the date only where it turns over, so
-  // a date lines up with the first timestamp it covers
-  const zone = selectedTimeZone(local);
-  field.append(
-    labelTier({
-      bandClass: "pipeline-band pipeline-band--foot",
-      spanClass: "pipeline-run-label",
-      runs,
-      textOf: (init) => initParts(init.init_time, zone).time,
-    }),
-  );
-  let previousDate = null;
-  field.append(
-    labelTier({
-      spanClass: "pipeline-run-date",
-      runs,
-      textOf: (init) => {
-        const { date } = initParts(init.init_time, zone);
-        const turned = date !== previousDate;
-        previousDate = date;
-        return turned ? date : "";
-      },
-    }),
-  );
+  field.append(...initTiers(runs, local));
   return field;
 }
 
 function renderField(product, local, runCount) {
   const runs = product.recent_inits.slice(-Math.max(1, runCount || RUNS_MAX));
   const extents = leadExtents(product);
+  const column = initColumnPx(local);
   const field = element("div", {
     class: "pipeline-field",
-    style: `--sq:${CELL_PX}px;--run-gap:${RUN_GAP_PX}px;--band-gutter:${gutterPx(bandsOf(product))}px`,
+    // a cell is as wide as its init label; the lead axis keeps its own scale
+    style: `--sq:${column}px;--run-gap:${RUN_GAP_PX}px;--clumped-run-gap:${RUN_GAP_PX}px;--run-width:${column}px;--band-gutter:${gutterPx(bandsOf(product))}px`,
   });
   let dimension = null;
 
@@ -789,29 +802,14 @@ function renderField(product, local, runCount) {
         label: band.label,
         labelTitle: band.label,
         // a lead band is as tall as its share of the run; a facet band is a cell
-        style:
-          band.kind === "lead"
-            ? `--cell-h:${(extents.get(band.key) ?? CELL_PX).toFixed(2)}px`
-            : null,
+        style: `--cell-h:${(band.kind === "lead" ? (extents.get(band.key) ?? CELL_PX) : CELL_PX).toFixed(2)}px`,
         children: runs.map((init) => renderCell(band, init, local)),
       }),
     );
   }
 
-  const first = runs[0];
-  const last = runs.at(-1);
-  if (first && last) {
-    field.append(
-      element("div", { class: "pipeline-axis" }, [
-        element("span"),
-        element(
-          "span",
-          null,
-          `${initShort(first.init_time, local)} → ${initShort(last.init_time, local)}`,
-        ),
-      ]),
-    );
-  }
+  // every column is wide enough to name itself, so the axis is per column
+  field.append(...initTiers(runs, local));
   return field;
 }
 
@@ -1063,7 +1061,7 @@ function hydrateRow(row, product, now, local, available) {
         runsThatFitFacetRows(product, available, view.dimension),
         view.dimension,
       )
-    : renderField(product, local, runsThatFit(product, available));
+    : renderField(product, local, runsThatFit(product, available, local));
 
   const viz = row.querySelector('[data-slot="field"]');
   viz.replaceChildren(field);

--- a/public/pipeline.mjs
+++ b/public/pipeline.mjs
@@ -16,7 +16,10 @@ const SQUARE_PX = 8;
 const CLUMP_GAP_PX = 1; // between facet squares within one run
 const RUN_GAP_PX = 2; // between runs of a single square
 const CLUMPED_RUN_GAP_PX = 6; // between runs of a clump, which needs daylight
-const BAND_GUTTER_PX = 140; // the lead/facet label column
+const CH_PX = 6; // one monospace character at the band-label size
+const GUTTER_MAX_CH = 24; // long facet labels get room, but not unbounded
+const FACET_SQUARE_PX = 12; // wide enough for a lead label over each column
+const FACET_GAP_PX = 2; // and enough air that the labels do not touch
 const RUNS_MAX = 10; // what the payload carries
 
 function hasTimestamp(value) {
@@ -340,6 +343,16 @@ export function facetsAt(product, init, leadName) {
    the viewport. Falls back to everything the payload carries when the width is
    not measurable yet. */
 
+/* The label gutter is only as wide as the labels a product actually renders.
+   Lead-only rows read "3d"; a facet row reads "precipitation and snow". Sizing
+   it per product is what keeps the strip from starting a third of the way in. */
+
+export function bandGutterCh(product) {
+  const labels = bandsOf(product).map((band) => band.label ?? "");
+  const widest = labels.reduce((max, label) => Math.max(max, label.length), 2);
+  return Math.min(GUTTER_MAX_CH, widest);
+}
+
 export function runsThatFit(product, availablePx) {
   const clumped = hasJointFacets(product);
   const widest = clumped
@@ -354,8 +367,11 @@ export function runsThatFit(product, availablePx) {
     : 1;
   const runWidth = widest * SQUARE_PX + (widest - 1) * CLUMP_GAP_PX;
   const gap = clumped ? CLUMPED_RUN_GAP_PX : RUN_GAP_PX;
-  const usable = availablePx - BAND_GUTTER_PX - 6; // 0.6rem band gap
-  if (!Number.isFinite(usable) || usable <= 0) return RUNS_MAX;
+  // an unmeasured row shows everything rather than nothing
+  if (!Number.isFinite(availablePx) || availablePx <= 0) return RUNS_MAX;
+  // 6px band gap, and 4px of slack so a font fallback cannot overflow the row
+  const usable = availablePx - bandGutterCh(product) * CH_PX - 6 - 4;
+  if (usable <= 0) return 1;
   return Math.max(1, Math.min(RUNS_MAX, Math.floor((usable + gap) / (runWidth + gap))));
 }
 
@@ -436,11 +452,181 @@ function renderCell(band, init, local, measured) {
   );
 }
 
+/* The facet-row field spends width on lead-group columns inside every run, so
+   it needs its own fit. */
+
+export function facetRowsOf(product) {
+  const newest = product.recent_inits?.at(-1);
+  const leads = bandsOf(product);
+  return (product.facet_groups ?? []).filter((facet) =>
+    leads.some((lead) =>
+      facetsAt(product, newest, lead.key).some((entry) => entry.name === facet.name),
+    ),
+  );
+}
+
+function facetRowsGutterCh(product) {
+  return Math.min(
+    GUTTER_MAX_CH,
+    facetRowsOf(product).reduce(
+      (max, facet) => Math.max(max, facet.label.length),
+      2,
+    ),
+  );
+}
+
+export function runsThatFitFacetRows(product, availablePx) {
+  // a run is still the group: one square per lead group inside it
+  const leads = Math.max(1, bandsOf(product).length);
+  const runWidth = leads * FACET_SQUARE_PX + (leads - 1) * FACET_GAP_PX;
+  if (!Number.isFinite(availablePx) || availablePx <= 0) return RUNS_MAX;
+  const usable = availablePx - facetRowsGutterCh(product) * CH_PX - 6 - 4;
+  if (usable <= 0) return 1;
+  return Math.max(
+    1,
+    Math.min(
+      RUNS_MAX,
+      Math.floor((usable + CLUMPED_RUN_GAP_PX) / (runWidth + CLUMPED_RUN_GAP_PX)),
+    ),
+  );
+}
+
+/* The facet-row field: one row per facet, one run per block, one column per
+   lead group inside a block. The runs
+   clumped inside each cell. Same squares and same titles as the banded field —
+   only which dimension owns which axis changes. */
+
+function renderFacetRows(product, local, runCount) {
+  const runs = product.recent_inits.slice(-Math.max(1, runCount || RUNS_MAX));
+  const leads = [...bandsOf(product)].reverse(); // shortest horizon first
+  const facets = facetRowsOf(product);
+  const field = element("div", {
+    class: "pipeline-field pipeline-field--facets",
+    style: `--sq:${FACET_SQUARE_PX}px;--clump-gap:${FACET_GAP_PX}px;--clumped-run-gap:${CLUMPED_RUN_GAP_PX}px;--band-gutter:${facetRowsGutterCh(product) * CH_PX}px;--leads:${leads.length}`,
+  });
+
+  // the lead order repeats in every run, so name it once over the first block
+  field.append(
+    element("div", { class: "pipeline-band pipeline-band--head" }, [
+      element("span", { class: "pipeline-band-label" }),
+      element(
+        "div",
+        { class: "pipeline-cells", "data-clumped": "" },
+        runs.map((init, index) =>
+          element(
+            "div",
+            { class: "pipeline-clump" },
+            index === 0
+              ? leads.map((lead) =>
+                  element(
+                    "span",
+                    { class: "pipeline-column-label", title: `lead ${lead.label}` },
+                    lead.label,
+                  ),
+                )
+              : leads.map(() => element("span", { class: "pipeline-column-label" })),
+          ),
+        ),
+      ),
+    ]),
+  );
+
+  for (const facet of facets) {
+    const cells = element("div", { class: "pipeline-cells", "data-clumped": "" });
+    for (const init of runs) {
+      const clump = element("div", { class: "pipeline-clump" });
+      for (const lead of leads) {
+        const measured = facetsAt(product, init, lead.key).find(
+          (entry) => entry.name === facet.name,
+        );
+        const band = {
+          kind: "facet",
+          key: facet.name,
+          label: facet.label,
+          dimension: facet.dimension,
+          lead: lead.label,
+        };
+        const timing = (init.lead_groups ?? []).find(
+          (group) => group.name === lead.key,
+        )?.timing;
+        clump.append(
+          renderCell(
+            band,
+            init,
+            local,
+            measured
+              ? facetCell(measured, init, timing ?? init.timing)
+              : { state: "unobserved" },
+          ),
+        );
+      }
+      cells.append(clump);
+    }
+    field.append(
+      element("div", { class: "pipeline-band", "data-kind": "facet" }, [
+        element(
+          "span",
+          { class: "pipeline-band-label", title: `${facet.label} (${facet.dimension})` },
+          facet.label,
+        ),
+        cells,
+      ]),
+    );
+  }
+
+  // two tiers under the blocks: the init time on every block, then each date
+  // centred under the run of blocks that share it
+  field.append(
+    element("div", { class: "pipeline-band pipeline-band--foot" }, [
+      element("span", { class: "pipeline-band-label" }),
+      element(
+        "div",
+        { class: "pipeline-cells", "data-clumped": "" },
+        runs.map((init) =>
+          element(
+            "span",
+            {
+              class: "pipeline-run-label",
+              title: initShort(init.init_time, local),
+            },
+            initParts(init.init_time, selectedTimeZone(local)).time,
+          ),
+        ),
+      ),
+    ]),
+  );
+
+  // the date tier mirrors the time tier block for block, carrying text only
+  // where the date turns over, so a date lines up with its first timestamp
+  let previousDate = null;
+  field.append(
+    element("div", { class: "pipeline-band pipeline-band--dates" }, [
+      element("span", { class: "pipeline-band-label" }),
+      element(
+        "div",
+        { class: "pipeline-cells", "data-clumped": "" },
+        runs.map((init) => {
+          const { date } = initParts(init.init_time, selectedTimeZone(local));
+          const turned = date !== previousDate;
+          previousDate = date;
+          return element(
+            "span",
+            { class: "pipeline-run-date" },
+            turned ? date : "",
+          );
+        }),
+      ),
+    ]),
+  );
+
+  return field;
+}
+
 function renderField(product, local, runCount) {
   const runs = product.recent_inits.slice(-Math.max(1, runCount || RUNS_MAX));
   const field = element("div", {
     class: "pipeline-field",
-    style: `--sq:${SQUARE_PX}px;--clump-gap:${CLUMP_GAP_PX}px;--run-gap:${RUN_GAP_PX}px;--clumped-run-gap:${CLUMPED_RUN_GAP_PX}px;--band-gutter:${BAND_GUTTER_PX}px`,
+    style: `--sq:${SQUARE_PX}px;--clump-gap:${CLUMP_GAP_PX}px;--run-gap:${RUN_GAP_PX}px;--clumped-run-gap:${CLUMPED_RUN_GAP_PX}px;--band-gutter:${bandGutterCh(product) * CH_PX}px`,
   });
   let dimension = null;
 
@@ -762,9 +948,17 @@ function hydrateRow(row, product, now, local) {
   // field it holds — measuring it cannot feed back into the fit
   const body = row.querySelector(".pipeline-row-body");
   const available = body?.getBoundingClientRect().width ?? 0;
+  // with the joint, facets get their own labelled rows; without it, the two
+  // published marginals get their own bands
+  const nested = hasJointFacets(product);
+  const runCount = nested
+    ? runsThatFitFacetRows(product, available)
+    : runsThatFit(product, available);
   row
     .querySelector('[data-slot="field"]')
-    .replaceChildren(renderField(product, local, runsThatFit(product, available)));
+    .replaceChildren(
+      (nested ? renderFacetRows : renderField)(product, local, runCount),
+    );
   hydrateEta(row, product, now, local);
 
   const button = row.querySelector('[data-slot="details-button"]');

--- a/public/pipeline.mjs
+++ b/public/pipeline.mjs
@@ -500,7 +500,7 @@ export function facetRows(product) {
     label: facet.label,
     status: statusLabel(facet.status),
     completion: facet.completion_pct,
-    count: `${facet.dependencies_available.toLocaleString("en-US")} / ${facet.dependencies_expected.toLocaleString("en-US")} files`,
+    count: `${facet.dependencies_available.toLocaleString("en-US")} / ${facet.dependencies_expected.toLocaleString("en-US")} observed`,
   }));
 }
 
@@ -563,7 +563,7 @@ function buildDetails(product, now, local) {
   const facetTable = element("table", { class: "pipeline-facets" }, [
     element("thead", null, [
       element("tr", null, [
-        element("th", { colspan: "5" }, "file arrival coverage"),
+        element("th", { colspan: "5" }, "arrival coverage"),
       ]),
       element("tr", null, [
         element("th", null, "dimension"),

--- a/public/pipeline.mjs
+++ b/public/pipeline.mjs
@@ -10,6 +10,8 @@ const HEALTH_REFRESH_INTERVAL_MS = 5 * 60 * 1000;
 const STALE_AFTER_MS = 10 * 60 * 1000;
 const FETCH_TIMEOUT_MS = 10_000;
 const DASHBOARD_VERSIONS = new Set([1, 2]);
+// the payload carries ten runs; the field shows the most recent few
+const RUNS_SHOWN = 4;
 
 function hasTimestamp(value) {
   return (
@@ -362,7 +364,7 @@ function renderCell(band, init, local) {
 }
 
 function renderField(product, local) {
-  const runs = product.recent_inits.slice(-10);
+  const runs = product.recent_inits.slice(-RUNS_SHOWN);
   const field = element("div", { class: "pipeline-field" });
   let dimension = null;
 

--- a/public/pipeline.mjs
+++ b/public/pipeline.mjs
@@ -9,7 +9,7 @@ const POLL_INTERVAL_MS = 15_000;
 const HEALTH_REFRESH_INTERVAL_MS = 5 * 60 * 1000;
 const STALE_AFTER_MS = 10 * 60 * 1000;
 const FETCH_TIMEOUT_MS = 10_000;
-const DASHBOARD_VERSIONS = new Set([1, 2]);
+const DASHBOARD_VERSION = 2; // the granular schema; the lead-only shape is gone
 // Field geometry. JS owns these because the run count is computed from them;
 // the CSS reads them back off the field as custom properties.
 const CELL_PX = 12; // one measurement, the same size in every view
@@ -19,6 +19,9 @@ const CLUMPED_RUN_GAP_PX = 6; // between run blocks, which need daylight
 // no lead group is thinner than its own label: "0h" is two characters, which is
 // exactly one cell, so every group can name itself
 const MIN_LEAD_PX = 12;
+const BAND_GAP_PX = 2; // between bands, inside a field
+const LABEL_PX = 12; // one axis-label row
+const FOOT_GAP_PX = 3; // the breath above the init tiers
 const CH_PX = 6; // one monospace character at the band-label size
 const GUTTER_MAX_CH = 24; // long facet labels get room, but not unbounded
 const RUNS_MAX = 10; // what the payload carries
@@ -55,7 +58,7 @@ function validFacets(facets) {
 export function validateDashboard(data) {
   if (
     !data ||
-    !DASHBOARD_VERSIONS.has(data.v) ||
+    data.v !== DASHBOARD_VERSION ||
     !hasTimestamp(data.generated_at) ||
     !Array.isArray(data.groups) ||
     data.groups.length === 0 ||
@@ -63,7 +66,6 @@ export function validateDashboard(data) {
   ) {
     throw new TypeError("Invalid pipeline dashboard");
   }
-  let hasFacetGroups = false;
   for (const group of data.groups) {
     if (
       typeof group.id !== "string" ||
@@ -84,7 +86,6 @@ export function validateDashboard(data) {
       }
       if (product.facet_groups != null) {
         if (
-          data.v !== 2 ||
           !Array.isArray(product.facet_groups) ||
           product.facet_groups.length === 0 ||
           !product.facet_groups.every(
@@ -96,24 +97,20 @@ export function validateDashboard(data) {
         ) {
           throw new TypeError("Invalid pipeline facet group");
         }
-        hasFacetGroups = true;
       }
       for (const init of product.recent_inits) {
-        if (init.facets != null && (data.v !== 2 || !validFacets(init.facets))) {
+        if (init.facets != null && !validFacets(init.facets)) {
           throw new TypeError("Invalid pipeline facet");
         }
         // the lead × facet joint: the same facet shape, reported per lead group
         for (const group of init.lead_groups ?? []) {
           if (group.facets == null) continue;
-          if (data.v !== 2 || !validFacets(group.facets)) {
+          if (!validFacets(group.facets)) {
             throw new TypeError("Invalid pipeline facet");
           }
         }
       }
     }
-  }
-  if (data.v === 2 && !hasFacetGroups) {
-    throw new TypeError("Invalid pipeline dashboard");
   }
   return data;
 }
@@ -368,27 +365,43 @@ export function leadExtents(product) {
   );
 }
 
+/* How tall a view draws. The label rows have fixed heights, so this needs no
+   measurement — which matters because the render pass writes without reading. */
+
+function chromePx(view, rows) {
+  const head = view.dimension ? LABEL_PX + BAND_GAP_PX : 0;
+  const tiers = FOOT_GAP_PX + 2 * (LABEL_PX + BAND_GAP_PX);
+  return head + tiers + BAND_GAP_PX * Math.max(0, rows - 1);
+}
+
+function viewHeightPx(product, view) {
+  const bands = view.dimension
+    ? facetRowsOf(product, view.dimension).map(() => CELL_PX)
+    : [...leadExtents(product).values()];
+  const rows = bands.length || 1;
+  return bands.reduce((sum, px) => sum + px, 0) + chromePx(view, rows);
+}
+
+
+
+/* The box every view of a product sits in: the tallest one. Clicking through
+   the views then never moves the rest of the page. */
+
+export function reservedHeightPx(product) {
+  return Math.max(
+    ...viewsOf(product).map((view) => viewHeightPx(product, view)),
+  );
+}
+
 /* The bands of the marginal field, top row first: longest horizon down to the
    floor, then a band per facet grouped by dimension. Bands come from the product
    rather than one run, so the field keeps its shape as runs scroll through it. */
 
 export function bandsOf(product) {
-  const newest = product.recent_inits?.at(-1);
-  // the banded field stacks bottom-up, so the longest horizon is the top row
+  // the lead grid stacks bottom-up, so the longest horizon is the top row
   const leads = [...leadAxis(product)].reverse();
 
-  const declaredFacets = product.facet_groups?.length
-    ? product.facet_groups
-    : (newest?.facets ?? []);
-  const facets = declaredFacets.map((facet) => ({
-    kind: "facet",
-    key: facet.name,
-    label: facet.label,
-    dimension: facet.dimension,
-  }));
-  // with the joint, facets sit inside their lead band and a band of their own
-  // would only repeat the run total
-  return usesFacetRows(product) ? leads : [...leads, ...facets];
+  return leads;
 }
 
 /* The facets of one lead group in one run, in the product's declared order.
@@ -705,7 +718,7 @@ function renderFacetRows(product, local, runCount, dimension) {
     class: "pipeline-field",
     // lead time runs across here, so progress fills across too
     "data-fill": "side",
-    style: `--sq:${CELL_PX}px;--clump-gap:${CLUMP_GAP_PX}px;--clumped-run-gap:${CLUMPED_RUN_GAP_PX}px;--band-gutter:${gutterPx(facets)}px;--run-width:${runWidth}px`,
+    style: `--sq:${CELL_PX}px;--clump-gap:${CLUMP_GAP_PX}px;--clumped-run-gap:${CLUMPED_RUN_GAP_PX}px;--band-gutter:${gutterPx(facets)}px;--run-width:${runWidth}px;--band-gap:${BAND_GAP_PX}px;--label-h:${LABEL_PX}px;--reserve:${reservedHeightPx(product)}px`,
   });
 
   // the lead order repeats in every run, so name it once over the first block
@@ -737,8 +750,10 @@ function renderFacetRows(product, local, runCount, dimension) {
     }),
   );
 
+  // one container so the rows share out whatever height the box leaves them
+  const rowsNode = element("div", { class: "pipeline-rows" });
   for (const facet of facets) {
-    field.append(
+    rowsNode.append(
       bandNode({
         kind: "facet",
         label: facet.label,
@@ -773,6 +788,8 @@ function renderFacetRows(product, local, runCount, dimension) {
       }),
     );
   }
+  field.append(rowsNode);
+
 
   field.append(...initTiers(runs, local));
   return field;
@@ -785,7 +802,7 @@ function renderField(product, local, runCount) {
   const field = element("div", {
     class: "pipeline-field",
     // a cell is as wide as its init label; the lead axis keeps its own scale
-    style: `--sq:${column}px;--run-gap:${RUN_GAP_PX}px;--clumped-run-gap:${RUN_GAP_PX}px;--run-width:${column}px;--band-gutter:${gutterPx(bandsOf(product))}px`,
+    style: `--sq:${column}px;--run-gap:${RUN_GAP_PX}px;--clumped-run-gap:${RUN_GAP_PX}px;--run-width:${column}px;--band-gutter:${gutterPx(bandsOf(product))}px;--band-gap:${BAND_GAP_PX}px;--label-h:${LABEL_PX}px;--reserve:${reservedHeightPx(product)}px`,
   });
   let dimension = null;
 
@@ -1026,7 +1043,16 @@ function buildDetails(product, now, local) {
             value: String(facet.completion),
             "aria-label": `${Math.round(facet.completion * 100)}% complete`,
           }),
-          ` ${Math.round(facet.completion * 100)}%`,
+          // the number holds three characters whatever it is — "5", "62", "100" —
+          // so every bar ends in the same place, with the sign kept against it
+          element("span", { class: "pipeline-facet-pct" }, [
+            element(
+              "span",
+              { class: "pipeline-facet-num" },
+              String(Math.round(facet.completion * 100)),
+            ),
+            "%",
+          ]),
         ]),
       ]),
     );
@@ -1034,7 +1060,7 @@ function buildDetails(product, now, local) {
   const facetTable = element("table", { class: "pipeline-facets" }, [
     element("thead", null, [
       element("tr", null, [
-        element("th", { colspan: "5" }, "arrival coverage"),
+        element("th", { colspan: "5" }, "arrival facets"),
       ]),
       element("tr", null, [
         element("th", null, "dimension"),

--- a/public/pipeline.mjs
+++ b/public/pipeline.mjs
@@ -12,14 +12,15 @@ const FETCH_TIMEOUT_MS = 10_000;
 const DASHBOARD_VERSIONS = new Set([1, 2]);
 // Field geometry. JS owns these because the run count is computed from them;
 // the CSS reads them back off the field as custom properties.
-const SQUARE_PX = 8;
-const CLUMP_GAP_PX = 1; // between facet squares within one run
-const RUN_GAP_PX = 2; // between runs of a single square
-const CLUMPED_RUN_GAP_PX = 6; // between runs of a clump, which needs daylight
+const CELL_PX = 12; // one measurement, the same size in every view
+const CLUMP_GAP_PX = 2; // between the lead columns within one run
+const RUN_GAP_PX = 2; // between runs, in the lead grid
+const CLUMPED_RUN_GAP_PX = 6; // between run blocks, which need daylight
+// no lead group is thinner than its own label: "0h" is two characters, which is
+// exactly one cell, so every group can name itself
+const MIN_LEAD_PX = 12;
 const CH_PX = 6; // one monospace character at the band-label size
 const GUTTER_MAX_CH = 24; // long facet labels get room, but not unbounded
-const FACET_SQUARE_PX = 12; // wide enough for a lead label over each column
-const FACET_GAP_PX = 2; // and enough air that the labels do not touch
 const RUNS_MAX = 10; // what the payload carries
 
 function hasTimestamp(value) {
@@ -339,6 +340,34 @@ export function leadAxis(product) {
   }));
 }
 
+/* How much of the lead axis each group takes. Main's bars sized a segment by
+   the group's share of the run's expected files, and this keeps that reading:
+   the cell size is constant across views, and the lead dimension stretches.
+   The total stays what uniform cells would have occupied, so a view's footprint
+   does not change, and a floor keeps the smallest group from vanishing — GEFS
+   f000 is 0.7% of its run, which would round to nothing. */
+
+export function leadExtents(product) {
+  const leads = leadAxis(product);
+  const newest = product.recent_inits?.at(-1);
+  const slices = leadSlices(newest?.lead_groups ?? []);
+  const expected = leads.map(
+    (lead) => slices.find((slice) => slice.name === lead.key)?.expected ?? 0,
+  );
+  const total = expected.reduce((sum, count) => sum + count, 0);
+  // every group starts at its label's width, then shares out an allowance the
+  // size of the axis again — so the biggest group reads as biggest without the
+  // smallest becoming a sliver that cannot name itself
+  const allowance = leads.length * CELL_PX;
+  return new Map(
+    leads.map((lead, index) => [
+      lead.key,
+      MIN_LEAD_PX +
+        (total ? expected[index] / total : 1 / leads.length) * allowance,
+    ]),
+  );
+}
+
 /* The bands of the marginal field, top row first: longest horizon down to the
    floor, then a band per facet grouped by dimension. Bands come from the product
    rather than one run, so the field keeps its shape as runs scroll through it. */
@@ -412,8 +441,25 @@ export function runsThatFit(product, availablePx) {
   return runsFitting(
     availablePx,
     gutterPx(bandsOf(product)),
-    SQUARE_PX,
+    CELL_PX,
     RUN_GAP_PX,
+  );
+}
+
+/* A facet grid spends its width on lead columns inside every run, and those
+   columns are proportional, so the block width comes from the extents. */
+
+export function runsThatFitFacetRows(product, availablePx, dimension) {
+  const leads = leadAxis(product);
+  const extents = leadExtents(product);
+  const runWidth =
+    leads.reduce((sum, lead) => sum + (extents.get(lead.key) ?? CELL_PX), 0) +
+    Math.max(0, leads.length - 1) * CLUMP_GAP_PX;
+  return runsFitting(
+    availablePx,
+    gutterPx(facetRowsOf(product, dimension)),
+    runWidth,
+    CLUMPED_RUN_GAP_PX,
   );
 }
 
@@ -425,9 +471,10 @@ function bandNode({
   label = "",
   labelTitle,
   clumped = false,
+  style,
   children,
 }) {
-  return element("div", { class: className, "data-kind": kind }, [
+  return element("div", { class: className, "data-kind": kind, style }, [
     element("span", { class: "pipeline-band-label", title: labelTitle }, label),
     element(
       "div",
@@ -497,7 +544,7 @@ export function cellTitle(band, init, cell, local) {
     .join(" · ");
 }
 
-function renderCell(band, init, local, measured) {
+function renderCell(band, init, local, measured, style) {
   const cell = measured ?? cellOf(band, init);
   return element(
     "div",
@@ -506,6 +553,7 @@ function renderCell(band, init, local, measured) {
       "data-init-time": init?.init_time,
       "data-timing": cell.timing,
       title: cellTitle(band, init, cell, local),
+      style,
     },
     element("div", {
       class: "pipeline-cell-fill",
@@ -517,7 +565,7 @@ function renderCell(band, init, local, measured) {
 /* The facet-row field spends width on lead-group columns inside every run, so
    it needs its own fit. */
 
-export function facetRowsOf(product) {
+export function facetRowsOf(product, dimension) {
   // every facet the joint mentions anywhere in the displayed runs: the newest
   // run may report none yet, and a rollout or rollback can leave the window
   // mixed, but those rows still have measurements in the runs beside them
@@ -537,7 +585,28 @@ export function facetRowsOf(product) {
   const undeclared = [...reported.values()].filter(
     (facet) => !declared.some((entry) => entry.name === facet.name),
   );
-  return [...declared, ...undeclared];
+  const rows = [...declared, ...undeclared];
+  return dimension ? rows.filter((facet) => facet.dimension === dimension) : rows;
+}
+
+/* The views a product offers, in click order: the lead grid it opens on, then
+   one grid per facet dimension the joint reports. A product without a joint
+   offers the lead grid alone, so clicking it does nothing. */
+
+export function viewsOf(product) {
+  const dimensions = [];
+  for (const facet of facetRowsOf(product)) {
+    if (!dimensions.includes(facet.dimension)) dimensions.push(facet.dimension);
+  }
+  return [
+    { rows: "lead time", dimension: null },
+    ...dimensions.map((dimension) => ({ rows: dimension, dimension })),
+  ];
+}
+
+export function viewAt(product, index) {
+  const views = viewsOf(product);
+  return views[((index % views.length) + views.length) % views.length];
 }
 
 /* The layout only transposes when there are rows to draw. Without this a joint
@@ -545,17 +614,6 @@ export function facetRowsOf(product) {
 
 export function usesFacetRows(product) {
   return hasJointFacets(product) && facetRowsOf(product).length > 0;
-}
-
-export function runsThatFitFacetRows(product, availablePx) {
-  // a run is still the group: one square per lead group inside it
-  const leads = Math.max(1, leadAxis(product).length);
-  return runsFitting(
-    availablePx,
-    gutterPx(facetRowsOf(product)),
-    leads * FACET_SQUARE_PX + (leads - 1) * FACET_GAP_PX,
-    CLUMPED_RUN_GAP_PX,
-  );
 }
 
 /* The joint, indexed once per render: which facets a run reported under a lead
@@ -599,16 +657,19 @@ function labelTier({ bandClass = "pipeline-band", spanClass, runs, textOf }) {
    lead group inside a block. Same squares and same hover labels as the banded
    field — only which dimension owns which axis changes. */
 
-function renderFacetRows(product, local, runCount) {
+function renderFacetRows(product, local, runCount, dimension) {
   const runs = product.recent_inits.slice(-Math.max(1, runCount || RUNS_MAX));
   const leads = leadAxis(product); // shortest horizon first
-  const facets = facetRowsOf(product);
+  const facets = facetRowsOf(product, dimension);
   const joint = jointIndex(product, runs, leads);
+  const extents = leadExtents(product);
+  const leadWidth = (lead) => extents.get(lead.key) ?? CELL_PX;
   const runWidth =
-    leads.length * FACET_SQUARE_PX + (leads.length - 1) * FACET_GAP_PX;
+    leads.reduce((sum, lead) => sum + leadWidth(lead), 0) +
+    (leads.length - 1) * CLUMP_GAP_PX;
   const field = element("div", {
     class: "pipeline-field",
-    style: `--sq:${FACET_SQUARE_PX}px;--clump-gap:${FACET_GAP_PX}px;--clumped-run-gap:${CLUMPED_RUN_GAP_PX}px;--band-gutter:${gutterPx(facets)}px;--run-width:${runWidth}px`,
+    style: `--sq:${CELL_PX}px;--clump-gap:${CLUMP_GAP_PX}px;--clumped-run-gap:${CLUMPED_RUN_GAP_PX}px;--band-gutter:${gutterPx(facets)}px;--run-width:${runWidth}px`,
   });
 
   // the lead order repeats in every run, so name it once over the first block
@@ -620,15 +681,21 @@ function renderFacetRows(product, local, runCount) {
         element(
           "div",
           { class: "pipeline-clump" },
-          leads.map((lead) =>
-            element(
+          leads.map((lead) => {
+            // a proportional column can be narrower than its own name; the
+            // ones that cannot hold their label keep it on hover only
+            const width = leadWidth(lead);
+            const fits = width >= lead.label.length * CH_PX;
+            return element(
               "span",
-              index === 0
-                ? { class: "pipeline-column-label", title: `lead ${lead.label}` }
-                : { class: "pipeline-column-label" },
-              index === 0 ? lead.label : "",
-            ),
-          ),
+              {
+                class: "pipeline-column-label",
+                style: `--cell-w:${width.toFixed(2)}px`,
+                title: `lead ${lead.label}`,
+              },
+              index === 0 && fits ? lead.label : "",
+            );
+          }),
         ),
       ),
     }),
@@ -662,6 +729,7 @@ function renderFacetRows(product, local, runCount) {
                 facetAt
                   ? facetCell(facetAt, init, measured.timing)
                   : { state: "unobserved" },
+                `--cell-w:${leadWidth(lead).toFixed(2)}px`,
               );
             }),
           ),
@@ -699,9 +767,10 @@ function renderFacetRows(product, local, runCount) {
 
 function renderField(product, local, runCount) {
   const runs = product.recent_inits.slice(-Math.max(1, runCount || RUNS_MAX));
+  const extents = leadExtents(product);
   const field = element("div", {
     class: "pipeline-field",
-    style: `--sq:${SQUARE_PX}px;--run-gap:${RUN_GAP_PX}px;--band-gutter:${gutterPx(bandsOf(product))}px`,
+    style: `--sq:${CELL_PX}px;--run-gap:${RUN_GAP_PX}px;--band-gutter:${gutterPx(bandsOf(product))}px`,
   });
   let dimension = null;
 
@@ -719,6 +788,11 @@ function renderField(product, local, runCount) {
         kind: band.kind,
         label: band.label,
         labelTitle: band.label,
+        // a lead band is as tall as its share of the run; a facet band is a cell
+        style:
+          band.kind === "lead"
+            ? `--cell-h:${(extents.get(band.key) ?? CELL_PX).toFixed(2)}px`
+            : null,
         children: runs.map((init) => renderCell(band, init, local)),
       }),
     );
@@ -770,7 +844,7 @@ function renderStructure(app, dashboard, rows) {
             ]),
           ]),
           element("div", { class: "pipeline-row-body" }, [
-            element("div", { "data-slot": "field" }),
+            element("div", { class: "pipeline-viz", "data-slot": "field" }),
           ]),
           element("div", { class: "pipeline-stats" }, [
             element("strong", { "data-slot": "eta-init" }, "—"),
@@ -976,17 +1050,43 @@ function buildDetails(product, now, local) {
 }
 
 function hydrateRow(row, product, now, local, available) {
-  // with the joint, facets get their own labelled rows; without it, the two
-  // published marginals get their own bands
-  const nested = usesFacetRows(product);
-  const runCount = nested
-    ? runsThatFitFacetRows(product, available)
-    : runsThatFit(product, available);
-  row
-    .querySelector('[data-slot="field"]')
-    .replaceChildren(
-      (nested ? renderFacetRows : renderField)(product, local, runCount),
+  // the lead grid is the view a row opens on; the facet grids are a click away
+  const views = viewsOf(product);
+  const index = Number(row.dataset.view ?? 0) % views.length;
+  const view = views[index];
+  row.dataset.view = String(index);
+
+  const field = view.dimension
+    ? renderFacetRows(
+        product,
+        local,
+        runsThatFitFacetRows(product, available, view.dimension),
+        view.dimension,
+      )
+    : renderField(product, local, runsThatFit(product, available));
+
+  const viz = row.querySelector('[data-slot="field"]');
+  viz.replaceChildren(field);
+  // only worth announcing when there is somewhere to click to
+  if (views.length > 1) {
+    const next = views[(index + 1) % views.length];
+    field.append(
+      element(
+        "div",
+        { class: "pipeline-view-hint" },
+        view.dimension
+          ? `rows: ${view.rows} · columns: lead time · click for ${next.rows}`
+          : `rows: lead time · columns: init · click for ${next.rows}`,
+      ),
     );
+    viz.setAttribute("role", "button");
+    viz.setAttribute("tabindex", "0");
+    viz.setAttribute("aria-label", `${view.rows} by lead group; activate for ${next.rows}`);
+  } else {
+    viz.removeAttribute("role");
+    viz.removeAttribute("tabindex");
+    viz.removeAttribute("aria-label");
+  }
   hydrateEta(row, product, now, local);
 
   const button = row.querySelector('[data-slot="details-button"]');
@@ -1134,6 +1234,41 @@ function start(app) {
     displayedAt = now;
     renderSnapshot(app, snapshot, rows, now);
   }
+
+  /* Clicking a product's field cycles its rows: lead time, then one grid per
+     facet dimension. The listener is delegated to the group container so it
+     survives every re-render, and the view index lives on the row. */
+
+  function cycleView(row) {
+    if (!row || !displayedSnapshot) return;
+    const product = productsOf(displayedSnapshot).find(
+      (entry) => entry.id === row.dataset.productId,
+    );
+    if (!product || viewsOf(product).length < 2) return;
+    row.dataset.view = String(Number(row.dataset.view ?? 0) + 1);
+    const body = row.querySelector(".pipeline-row-body");
+    hydrateRow(
+      row,
+      product,
+      displayedAt ?? Date.now(),
+      document.body.classList.contains("pipeline-time-local"),
+      body?.getBoundingClientRect().width ?? 0,
+    );
+  }
+
+  const groupsSlot = app.querySelector('[data-slot="groups"]');
+  groupsSlot.addEventListener("click", (event) => {
+    // the details button and any link keep their own behaviour
+    if (event.target.closest("button, a, summary")) return;
+    cycleView(event.target.closest(".pipeline-viz")?.closest(".pipeline-row"));
+  });
+  groupsSlot.addEventListener("keydown", (event) => {
+    if (event.key !== "Enter" && event.key !== " ") return;
+    const viz = event.target.closest?.(".pipeline-viz");
+    if (!viz) return;
+    event.preventDefault();
+    cycleView(viz.closest(".pipeline-row"));
+  });
 
   // the run count comes from the measured row, so a resize has to re-fit
   let refitTimer = null;

--- a/public/pipeline.mjs
+++ b/public/pipeline.mjs
@@ -282,12 +282,14 @@ function leadSlices(groups) {
    product rather than a single run so the field keeps its shape as runs
    scroll through it. */
 
-/* True once a payload reports facets per lead group. Until then the two
-   published marginals are all there is, and facets get their own bands. */
+/* True once a payload reports facets per lead group. An empty array is a
+   validated, supported input — a run that reported nothing yet — so it does not
+   count as a joint. Until a real one arrives the two published marginals are all
+   there is, and facets get their own bands. */
 
 export function hasJointFacets(product) {
   return (product.recent_inits ?? []).some((init) =>
-    (init.lead_groups ?? []).some((group) => Array.isArray(group.facets)),
+    (init.lead_groups ?? []).some((group) => group.facets?.length),
   );
 }
 
@@ -318,7 +320,7 @@ export function bandsOf(product) {
   }));
   // with the joint, facets sit inside their lead band and a band of their own
   // would only repeat the run total
-  return hasJointFacets(product) ? leads : [...leads, ...facets];
+  return usesFacetRows(product) ? leads : [...leads, ...facets];
 }
 
 /* The facets of one lead group in one run, in the product's declared order.
@@ -354,7 +356,7 @@ export function bandGutterCh(product) {
 }
 
 export function runsThatFit(product, availablePx) {
-  const clumped = hasJointFacets(product);
+  const clumped = usesFacetRows(product);
   const widest = clumped
     ? Math.max(
         1,
@@ -456,13 +458,33 @@ function renderCell(band, init, local, measured) {
    it needs its own fit. */
 
 export function facetRowsOf(product) {
-  const newest = product.recent_inits?.at(-1);
-  const leads = bandsOf(product);
-  return (product.facet_groups ?? []).filter((facet) =>
-    leads.some((lead) =>
-      facetsAt(product, newest, lead.key).some((entry) => entry.name === facet.name),
-    ),
+  // every facet the joint mentions anywhere in the displayed runs: the newest
+  // run may report none yet, and a rollout or rollback can leave the window
+  // mixed, but those rows still have measurements in the runs beside them
+  const reported = new Map();
+  for (const init of product.recent_inits ?? []) {
+    for (const group of init.lead_groups ?? []) {
+      for (const facet of group.facets ?? []) {
+        if (!reported.has(facet.name)) reported.set(facet.name, facet);
+      }
+    }
+  }
+  // the declared schema owns the order; anything it never declares still gets a
+  // row, since the payload measured it
+  const declared = (product.facet_groups ?? []).filter((facet) =>
+    reported.has(facet.name),
   );
+  const undeclared = [...reported.values()].filter(
+    (facet) => !declared.some((entry) => entry.name === facet.name),
+  );
+  return [...declared, ...undeclared];
+}
+
+/* The layout only transposes when there are rows to draw. Without this a joint
+   that reports nothing would hide the lead measurements it replaced. */
+
+export function usesFacetRows(product) {
+  return hasJointFacets(product) && facetRowsOf(product).length > 0;
 }
 
 function facetRowsGutterCh(product) {
@@ -639,7 +661,7 @@ function renderField(product, local, runCount) {
     }
     dimension = band.kind === "facet" ? band.dimension : null;
 
-    const clumped = band.kind === "lead" && hasJointFacets(product);
+    const clumped = band.kind === "lead" && usesFacetRows(product);
     const cells = element("div", {
       class: "pipeline-cells",
       "data-clumped": clumped ? "" : null,
@@ -950,7 +972,7 @@ function hydrateRow(row, product, now, local) {
   const available = body?.getBoundingClientRect().width ?? 0;
   // with the joint, facets get their own labelled rows; without it, the two
   // published marginals get their own bands
-  const nested = hasJointFacets(product);
+  const nested = usesFacetRows(product);
   const runCount = nested
     ? runsThatFitFacetRows(product, available)
     : runsThatFit(product, available);
@@ -1103,7 +1125,13 @@ function start(app) {
   window.addEventListener("resize", () => {
     clearTimeout(refitTimer);
     refitTimer = setTimeout(() => {
-      if (displayedSnapshot) displaySnapshot(displayedSnapshot, Date.now());
+      if (!displayedSnapshot) return;
+      // a scrubbed snapshot keeps the time it was displayed at, exactly as the
+      // time-mode handler does — re-timing it to now invents latencies
+      displaySnapshot(
+        displayedSnapshot,
+        mode === "live" ? Date.now() : displayedAt,
+      );
     }, 150);
   });
 

--- a/public/pipeline.mjs
+++ b/public/pipeline.mjs
@@ -167,22 +167,48 @@ function formatDuration(seconds) {
   return `${Math.floor(seconds / 60)}m ${seconds % 60}s`;
 }
 
+/* Every square carries a hover label, so a faceted row asks for hundreds of
+   formatted init times per render. Constructing an Intl formatter each time
+   dominated the render; these two caches are keyed by the only things that
+   vary. */
+
+const initFormatters = new Map();
+const initPartCache = new Map();
+const INIT_PART_CACHE_MAX = 4096;
+
+function initFormatter(timeZone) {
+  let formatter = initFormatters.get(timeZone);
+  if (!formatter) {
+    formatter = new Intl.DateTimeFormat("en-US", {
+      month: "2-digit",
+      day: "2-digit",
+      hour: "2-digit",
+      hourCycle: "h23",
+      timeZone,
+      timeZoneName: "short",
+    });
+    initFormatters.set(timeZone, formatter);
+  }
+  return formatter;
+}
+
 export function initParts(timestamp, timeZone = "UTC") {
-  const parts = new Intl.DateTimeFormat("en-US", {
-    month: "2-digit",
-    day: "2-digit",
-    hour: "2-digit",
-    hourCycle: "h23",
-    timeZone,
-    timeZoneName: "short",
-  }).formatToParts(new Date(timestamp));
+  const key = `${timestamp}|${timeZone}`;
+  const cached = initPartCache.get(key);
+  if (cached) return cached;
+
+  const parts = initFormatter(timeZone).formatToParts(new Date(timestamp));
   const part = (type) =>
     parts.find((candidate) => candidate.type === type)?.value;
   const hour = part("hour");
-  return {
+  const value = {
     date: `${part("month")}-${part("day")}`,
     time: timeZone === "UTC" ? `${hour}z` : `${hour} ${part("timeZoneName")}`,
   };
+  // scrubbing through history would otherwise grow this without bound
+  if (initPartCache.size >= INIT_PART_CACHE_MAX) initPartCache.clear();
+  initPartCache.set(key, value);
+  return value;
 }
 
 const validTimeZoneCache = new Map();
@@ -203,10 +229,17 @@ function isValidTimeZone(timeZone) {
   return valid;
 }
 
+// Resolved once, after validation: every hover label asks for the zone, and both
+// resolving and validating it mean constructing a formatter.
+let localZone = null;
+
 export function selectedTimeZone(local) {
   if (!local) return "UTC";
-  const resolved = Intl.DateTimeFormat().resolvedOptions().timeZone;
-  return isValidTimeZone(resolved) ? resolved : "UTC";
+  if (localZone === null) {
+    const resolved = Intl.DateTimeFormat().resolvedOptions().timeZone;
+    localZone = isValidTimeZone(resolved) ? resolved : "UTC";
+  }
+  return localZone;
 }
 
 function initShort(timestamp, local) {
@@ -253,8 +286,7 @@ function timeNode(timestamp) {
 }
 
 /* One square per measurement. Lead-group counts arrive cumulative, so a band's
-   own share is the difference from the band below it — the same arithmetic the
-   bars used for segment heights. */
+   own share is the difference from the band below it. */
 
 function leadSlices(groups) {
   let previousAvailable = 0;
@@ -277,11 +309,6 @@ function leadSlices(groups) {
   });
 }
 
-/* The bands of a product's field, top row first: longest horizon down to the
-   floor, then a band per facet grouped by dimension. Bands come from the
-   product rather than a single run so the field keeps its shape as runs
-   scroll through it. */
-
 /* True once a payload reports facets per lead group. An empty array is a
    validated, supported input — a run that reported nothing yet — so it does not
    count as a joint. Until a real one arrives the two published marginals are all
@@ -293,21 +320,33 @@ export function hasJointFacets(product) {
   );
 }
 
-export function bandsOf(product) {
+/* The lead groups a product measures, shortest horizon first — the order the
+   payload declares them in. History snapshots declare neither list up front,
+   so both fall back to the newest run's own. */
+
+export function leadAxis(product) {
   const newest = product.recent_inits?.at(-1);
-  // history snapshots carry the same runs but declare neither list up front
   const labelOf = new Map(
     (product.lead_group_stats ?? []).map((stats) => [stats.name, stats.label]),
   );
-  const declaredLeads = product.lead_groups?.length
+  const declared = product.lead_groups?.length
     ? product.lead_groups
     : (newest?.lead_groups ?? []);
-  const leads = declaredLeads.map((group) => ({
+  return declared.map((group) => ({
     kind: "lead",
     key: group.name,
     label: group.label ?? labelOf.get(group.name) ?? group.name,
   }));
-  leads.reverse();
+}
+
+/* The bands of the marginal field, top row first: longest horizon down to the
+   floor, then a band per facet grouped by dimension. Bands come from the product
+   rather than one run, so the field keeps its shape as runs scroll through it. */
+
+export function bandsOf(product) {
+  const newest = product.recent_inits?.at(-1);
+  // the banded field stacks bottom-up, so the longest horizon is the top row
+  const leads = [...leadAxis(product)].reverse();
 
   const declaredFacets = product.facet_groups?.length
     ? product.facet_groups
@@ -334,47 +373,68 @@ export function facetsAt(product, init, leadName) {
   const order = (product.facet_groups ?? []).map((facet) => facet.name);
   const measured = new Map(group.facets.map((facet) => [facet.name, facet]));
   const ordered = order.length ? order : group.facets.map((f) => f.name);
-  // a facet absent at this lead leaves the clump one square narrower
+  // a facet absent at this lead simply has no square
   return ordered
     .map((name) => measured.get(name))
     .filter(Boolean);
 }
 
-/* How many runs fit. A run is one square when there is no joint and a clump of
-   facet squares when there is, so the answer depends on the product, not just
-   the viewport. Falls back to everything the payload carries when the width is
-   not measurable yet. */
+/* The label gutter is only as wide as the labels beside it. Lead-only rows read
+   "3d"; a facet row reads "precipitation and snow". Sizing it per product is
+   what keeps the strip from starting a third of the way in. Stated in px, not
+   ch: CSS resolves ch against the band's inherited font, which is not the
+   font these labels are set in. */
 
-/* The label gutter is only as wide as the labels a product actually renders.
-   Lead-only rows read "3d"; a facet row reads "precipitation and snow". Sizing
-   it per product is what keeps the strip from starting a third of the way in. */
-
-export function bandGutterCh(product) {
-  const labels = bandsOf(product).map((band) => band.label ?? "");
-  const widest = labels.reduce((max, label) => Math.max(max, label.length), 2);
-  return Math.min(GUTTER_MAX_CH, widest);
+export function gutterPx(labelled) {
+  const widest = labelled.reduce(
+    (max, entry) => Math.max(max, (entry.label ?? "").length),
+    2,
+  );
+  return Math.min(GUTTER_MAX_CH, widest) * CH_PX;
 }
 
-export function runsThatFit(product, availablePx) {
-  const clumped = usesFacetRows(product);
-  const widest = clumped
-    ? Math.max(
-        1,
-        ...(product.recent_inits ?? []).flatMap((init) =>
-          bandsOf(product).map(
-            (band) => facetsAt(product, init, band.key).length,
-          ),
-        ),
-      )
-    : 1;
-  const runWidth = widest * SQUARE_PX + (widest - 1) * CLUMP_GAP_PX;
-  const gap = clumped ? CLUMPED_RUN_GAP_PX : RUN_GAP_PX;
+/* How many runs fit, given what one run costs. Both layouts share the whole
+   calculation and differ only in that width. */
+
+function runsFitting(availablePx, gutter, runWidth, gap) {
   // an unmeasured row shows everything rather than nothing
   if (!Number.isFinite(availablePx) || availablePx <= 0) return RUNS_MAX;
   // 6px band gap, and 4px of slack so a font fallback cannot overflow the row
-  const usable = availablePx - bandGutterCh(product) * CH_PX - 6 - 4;
+  const usable = availablePx - gutter - 6 - 4;
   if (usable <= 0) return 1;
-  return Math.max(1, Math.min(RUNS_MAX, Math.floor((usable + gap) / (runWidth + gap))));
+  return Math.max(
+    1,
+    Math.min(RUNS_MAX, Math.floor((usable + gap) / (runWidth + gap))),
+  );
+}
+
+export function runsThatFit(product, availablePx) {
+  return runsFitting(
+    availablePx,
+    gutterPx(bandsOf(product)),
+    SQUARE_PX,
+    RUN_GAP_PX,
+  );
+}
+
+/* Every band is the same skeleton: a gutter label, then its row of cells. */
+
+function bandNode({
+  className = "pipeline-band",
+  kind,
+  label = "",
+  labelTitle,
+  clumped = false,
+  children,
+}) {
+  return element("div", { class: className, "data-kind": kind }, [
+    element("span", { class: "pipeline-band-label", title: labelTitle }, label),
+    element(
+      "div",
+      { class: "pipeline-cells", "data-clumped": clumped ? "" : null },
+      children,
+    ),
+  ]);
 }
 
 /* What one run measured for one band. A band the run never reported reads as
@@ -487,160 +547,153 @@ export function usesFacetRows(product) {
   return hasJointFacets(product) && facetRowsOf(product).length > 0;
 }
 
-function facetRowsGutterCh(product) {
-  return Math.min(
-    GUTTER_MAX_CH,
-    facetRowsOf(product).reduce(
-      (max, facet) => Math.max(max, facet.label.length),
-      2,
-    ),
-  );
-}
-
 export function runsThatFitFacetRows(product, availablePx) {
   // a run is still the group: one square per lead group inside it
-  const leads = Math.max(1, bandsOf(product).length);
-  const runWidth = leads * FACET_SQUARE_PX + (leads - 1) * FACET_GAP_PX;
-  if (!Number.isFinite(availablePx) || availablePx <= 0) return RUNS_MAX;
-  const usable = availablePx - facetRowsGutterCh(product) * CH_PX - 6 - 4;
-  if (usable <= 0) return 1;
-  return Math.max(
-    1,
-    Math.min(
-      RUNS_MAX,
-      Math.floor((usable + CLUMPED_RUN_GAP_PX) / (runWidth + CLUMPED_RUN_GAP_PX)),
-    ),
+  const leads = Math.max(1, leadAxis(product).length);
+  return runsFitting(
+    availablePx,
+    gutterPx(facetRowsOf(product)),
+    leads * FACET_SQUARE_PX + (leads - 1) * FACET_GAP_PX,
+    CLUMPED_RUN_GAP_PX,
   );
 }
 
-/* The facet-row field: one row per facet, one run per block, one column per
-   lead group inside a block. The runs
-   clumped inside each cell. Same squares and same titles as the banded field —
-   only which dimension owns which axis changes. */
+/* The joint, indexed once per render: which facets a run reported under a lead
+   group, and that group's timing. Built from `facetsAt` so the declared order
+   still decides, then read by name per square. */
+
+function jointIndex(product, runs, leads) {
+  const index = new Map();
+  for (const init of runs) {
+    const byLead = new Map();
+    for (const lead of leads) {
+      const facets = facetsAt(product, init, lead.key);
+      if (!facets.length) continue;
+      byLead.set(lead.key, {
+        // the lead group's own timing is more specific than the run's
+        timing:
+          (init.lead_groups ?? []).find((group) => group.name === lead.key)
+            ?.timing ?? init.timing,
+        facets: new Map(facets.map((facet) => [facet.name, facet])),
+      });
+    }
+    index.set(init, byLead);
+  }
+  return index;
+}
+
+/* One label tier under the blocks: a span per run, exactly one block wide, so
+   every tier centres on the same axis as the squares above it. */
+
+function labelTier({ bandClass = "pipeline-band", spanClass, runs, textOf }) {
+  return bandNode({
+    className: bandClass,
+    clumped: true,
+    children: runs.map((init) =>
+      element("span", { class: spanClass }, textOf(init)),
+    ),
+  });
+}
+
+/* The facet-row field: one row per facet, one block per run, one column per
+   lead group inside a block. Same squares and same hover labels as the banded
+   field — only which dimension owns which axis changes. */
 
 function renderFacetRows(product, local, runCount) {
   const runs = product.recent_inits.slice(-Math.max(1, runCount || RUNS_MAX));
-  const leads = [...bandsOf(product)].reverse(); // shortest horizon first
+  const leads = leadAxis(product); // shortest horizon first
   const facets = facetRowsOf(product);
+  const joint = jointIndex(product, runs, leads);
+  const runWidth =
+    leads.length * FACET_SQUARE_PX + (leads.length - 1) * FACET_GAP_PX;
   const field = element("div", {
-    class: "pipeline-field pipeline-field--facets",
-    style: `--sq:${FACET_SQUARE_PX}px;--clump-gap:${FACET_GAP_PX}px;--clumped-run-gap:${CLUMPED_RUN_GAP_PX}px;--band-gutter:${facetRowsGutterCh(product) * CH_PX}px;--leads:${leads.length}`,
+    class: "pipeline-field",
+    style: `--sq:${FACET_SQUARE_PX}px;--clump-gap:${FACET_GAP_PX}px;--clumped-run-gap:${CLUMPED_RUN_GAP_PX}px;--band-gutter:${gutterPx(facets)}px;--run-width:${runWidth}px`,
   });
 
   // the lead order repeats in every run, so name it once over the first block
   field.append(
-    element("div", { class: "pipeline-band pipeline-band--head" }, [
-      element("span", { class: "pipeline-band-label" }),
-      element(
-        "div",
-        { class: "pipeline-cells", "data-clumped": "" },
-        runs.map((init, index) =>
-          element(
-            "div",
-            { class: "pipeline-clump" },
-            index === 0
-              ? leads.map((lead) =>
-                  element(
-                    "span",
-                    { class: "pipeline-column-label", title: `lead ${lead.label}` },
-                    lead.label,
-                  ),
-                )
-              : leads.map(() => element("span", { class: "pipeline-column-label" })),
+    bandNode({
+      className: "pipeline-band pipeline-band--head",
+      clumped: true,
+      children: runs.map((init, index) =>
+        element(
+          "div",
+          { class: "pipeline-clump" },
+          leads.map((lead) =>
+            element(
+              "span",
+              index === 0
+                ? { class: "pipeline-column-label", title: `lead ${lead.label}` }
+                : { class: "pipeline-column-label" },
+              index === 0 ? lead.label : "",
+            ),
           ),
         ),
       ),
-    ]),
+    }),
   );
 
   for (const facet of facets) {
-    const cells = element("div", { class: "pipeline-cells", "data-clumped": "" });
-    for (const init of runs) {
-      const clump = element("div", { class: "pipeline-clump" });
-      for (const lead of leads) {
-        const measured = facetsAt(product, init, lead.key).find(
-          (entry) => entry.name === facet.name,
-        );
-        const band = {
-          kind: "facet",
-          key: facet.name,
-          label: facet.label,
-          dimension: facet.dimension,
-          lead: lead.label,
-        };
-        const timing = (init.lead_groups ?? []).find(
-          (group) => group.name === lead.key,
-        )?.timing;
-        clump.append(
-          renderCell(
-            band,
-            init,
-            local,
-            measured
-              ? facetCell(measured, init, timing ?? init.timing)
-              : { state: "unobserved" },
-          ),
-        );
-      }
-      cells.append(clump);
-    }
     field.append(
-      element("div", { class: "pipeline-band", "data-kind": "facet" }, [
-        element(
-          "span",
-          { class: "pipeline-band-label", title: `${facet.label} (${facet.dimension})` },
-          facet.label,
+      bandNode({
+        kind: "facet",
+        label: facet.label,
+        labelTitle: `${facet.label} (${facet.dimension})`,
+        clumped: true,
+        children: runs.map((init) =>
+          element(
+            "div",
+            { class: "pipeline-clump" },
+            leads.map((lead) => {
+              const measured = joint.get(init)?.get(lead.key);
+              const facetAt = measured?.facets.get(facet.name);
+              const band = {
+                kind: "facet",
+                key: facet.name,
+                label: facet.label,
+                dimension: facet.dimension,
+                lead: lead.label,
+              };
+              return renderCell(
+                band,
+                init,
+                local,
+                facetAt
+                  ? facetCell(facetAt, init, measured.timing)
+                  : { state: "unobserved" },
+              );
+            }),
+          ),
         ),
-        cells,
-      ]),
+      }),
     );
   }
 
-  // two tiers under the blocks: the init time on every block, then each date
-  // centred under the run of blocks that share it
+  // the init time under every block, then the date only where it turns over, so
+  // a date lines up with the first timestamp it covers
+  const zone = selectedTimeZone(local);
   field.append(
-    element("div", { class: "pipeline-band pipeline-band--foot" }, [
-      element("span", { class: "pipeline-band-label" }),
-      element(
-        "div",
-        { class: "pipeline-cells", "data-clumped": "" },
-        runs.map((init) =>
-          element(
-            "span",
-            {
-              class: "pipeline-run-label",
-              title: initShort(init.init_time, local),
-            },
-            initParts(init.init_time, selectedTimeZone(local)).time,
-          ),
-        ),
-      ),
-    ]),
+    labelTier({
+      bandClass: "pipeline-band pipeline-band--foot",
+      spanClass: "pipeline-run-label",
+      runs,
+      textOf: (init) => initParts(init.init_time, zone).time,
+    }),
   );
-
-  // the date tier mirrors the time tier block for block, carrying text only
-  // where the date turns over, so a date lines up with its first timestamp
   let previousDate = null;
   field.append(
-    element("div", { class: "pipeline-band pipeline-band--dates" }, [
-      element("span", { class: "pipeline-band-label" }),
-      element(
-        "div",
-        { class: "pipeline-cells", "data-clumped": "" },
-        runs.map((init) => {
-          const { date } = initParts(init.init_time, selectedTimeZone(local));
-          const turned = date !== previousDate;
-          previousDate = date;
-          return element(
-            "span",
-            { class: "pipeline-run-date" },
-            turned ? date : "",
-          );
-        }),
-      ),
-    ]),
+    labelTier({
+      spanClass: "pipeline-run-date",
+      runs,
+      textOf: (init) => {
+        const { date } = initParts(init.init_time, zone);
+        const turned = date !== previousDate;
+        previousDate = date;
+        return turned ? date : "";
+      },
+    }),
   );
-
   return field;
 }
 
@@ -648,7 +701,7 @@ function renderField(product, local, runCount) {
   const runs = product.recent_inits.slice(-Math.max(1, runCount || RUNS_MAX));
   const field = element("div", {
     class: "pipeline-field",
-    style: `--sq:${SQUARE_PX}px;--clump-gap:${CLUMP_GAP_PX}px;--run-gap:${RUN_GAP_PX}px;--clumped-run-gap:${CLUMPED_RUN_GAP_PX}px;--band-gutter:${bandGutterCh(product) * CH_PX}px`,
+    style: `--sq:${SQUARE_PX}px;--run-gap:${RUN_GAP_PX}px;--band-gutter:${gutterPx(bandsOf(product))}px`,
   });
   let dimension = null;
 
@@ -661,56 +714,13 @@ function renderField(product, local, runCount) {
     }
     dimension = band.kind === "facet" ? band.dimension : null;
 
-    const clumped = band.kind === "lead" && usesFacetRows(product);
-    const cells = element("div", {
-      class: "pipeline-cells",
-      "data-clumped": clumped ? "" : null,
-    });
-    for (const init of runs) {
-      if (!clumped) {
-        cells.append(renderCell(band, init, local));
-        continue;
-      }
-      // one square per facet, grouped inside the lead band it arrived under
-      const facets = facetsAt(product, init, band.key);
-      if (!facets.length) {
-        cells.append(renderCell(band, init, local));
-        continue;
-      }
-      // the lead group's own timing is more specific than the run's
-      const timing = (init.lead_groups ?? []).find(
-        (group) => group.name === band.key,
-      )?.timing;
-      cells.append(
-        element(
-          "div",
-          { class: "pipeline-clump" },
-          facets.map((facet) =>
-            renderCell(
-              {
-                kind: "facet",
-                key: facet.name,
-                label: facet.label,
-                dimension: facet.dimension,
-                lead: band.label,
-              },
-              init,
-              local,
-              facetCell(facet, init, timing ?? init.timing),
-            ),
-          ),
-        ),
-      );
-    }
     field.append(
-      element("div", { class: "pipeline-band", "data-kind": band.kind }, [
-        element(
-          "span",
-          { class: "pipeline-band-label", title: band.label },
-          band.label,
-        ),
-        cells,
-      ]),
+      bandNode({
+        kind: band.kind,
+        label: band.label,
+        labelTitle: band.label,
+        children: runs.map((init) => renderCell(band, init, local)),
+      }),
     );
   }
 
@@ -965,11 +975,7 @@ function buildDetails(product, now, local) {
   return element("div", null, [leadTable, facetTable]);
 }
 
-function hydrateRow(row, product, now, local) {
-  // the row body is a 1fr grid column, so its width is independent of the
-  // field it holds — measuring it cannot feed back into the fit
-  const body = row.querySelector(".pipeline-row-body");
-  const available = body?.getBoundingClientRect().width ?? 0;
+function hydrateRow(row, product, now, local, available) {
   // with the joint, facets get their own labelled rows; without it, the two
   // published marginals get their own bands
   const nested = usesFacetRows(product);
@@ -1075,9 +1081,18 @@ function renderSnapshot(app, snapshot, rows, now) {
   app
     .querySelector('[data-slot="generated-at"]')
     .replaceChildren(timeNode(snapshot.generated_at));
+  // measure every row before writing any of them: the row body is a 1fr grid
+  // column, so its width does not depend on the field it holds, and reading all
+  // the widths first costs one layout instead of one per product
+  const pending = [];
   for (const product of productsOf(snapshot)) {
     const row = rows.get(product.id);
-    if (row) hydrateRow(row, product, now, local);
+    if (!row) continue;
+    const body = row.querySelector(".pipeline-row-body");
+    pending.push([row, product, body?.getBoundingClientRect().width ?? 0]);
+  }
+  for (const [row, product, available] of pending) {
+    hydrateRow(row, product, now, local, available);
   }
   renderAdvisories(app, snapshot.advisories ?? [], rows);
 }

--- a/public/pipeline.mjs
+++ b/public/pipeline.mjs
@@ -21,6 +21,27 @@ function hasTimestamp(value) {
   );
 }
 
+function validFacets(facets) {
+  return (
+    Array.isArray(facets) &&
+    facets.every(
+      (facet) =>
+        typeof facet.dimension === "string" &&
+        typeof facet.name === "string" &&
+        typeof facet.label === "string" &&
+        Number.isInteger(facet.dependencies_available) &&
+        facet.dependencies_available >= 0 &&
+        Number.isInteger(facet.dependencies_expected) &&
+        facet.dependencies_expected > 0 &&
+        facet.dependencies_available <= facet.dependencies_expected &&
+        Number.isFinite(facet.completion_pct) &&
+        facet.completion_pct >= 0 &&
+        facet.completion_pct <= 1 &&
+        typeof facet.status === "string",
+    )
+  );
+}
+
 export function validateDashboard(data) {
   if (
     !data ||
@@ -68,27 +89,15 @@ export function validateDashboard(data) {
         hasFacetGroups = true;
       }
       for (const init of product.recent_inits) {
-        if (init.facets == null) continue;
-        if (
-          data.v !== 2 ||
-          !Array.isArray(init.facets) ||
-          !init.facets.every(
-            (facet) =>
-              typeof facet.dimension === "string" &&
-              typeof facet.name === "string" &&
-              typeof facet.label === "string" &&
-              Number.isInteger(facet.dependencies_available) &&
-              facet.dependencies_available >= 0 &&
-              Number.isInteger(facet.dependencies_expected) &&
-              facet.dependencies_expected > 0 &&
-              facet.dependencies_available <= facet.dependencies_expected &&
-              Number.isFinite(facet.completion_pct) &&
-              facet.completion_pct >= 0 &&
-              facet.completion_pct <= 1 &&
-              typeof facet.status === "string",
-          )
-        ) {
+        if (init.facets != null && (data.v !== 2 || !validFacets(init.facets))) {
           throw new TypeError("Invalid pipeline facet");
+        }
+        // the lead × facet joint: the same facet shape, reported per lead group
+        for (const group of init.lead_groups ?? []) {
+          if (group.facets == null) continue;
+          if (data.v !== 2 || !validFacets(group.facets)) {
+            throw new TypeError("Invalid pipeline facet");
+          }
         }
       }
     }
@@ -264,6 +273,15 @@ function leadSlices(groups) {
    product rather than a single run so the field keeps its shape as runs
    scroll through it. */
 
+/* True once a payload reports facets per lead group. Until then the two
+   published marginals are all there is, and facets get their own bands. */
+
+export function hasJointFacets(product) {
+  return (product.recent_inits ?? []).some((init) =>
+    (init.lead_groups ?? []).some((group) => Array.isArray(group.facets)),
+  );
+}
+
 export function bandsOf(product) {
   const newest = product.recent_inits?.at(-1);
   // history snapshots carry the same runs but declare neither list up front
@@ -289,7 +307,26 @@ export function bandsOf(product) {
     label: facet.label,
     dimension: facet.dimension,
   }));
-  return [...leads, ...facets];
+  // with the joint, facets sit inside their lead band and a band of their own
+  // would only repeat the run total
+  return hasJointFacets(product) ? leads : [...leads, ...facets];
+}
+
+/* The facets of one lead group in one run, in the product's declared order.
+   Empty when the payload reports no joint for that group. */
+
+export function facetsAt(product, init, leadName) {
+  const group = (init?.lead_groups ?? []).find(
+    (entry) => entry.name === leadName,
+  );
+  if (!Array.isArray(group?.facets)) return [];
+  const order = (product.facet_groups ?? []).map((facet) => facet.name);
+  const measured = new Map(group.facets.map((facet) => [facet.name, facet]));
+  const ordered = order.length ? order : group.facets.map((f) => f.name);
+  // a facet absent at this lead leaves the clump one square narrower
+  return ordered
+    .map((name) => measured.get(name))
+    .filter(Boolean);
 }
 
 /* What one run measured for one band. A band the run never reported reads as
@@ -313,9 +350,13 @@ export function cellOf(band, init) {
 
   const facet = (init.facets ?? []).find((entry) => entry.name === band.key);
   if (!facet) return { state: "unobserved" };
+  return facetCell(facet, init);
+}
+
+function facetCell(facet, init, timing = init.timing) {
   return {
     state: facet.status,
-    timing: init.timing,
+    timing,
     completion: facet.completion_pct ?? 0,
     available: facet.dependencies_available,
     expected: facet.dependencies_expected,
@@ -337,6 +378,8 @@ export function cellTitle(band, init, cell, local) {
       : `${Math.round((cell.completion ?? 0) * 100)}%`;
   return [
     band.kind === "facet" ? `${band.label} (${band.dimension})` : `lead ${band.label}`,
+    // a facet nested in a lead band names the lead it belongs to
+    band.lead ? `lead ${band.lead}` : null,
     when,
     volume,
     statusLabel(cell.state),
@@ -346,8 +389,8 @@ export function cellTitle(band, init, cell, local) {
     .join(" · ");
 }
 
-function renderCell(band, init, local) {
-  const cell = cellOf(band, init);
+function renderCell(band, init, local, measured) {
+  const cell = measured ?? cellOf(band, init);
   return element(
     "div",
     {
@@ -377,8 +420,47 @@ function renderField(product, local) {
     }
     dimension = band.kind === "facet" ? band.dimension : null;
 
-    const cells = element("div", { class: "pipeline-cells" });
-    for (const init of runs) cells.append(renderCell(band, init, local));
+    const clumped = band.kind === "lead" && hasJointFacets(product);
+    const cells = element("div", {
+      class: "pipeline-cells",
+      "data-clumped": clumped ? "" : null,
+    });
+    for (const init of runs) {
+      if (!clumped) {
+        cells.append(renderCell(band, init, local));
+        continue;
+      }
+      // one square per facet, grouped inside the lead band it arrived under
+      const facets = facetsAt(product, init, band.key);
+      if (!facets.length) {
+        cells.append(renderCell(band, init, local));
+        continue;
+      }
+      // the lead group's own timing is more specific than the run's
+      const timing = (init.lead_groups ?? []).find(
+        (group) => group.name === band.key,
+      )?.timing;
+      cells.append(
+        element(
+          "div",
+          { class: "pipeline-clump" },
+          facets.map((facet) =>
+            renderCell(
+              {
+                kind: "facet",
+                key: facet.name,
+                label: facet.label,
+                dimension: facet.dimension,
+                lead: band.label,
+              },
+              init,
+              local,
+              facetCell(facet, init, timing ?? init.timing),
+            ),
+          ),
+        ),
+      );
+    }
     field.append(
       element("div", { class: "pipeline-band", "data-kind": band.kind }, [
         element(

--- a/test/fixtures/pipeline-dashboard.json
+++ b/test/fixtures/pipeline-dashboard.json
@@ -1,5 +1,5 @@
 {
-  "v": 1,
+  "v": 2,
   "generated_at": "2026-07-25T18:00:00Z",
   "window_days": 90,
   "advisories": [
@@ -30,6 +30,13 @@
             {"name": "f024", "label": "1d", "leads_in_group": 5, "center_pct": 1.5},
             {"name": "f072", "label": "3d", "leads_in_group": 13, "center_pct": 4.5}
           ],
+          "facet_groups": [
+            {"dimension": "component", "name": "component:pgrb2a", "label": "pgrb2a"},
+            {"dimension": "component", "name": "component:pgrb2b", "label": "pgrb2b"},
+            {"dimension": "component", "name": "component:pgrb2s", "label": "pgrb2s"},
+            {"dimension": "member", "name": "members:control", "label": "control"},
+            {"dimension": "member", "name": "members:perturbed", "label": "perturbed"}
+          ],
           "latency_stats": {
             "p50_s": 3600,
             "p95_s": 5400,
@@ -51,7 +58,7 @@
             {"init_time": "2026-07-24T18:00:00Z", "status": "complete", "timing": "on_time", "completion_pct": 1, "latency_s": 3690, "lead_groups": [{"name": "f000", "status": "complete", "timing": "on_time", "completion_pct": 1, "latency_s": 840, "leads_available": 1, "leads_expected": 1}, {"name": "f024", "status": "complete", "timing": "on_time", "completion_pct": 1, "latency_s": 1830, "leads_available": 5, "leads_expected": 5}, {"name": "f072", "status": "complete", "timing": "on_time", "completion_pct": 1, "latency_s": 3690, "leads_available": 13, "leads_expected": 13}]},
             {"init_time": "2026-07-25T00:00:00Z", "status": "complete", "timing": "delayed", "completion_pct": 1, "latency_s": 5700, "lead_groups": [{"name": "f000", "status": "complete", "timing": "on_time", "completion_pct": 1, "latency_s": 850, "leads_available": 1, "leads_expected": 1}, {"name": "f024", "status": "complete", "timing": "on_time", "completion_pct": 1, "latency_s": 1900, "leads_available": 5, "leads_expected": 5}, {"name": "f072", "status": "complete", "timing": "delayed", "completion_pct": 1, "latency_s": 5700, "leads_available": 13, "leads_expected": 13}]},
             {"init_time": "2026-07-25T06:00:00Z", "status": "failed", "completion_pct": 0.38, "lead_groups": [{"name": "f000", "status": "complete", "timing": "on_time", "completion_pct": 1, "latency_s": 900, "leads_available": 1, "leads_expected": 1}, {"name": "f024", "status": "complete", "timing": "delayed", "completion_pct": 1, "latency_s": 3000, "leads_available": 5, "leads_expected": 5}, {"name": "f072", "status": "failed", "completion_pct": 0.38, "leads_available": 5, "leads_expected": 13}]},
-            {"init_time": "2026-07-25T12:00:00Z", "status": "in_flight", "timing": "delayed", "completion_pct": 0.38, "lead_groups": [{"name": "f000", "status": "complete", "timing": "on_time", "completion_pct": 1, "latency_s": 920, "leads_available": 1, "leads_expected": 1}, {"name": "f024", "status": "complete", "timing": "delayed", "completion_pct": 1, "latency_s": 3100, "leads_available": 5, "leads_expected": 5}, {"name": "f072", "status": "in_flight", "timing": "delayed", "completion_pct": 0.38, "leads_available": 5, "leads_expected": 13}]}
+            {"init_time": "2026-07-25T12:00:00Z", "status": "in_flight", "timing": "delayed", "completion_pct": 0.38, "lead_groups": [{"name": "f000", "status": "complete", "timing": "on_time", "completion_pct": 1, "latency_s": 920, "leads_available": 1, "leads_expected": 1}, {"name": "f024", "status": "complete", "timing": "delayed", "completion_pct": 1, "latency_s": 3100, "leads_available": 5, "leads_expected": 5}, {"name": "f072", "status": "in_flight", "timing": "delayed", "completion_pct": 0.38, "leads_available": 5, "leads_expected": 13}], "facets": [{"dimension": "component", "name": "component:pgrb2a", "label": "pgrb2a", "dependencies_available": 30, "dependencies_expected": 40, "completion_pct": 0.75, "status": "in_flight"}, {"dimension": "component", "name": "component:pgrb2b", "label": "pgrb2b", "dependencies_available": 20, "dependencies_expected": 40, "completion_pct": 0.5, "status": "in_flight"}, {"dimension": "component", "name": "component:pgrb2s", "label": "pgrb2s", "dependencies_available": 40, "dependencies_expected": 40, "completion_pct": 1, "status": "complete"}, {"dimension": "member", "name": "members:control", "label": "control", "dependencies_available": 8, "dependencies_expected": 8, "completion_pct": 1, "status": "complete"}, {"dimension": "member", "name": "members:perturbed", "label": "perturbed", "dependencies_available": 82, "dependencies_expected": 96, "completion_pct": 0.8542, "status": "in_flight"}]}
           ],
           "next_expected_init": "2026-07-25T18:00:00Z",
           "next_expected_completion_at": "2026-07-25T19:30:00Z"

--- a/test/fixtures/pipeline-dashboard.json
+++ b/test/fixtures/pipeline-dashboard.json
@@ -8,7 +8,9 @@
       "agency": "noaa",
       "title": "Fixture: GFS dissemination delay",
       "cause": "Local failure-mode preview",
-      "product_ids": ["external-noaa-gfs-aws"],
+      "product_ids": [
+        "external-noaa-gfs-aws"
+      ],
       "url": "https://nomads.ncep.noaa.gov/status.php"
     }
   ],
@@ -24,18 +26,58 @@
           "source_label": "AWS",
           "row_label": "AWS",
           "cadence_hours": 6,
-          "init_hours": ["00", "06", "12", "18"],
+          "init_hours": [
+            "00",
+            "06",
+            "12",
+            "18"
+          ],
           "lead_groups": [
-            {"name": "f000", "label": "0h", "leads_in_group": 1, "center_pct": 0.25},
-            {"name": "f024", "label": "1d", "leads_in_group": 5, "center_pct": 1.5},
-            {"name": "f072", "label": "3d", "leads_in_group": 13, "center_pct": 4.5}
+            {
+              "name": "f000",
+              "label": "0h",
+              "leads_in_group": 1,
+              "center_pct": 0.25
+            },
+            {
+              "name": "f024",
+              "label": "1d",
+              "leads_in_group": 5,
+              "center_pct": 1.5
+            },
+            {
+              "name": "f072",
+              "label": "3d",
+              "leads_in_group": 13,
+              "center_pct": 4.5
+            }
           ],
           "facet_groups": [
-            {"dimension": "component", "name": "component:pgrb2a", "label": "pgrb2a"},
-            {"dimension": "component", "name": "component:pgrb2b", "label": "pgrb2b"},
-            {"dimension": "component", "name": "component:pgrb2s", "label": "pgrb2s"},
-            {"dimension": "member", "name": "members:control", "label": "control"},
-            {"dimension": "member", "name": "members:perturbed", "label": "perturbed"}
+            {
+              "dimension": "component",
+              "name": "component:pgrb2a",
+              "label": "pgrb2a"
+            },
+            {
+              "dimension": "component",
+              "name": "component:pgrb2b",
+              "label": "pgrb2b"
+            },
+            {
+              "dimension": "component",
+              "name": "component:pgrb2s",
+              "label": "pgrb2s"
+            },
+            {
+              "dimension": "member",
+              "name": "members:control",
+              "label": "control"
+            },
+            {
+              "dimension": "member",
+              "name": "members:perturbed",
+              "label": "perturbed"
+            }
           ],
           "latency_stats": {
             "p50_s": 3600,
@@ -44,21 +86,1843 @@
             "sample_init_count": 30
           },
           "lead_group_stats": [
-            {"name": "f000", "label": "0h", "leads_in_group": 1, "p50_s": 900, "p95_s": 1200, "p99_s": 1500},
-            {"name": "f024", "label": "1d", "leads_in_group": 5, "p50_s": 1800, "p95_s": 2400, "p99_s": 2700},
-            {"name": "f072", "label": "3d", "leads_in_group": 13, "p50_s": 3600, "p95_s": 5400, "p99_s": 6000}
+            {
+              "name": "f000",
+              "label": "0h",
+              "leads_in_group": 1,
+              "p50_s": 900,
+              "p95_s": 1200,
+              "p99_s": 1500
+            },
+            {
+              "name": "f024",
+              "label": "1d",
+              "leads_in_group": 5,
+              "p50_s": 1800,
+              "p95_s": 2400,
+              "p99_s": 2700
+            },
+            {
+              "name": "f072",
+              "label": "3d",
+              "leads_in_group": 13,
+              "p50_s": 3600,
+              "p95_s": 5400,
+              "p99_s": 6000
+            }
           ],
           "recent_inits": [
-            {"init_time": "2026-07-23T06:00:00Z", "status": "complete", "timing": "on_time", "completion_pct": 1, "latency_s": 3420, "lead_groups": [{"name": "f000", "status": "complete", "timing": "on_time", "completion_pct": 1, "latency_s": 800, "leads_available": 1, "leads_expected": 1}, {"name": "f024", "status": "complete", "timing": "on_time", "completion_pct": 1, "latency_s": 1700, "leads_available": 5, "leads_expected": 5}, {"name": "f072", "status": "complete", "timing": "on_time", "completion_pct": 1, "latency_s": 3420, "leads_available": 13, "leads_expected": 13}]},
-            {"init_time": "2026-07-23T12:00:00Z", "status": "complete", "timing": "on_time", "completion_pct": 1, "latency_s": 3510, "lead_groups": [{"name": "f000", "status": "complete", "timing": "on_time", "completion_pct": 1, "latency_s": 810, "leads_available": 1, "leads_expected": 1}, {"name": "f024", "status": "complete", "timing": "on_time", "completion_pct": 1, "latency_s": 1750, "leads_available": 5, "leads_expected": 5}, {"name": "f072", "status": "complete", "timing": "on_time", "completion_pct": 1, "latency_s": 3510, "leads_available": 13, "leads_expected": 13}]},
-            {"init_time": "2026-07-23T18:00:00Z", "status": "complete", "timing": "on_time", "completion_pct": 1, "latency_s": 3480, "lead_groups": [{"name": "f000", "status": "complete", "timing": "on_time", "completion_pct": 1, "latency_s": 790, "leads_available": 1, "leads_expected": 1}, {"name": "f024", "status": "complete", "timing": "on_time", "completion_pct": 1, "latency_s": 1720, "leads_available": 5, "leads_expected": 5}, {"name": "f072", "status": "complete", "timing": "on_time", "completion_pct": 1, "latency_s": 3480, "leads_available": 13, "leads_expected": 13}]},
-            {"init_time": "2026-07-24T00:00:00Z", "status": "complete", "timing": "on_time", "completion_pct": 1, "latency_s": 3550, "lead_groups": [{"name": "f000", "status": "complete", "timing": "on_time", "completion_pct": 1, "latency_s": 820, "leads_available": 1, "leads_expected": 1}, {"name": "f024", "status": "complete", "timing": "on_time", "completion_pct": 1, "latency_s": 1780, "leads_available": 5, "leads_expected": 5}, {"name": "f072", "status": "complete", "timing": "on_time", "completion_pct": 1, "latency_s": 3550, "leads_available": 13, "leads_expected": 13}]},
-            {"init_time": "2026-07-24T06:00:00Z", "status": "complete", "timing": "on_time", "completion_pct": 1, "latency_s": 3610, "lead_groups": [{"name": "f000", "status": "complete", "timing": "on_time", "completion_pct": 1, "latency_s": 830, "leads_available": 1, "leads_expected": 1}, {"name": "f024", "status": "complete", "timing": "on_time", "completion_pct": 1, "latency_s": 1810, "leads_available": 5, "leads_expected": 5}, {"name": "f072", "status": "complete", "timing": "on_time", "completion_pct": 1, "latency_s": 3610, "leads_available": 13, "leads_expected": 13}]},
-            {"init_time": "2026-07-24T12:00:00Z", "status": "complete", "timing": "on_time", "completion_pct": 1, "latency_s": 3500, "lead_groups": [{"name": "f000", "status": "complete", "timing": "on_time", "completion_pct": 1, "latency_s": 800, "leads_available": 1, "leads_expected": 1}, {"name": "f024", "status": "complete", "timing": "on_time", "completion_pct": 1, "latency_s": 1760, "leads_available": 5, "leads_expected": 5}, {"name": "f072", "status": "complete", "timing": "on_time", "completion_pct": 1, "latency_s": 3500, "leads_available": 13, "leads_expected": 13}]},
-            {"init_time": "2026-07-24T18:00:00Z", "status": "complete", "timing": "on_time", "completion_pct": 1, "latency_s": 3690, "lead_groups": [{"name": "f000", "status": "complete", "timing": "on_time", "completion_pct": 1, "latency_s": 840, "leads_available": 1, "leads_expected": 1}, {"name": "f024", "status": "complete", "timing": "on_time", "completion_pct": 1, "latency_s": 1830, "leads_available": 5, "leads_expected": 5}, {"name": "f072", "status": "complete", "timing": "on_time", "completion_pct": 1, "latency_s": 3690, "leads_available": 13, "leads_expected": 13}]},
-            {"init_time": "2026-07-25T00:00:00Z", "status": "complete", "timing": "delayed", "completion_pct": 1, "latency_s": 5700, "lead_groups": [{"name": "f000", "status": "complete", "timing": "on_time", "completion_pct": 1, "latency_s": 850, "leads_available": 1, "leads_expected": 1}, {"name": "f024", "status": "complete", "timing": "on_time", "completion_pct": 1, "latency_s": 1900, "leads_available": 5, "leads_expected": 5}, {"name": "f072", "status": "complete", "timing": "delayed", "completion_pct": 1, "latency_s": 5700, "leads_available": 13, "leads_expected": 13}]},
-            {"init_time": "2026-07-25T06:00:00Z", "status": "failed", "completion_pct": 0.38, "lead_groups": [{"name": "f000", "status": "complete", "timing": "on_time", "completion_pct": 1, "latency_s": 900, "leads_available": 1, "leads_expected": 1}, {"name": "f024", "status": "complete", "timing": "delayed", "completion_pct": 1, "latency_s": 3000, "leads_available": 5, "leads_expected": 5}, {"name": "f072", "status": "failed", "completion_pct": 0.38, "leads_available": 5, "leads_expected": 13}]},
-            {"init_time": "2026-07-25T12:00:00Z", "status": "in_flight", "timing": "delayed", "completion_pct": 0.38, "lead_groups": [{"name": "f000", "status": "complete", "timing": "on_time", "completion_pct": 1, "latency_s": 920, "leads_available": 1, "leads_expected": 1}, {"name": "f024", "status": "complete", "timing": "delayed", "completion_pct": 1, "latency_s": 3100, "leads_available": 5, "leads_expected": 5}, {"name": "f072", "status": "in_flight", "timing": "delayed", "completion_pct": 0.38, "leads_available": 5, "leads_expected": 13}], "facets": [{"dimension": "component", "name": "component:pgrb2a", "label": "pgrb2a", "dependencies_available": 30, "dependencies_expected": 40, "completion_pct": 0.75, "status": "in_flight"}, {"dimension": "component", "name": "component:pgrb2b", "label": "pgrb2b", "dependencies_available": 20, "dependencies_expected": 40, "completion_pct": 0.5, "status": "in_flight"}, {"dimension": "component", "name": "component:pgrb2s", "label": "pgrb2s", "dependencies_available": 40, "dependencies_expected": 40, "completion_pct": 1, "status": "complete"}, {"dimension": "member", "name": "members:control", "label": "control", "dependencies_available": 8, "dependencies_expected": 8, "completion_pct": 1, "status": "complete"}, {"dimension": "member", "name": "members:perturbed", "label": "perturbed", "dependencies_available": 82, "dependencies_expected": 96, "completion_pct": 0.8542, "status": "in_flight"}]}
+            {
+              "init_time": "2026-07-23T06:00:00Z",
+              "status": "complete",
+              "timing": "on_time",
+              "completion_pct": 1,
+              "latency_s": 3420,
+              "lead_groups": [
+                {
+                  "name": "f000",
+                  "status": "complete",
+                  "timing": "on_time",
+                  "completion_pct": 1,
+                  "latency_s": 800,
+                  "leads_available": 1,
+                  "leads_expected": 1,
+                  "facets": [
+                    {
+                      "dimension": "component",
+                      "name": "component:pgrb2a",
+                      "label": "pgrb2a",
+                      "status": "complete",
+                      "completion_pct": 1.0,
+                      "dependencies_available": 2,
+                      "dependencies_expected": 2
+                    },
+                    {
+                      "dimension": "component",
+                      "name": "component:pgrb2b",
+                      "label": "pgrb2b",
+                      "status": "complete",
+                      "completion_pct": 1.0,
+                      "dependencies_available": 2,
+                      "dependencies_expected": 2
+                    },
+                    {
+                      "dimension": "component",
+                      "name": "component:pgrb2s",
+                      "label": "pgrb2s",
+                      "status": "complete",
+                      "completion_pct": 1.0,
+                      "dependencies_available": 1,
+                      "dependencies_expected": 1
+                    },
+                    {
+                      "dimension": "member",
+                      "name": "members:control",
+                      "label": "control",
+                      "status": "complete",
+                      "completion_pct": 1.0,
+                      "dependencies_available": 1,
+                      "dependencies_expected": 1
+                    },
+                    {
+                      "dimension": "member",
+                      "name": "members:perturbed",
+                      "label": "perturbed",
+                      "status": "complete",
+                      "completion_pct": 1.0,
+                      "dependencies_available": 4,
+                      "dependencies_expected": 4
+                    }
+                  ]
+                },
+                {
+                  "name": "f024",
+                  "status": "complete",
+                  "timing": "on_time",
+                  "completion_pct": 1,
+                  "latency_s": 1700,
+                  "leads_available": 5,
+                  "leads_expected": 5,
+                  "facets": [
+                    {
+                      "dimension": "component",
+                      "name": "component:pgrb2a",
+                      "label": "pgrb2a",
+                      "status": "complete",
+                      "completion_pct": 1.0,
+                      "dependencies_available": 10,
+                      "dependencies_expected": 10
+                    },
+                    {
+                      "dimension": "component",
+                      "name": "component:pgrb2b",
+                      "label": "pgrb2b",
+                      "status": "complete",
+                      "completion_pct": 1.0,
+                      "dependencies_available": 10,
+                      "dependencies_expected": 10
+                    },
+                    {
+                      "dimension": "component",
+                      "name": "component:pgrb2s",
+                      "label": "pgrb2s",
+                      "status": "complete",
+                      "completion_pct": 1.0,
+                      "dependencies_available": 5,
+                      "dependencies_expected": 5
+                    },
+                    {
+                      "dimension": "member",
+                      "name": "members:control",
+                      "label": "control",
+                      "status": "complete",
+                      "completion_pct": 1.0,
+                      "dependencies_available": 5,
+                      "dependencies_expected": 5
+                    },
+                    {
+                      "dimension": "member",
+                      "name": "members:perturbed",
+                      "label": "perturbed",
+                      "status": "complete",
+                      "completion_pct": 1.0,
+                      "dependencies_available": 20,
+                      "dependencies_expected": 20
+                    }
+                  ]
+                },
+                {
+                  "name": "f072",
+                  "status": "complete",
+                  "timing": "on_time",
+                  "completion_pct": 1,
+                  "latency_s": 3420,
+                  "leads_available": 13,
+                  "leads_expected": 13,
+                  "facets": [
+                    {
+                      "dimension": "component",
+                      "name": "component:pgrb2a",
+                      "label": "pgrb2a",
+                      "status": "complete",
+                      "completion_pct": 1.0,
+                      "dependencies_available": 26,
+                      "dependencies_expected": 26
+                    },
+                    {
+                      "dimension": "component",
+                      "name": "component:pgrb2b",
+                      "label": "pgrb2b",
+                      "status": "complete",
+                      "completion_pct": 1.0,
+                      "dependencies_available": 26,
+                      "dependencies_expected": 26
+                    },
+                    {
+                      "dimension": "component",
+                      "name": "component:pgrb2s",
+                      "label": "pgrb2s",
+                      "status": "complete",
+                      "completion_pct": 1.0,
+                      "dependencies_available": 13,
+                      "dependencies_expected": 13
+                    },
+                    {
+                      "dimension": "member",
+                      "name": "members:control",
+                      "label": "control",
+                      "status": "complete",
+                      "completion_pct": 1.0,
+                      "dependencies_available": 13,
+                      "dependencies_expected": 13
+                    },
+                    {
+                      "dimension": "member",
+                      "name": "members:perturbed",
+                      "label": "perturbed",
+                      "status": "complete",
+                      "completion_pct": 1.0,
+                      "dependencies_available": 52,
+                      "dependencies_expected": 52
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "init_time": "2026-07-23T12:00:00Z",
+              "status": "complete",
+              "timing": "on_time",
+              "completion_pct": 1,
+              "latency_s": 3510,
+              "lead_groups": [
+                {
+                  "name": "f000",
+                  "status": "complete",
+                  "timing": "on_time",
+                  "completion_pct": 1,
+                  "latency_s": 810,
+                  "leads_available": 1,
+                  "leads_expected": 1,
+                  "facets": [
+                    {
+                      "dimension": "component",
+                      "name": "component:pgrb2a",
+                      "label": "pgrb2a",
+                      "status": "complete",
+                      "completion_pct": 1.0,
+                      "dependencies_available": 2,
+                      "dependencies_expected": 2
+                    },
+                    {
+                      "dimension": "component",
+                      "name": "component:pgrb2b",
+                      "label": "pgrb2b",
+                      "status": "complete",
+                      "completion_pct": 1.0,
+                      "dependencies_available": 2,
+                      "dependencies_expected": 2
+                    },
+                    {
+                      "dimension": "component",
+                      "name": "component:pgrb2s",
+                      "label": "pgrb2s",
+                      "status": "complete",
+                      "completion_pct": 1.0,
+                      "dependencies_available": 1,
+                      "dependencies_expected": 1
+                    },
+                    {
+                      "dimension": "member",
+                      "name": "members:control",
+                      "label": "control",
+                      "status": "complete",
+                      "completion_pct": 1.0,
+                      "dependencies_available": 1,
+                      "dependencies_expected": 1
+                    },
+                    {
+                      "dimension": "member",
+                      "name": "members:perturbed",
+                      "label": "perturbed",
+                      "status": "complete",
+                      "completion_pct": 1.0,
+                      "dependencies_available": 4,
+                      "dependencies_expected": 4
+                    }
+                  ]
+                },
+                {
+                  "name": "f024",
+                  "status": "complete",
+                  "timing": "on_time",
+                  "completion_pct": 1,
+                  "latency_s": 1750,
+                  "leads_available": 5,
+                  "leads_expected": 5,
+                  "facets": [
+                    {
+                      "dimension": "component",
+                      "name": "component:pgrb2a",
+                      "label": "pgrb2a",
+                      "status": "complete",
+                      "completion_pct": 1.0,
+                      "dependencies_available": 10,
+                      "dependencies_expected": 10
+                    },
+                    {
+                      "dimension": "component",
+                      "name": "component:pgrb2b",
+                      "label": "pgrb2b",
+                      "status": "complete",
+                      "completion_pct": 1.0,
+                      "dependencies_available": 10,
+                      "dependencies_expected": 10
+                    },
+                    {
+                      "dimension": "component",
+                      "name": "component:pgrb2s",
+                      "label": "pgrb2s",
+                      "status": "complete",
+                      "completion_pct": 1.0,
+                      "dependencies_available": 5,
+                      "dependencies_expected": 5
+                    },
+                    {
+                      "dimension": "member",
+                      "name": "members:control",
+                      "label": "control",
+                      "status": "complete",
+                      "completion_pct": 1.0,
+                      "dependencies_available": 5,
+                      "dependencies_expected": 5
+                    },
+                    {
+                      "dimension": "member",
+                      "name": "members:perturbed",
+                      "label": "perturbed",
+                      "status": "complete",
+                      "completion_pct": 1.0,
+                      "dependencies_available": 20,
+                      "dependencies_expected": 20
+                    }
+                  ]
+                },
+                {
+                  "name": "f072",
+                  "status": "complete",
+                  "timing": "on_time",
+                  "completion_pct": 1,
+                  "latency_s": 3510,
+                  "leads_available": 13,
+                  "leads_expected": 13,
+                  "facets": [
+                    {
+                      "dimension": "component",
+                      "name": "component:pgrb2a",
+                      "label": "pgrb2a",
+                      "status": "complete",
+                      "completion_pct": 1.0,
+                      "dependencies_available": 26,
+                      "dependencies_expected": 26
+                    },
+                    {
+                      "dimension": "component",
+                      "name": "component:pgrb2b",
+                      "label": "pgrb2b",
+                      "status": "complete",
+                      "completion_pct": 1.0,
+                      "dependencies_available": 26,
+                      "dependencies_expected": 26
+                    },
+                    {
+                      "dimension": "component",
+                      "name": "component:pgrb2s",
+                      "label": "pgrb2s",
+                      "status": "complete",
+                      "completion_pct": 1.0,
+                      "dependencies_available": 13,
+                      "dependencies_expected": 13
+                    },
+                    {
+                      "dimension": "member",
+                      "name": "members:control",
+                      "label": "control",
+                      "status": "complete",
+                      "completion_pct": 1.0,
+                      "dependencies_available": 13,
+                      "dependencies_expected": 13
+                    },
+                    {
+                      "dimension": "member",
+                      "name": "members:perturbed",
+                      "label": "perturbed",
+                      "status": "complete",
+                      "completion_pct": 1.0,
+                      "dependencies_available": 52,
+                      "dependencies_expected": 52
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "init_time": "2026-07-23T18:00:00Z",
+              "status": "complete",
+              "timing": "on_time",
+              "completion_pct": 1,
+              "latency_s": 3480,
+              "lead_groups": [
+                {
+                  "name": "f000",
+                  "status": "complete",
+                  "timing": "on_time",
+                  "completion_pct": 1,
+                  "latency_s": 790,
+                  "leads_available": 1,
+                  "leads_expected": 1,
+                  "facets": [
+                    {
+                      "dimension": "component",
+                      "name": "component:pgrb2a",
+                      "label": "pgrb2a",
+                      "status": "complete",
+                      "completion_pct": 1.0,
+                      "dependencies_available": 2,
+                      "dependencies_expected": 2
+                    },
+                    {
+                      "dimension": "component",
+                      "name": "component:pgrb2b",
+                      "label": "pgrb2b",
+                      "status": "complete",
+                      "completion_pct": 1.0,
+                      "dependencies_available": 2,
+                      "dependencies_expected": 2
+                    },
+                    {
+                      "dimension": "component",
+                      "name": "component:pgrb2s",
+                      "label": "pgrb2s",
+                      "status": "complete",
+                      "completion_pct": 1.0,
+                      "dependencies_available": 1,
+                      "dependencies_expected": 1
+                    },
+                    {
+                      "dimension": "member",
+                      "name": "members:control",
+                      "label": "control",
+                      "status": "complete",
+                      "completion_pct": 1.0,
+                      "dependencies_available": 1,
+                      "dependencies_expected": 1
+                    },
+                    {
+                      "dimension": "member",
+                      "name": "members:perturbed",
+                      "label": "perturbed",
+                      "status": "complete",
+                      "completion_pct": 1.0,
+                      "dependencies_available": 4,
+                      "dependencies_expected": 4
+                    }
+                  ]
+                },
+                {
+                  "name": "f024",
+                  "status": "complete",
+                  "timing": "on_time",
+                  "completion_pct": 1,
+                  "latency_s": 1720,
+                  "leads_available": 5,
+                  "leads_expected": 5,
+                  "facets": [
+                    {
+                      "dimension": "component",
+                      "name": "component:pgrb2a",
+                      "label": "pgrb2a",
+                      "status": "complete",
+                      "completion_pct": 1.0,
+                      "dependencies_available": 10,
+                      "dependencies_expected": 10
+                    },
+                    {
+                      "dimension": "component",
+                      "name": "component:pgrb2b",
+                      "label": "pgrb2b",
+                      "status": "complete",
+                      "completion_pct": 1.0,
+                      "dependencies_available": 10,
+                      "dependencies_expected": 10
+                    },
+                    {
+                      "dimension": "component",
+                      "name": "component:pgrb2s",
+                      "label": "pgrb2s",
+                      "status": "complete",
+                      "completion_pct": 1.0,
+                      "dependencies_available": 5,
+                      "dependencies_expected": 5
+                    },
+                    {
+                      "dimension": "member",
+                      "name": "members:control",
+                      "label": "control",
+                      "status": "complete",
+                      "completion_pct": 1.0,
+                      "dependencies_available": 5,
+                      "dependencies_expected": 5
+                    },
+                    {
+                      "dimension": "member",
+                      "name": "members:perturbed",
+                      "label": "perturbed",
+                      "status": "complete",
+                      "completion_pct": 1.0,
+                      "dependencies_available": 20,
+                      "dependencies_expected": 20
+                    }
+                  ]
+                },
+                {
+                  "name": "f072",
+                  "status": "complete",
+                  "timing": "on_time",
+                  "completion_pct": 1,
+                  "latency_s": 3480,
+                  "leads_available": 13,
+                  "leads_expected": 13,
+                  "facets": [
+                    {
+                      "dimension": "component",
+                      "name": "component:pgrb2a",
+                      "label": "pgrb2a",
+                      "status": "complete",
+                      "completion_pct": 1.0,
+                      "dependencies_available": 26,
+                      "dependencies_expected": 26
+                    },
+                    {
+                      "dimension": "component",
+                      "name": "component:pgrb2b",
+                      "label": "pgrb2b",
+                      "status": "complete",
+                      "completion_pct": 1.0,
+                      "dependencies_available": 26,
+                      "dependencies_expected": 26
+                    },
+                    {
+                      "dimension": "component",
+                      "name": "component:pgrb2s",
+                      "label": "pgrb2s",
+                      "status": "complete",
+                      "completion_pct": 1.0,
+                      "dependencies_available": 13,
+                      "dependencies_expected": 13
+                    },
+                    {
+                      "dimension": "member",
+                      "name": "members:control",
+                      "label": "control",
+                      "status": "complete",
+                      "completion_pct": 1.0,
+                      "dependencies_available": 13,
+                      "dependencies_expected": 13
+                    },
+                    {
+                      "dimension": "member",
+                      "name": "members:perturbed",
+                      "label": "perturbed",
+                      "status": "complete",
+                      "completion_pct": 1.0,
+                      "dependencies_available": 52,
+                      "dependencies_expected": 52
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "init_time": "2026-07-24T00:00:00Z",
+              "status": "complete",
+              "timing": "on_time",
+              "completion_pct": 1,
+              "latency_s": 3550,
+              "lead_groups": [
+                {
+                  "name": "f000",
+                  "status": "complete",
+                  "timing": "on_time",
+                  "completion_pct": 1,
+                  "latency_s": 820,
+                  "leads_available": 1,
+                  "leads_expected": 1,
+                  "facets": [
+                    {
+                      "dimension": "component",
+                      "name": "component:pgrb2a",
+                      "label": "pgrb2a",
+                      "status": "complete",
+                      "completion_pct": 1.0,
+                      "dependencies_available": 2,
+                      "dependencies_expected": 2
+                    },
+                    {
+                      "dimension": "component",
+                      "name": "component:pgrb2b",
+                      "label": "pgrb2b",
+                      "status": "complete",
+                      "completion_pct": 1.0,
+                      "dependencies_available": 2,
+                      "dependencies_expected": 2
+                    },
+                    {
+                      "dimension": "component",
+                      "name": "component:pgrb2s",
+                      "label": "pgrb2s",
+                      "status": "complete",
+                      "completion_pct": 1.0,
+                      "dependencies_available": 1,
+                      "dependencies_expected": 1
+                    },
+                    {
+                      "dimension": "member",
+                      "name": "members:control",
+                      "label": "control",
+                      "status": "complete",
+                      "completion_pct": 1.0,
+                      "dependencies_available": 1,
+                      "dependencies_expected": 1
+                    },
+                    {
+                      "dimension": "member",
+                      "name": "members:perturbed",
+                      "label": "perturbed",
+                      "status": "complete",
+                      "completion_pct": 1.0,
+                      "dependencies_available": 4,
+                      "dependencies_expected": 4
+                    }
+                  ]
+                },
+                {
+                  "name": "f024",
+                  "status": "complete",
+                  "timing": "on_time",
+                  "completion_pct": 1,
+                  "latency_s": 1780,
+                  "leads_available": 5,
+                  "leads_expected": 5,
+                  "facets": [
+                    {
+                      "dimension": "component",
+                      "name": "component:pgrb2a",
+                      "label": "pgrb2a",
+                      "status": "complete",
+                      "completion_pct": 1.0,
+                      "dependencies_available": 10,
+                      "dependencies_expected": 10
+                    },
+                    {
+                      "dimension": "component",
+                      "name": "component:pgrb2b",
+                      "label": "pgrb2b",
+                      "status": "complete",
+                      "completion_pct": 1.0,
+                      "dependencies_available": 10,
+                      "dependencies_expected": 10
+                    },
+                    {
+                      "dimension": "component",
+                      "name": "component:pgrb2s",
+                      "label": "pgrb2s",
+                      "status": "complete",
+                      "completion_pct": 1.0,
+                      "dependencies_available": 5,
+                      "dependencies_expected": 5
+                    },
+                    {
+                      "dimension": "member",
+                      "name": "members:control",
+                      "label": "control",
+                      "status": "complete",
+                      "completion_pct": 1.0,
+                      "dependencies_available": 5,
+                      "dependencies_expected": 5
+                    },
+                    {
+                      "dimension": "member",
+                      "name": "members:perturbed",
+                      "label": "perturbed",
+                      "status": "complete",
+                      "completion_pct": 1.0,
+                      "dependencies_available": 20,
+                      "dependencies_expected": 20
+                    }
+                  ]
+                },
+                {
+                  "name": "f072",
+                  "status": "complete",
+                  "timing": "on_time",
+                  "completion_pct": 1,
+                  "latency_s": 3550,
+                  "leads_available": 13,
+                  "leads_expected": 13,
+                  "facets": [
+                    {
+                      "dimension": "component",
+                      "name": "component:pgrb2a",
+                      "label": "pgrb2a",
+                      "status": "complete",
+                      "completion_pct": 1.0,
+                      "dependencies_available": 26,
+                      "dependencies_expected": 26
+                    },
+                    {
+                      "dimension": "component",
+                      "name": "component:pgrb2b",
+                      "label": "pgrb2b",
+                      "status": "complete",
+                      "completion_pct": 1.0,
+                      "dependencies_available": 26,
+                      "dependencies_expected": 26
+                    },
+                    {
+                      "dimension": "component",
+                      "name": "component:pgrb2s",
+                      "label": "pgrb2s",
+                      "status": "complete",
+                      "completion_pct": 1.0,
+                      "dependencies_available": 13,
+                      "dependencies_expected": 13
+                    },
+                    {
+                      "dimension": "member",
+                      "name": "members:control",
+                      "label": "control",
+                      "status": "complete",
+                      "completion_pct": 1.0,
+                      "dependencies_available": 13,
+                      "dependencies_expected": 13
+                    },
+                    {
+                      "dimension": "member",
+                      "name": "members:perturbed",
+                      "label": "perturbed",
+                      "status": "complete",
+                      "completion_pct": 1.0,
+                      "dependencies_available": 52,
+                      "dependencies_expected": 52
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "init_time": "2026-07-24T06:00:00Z",
+              "status": "complete",
+              "timing": "on_time",
+              "completion_pct": 1,
+              "latency_s": 3610,
+              "lead_groups": [
+                {
+                  "name": "f000",
+                  "status": "complete",
+                  "timing": "on_time",
+                  "completion_pct": 1,
+                  "latency_s": 830,
+                  "leads_available": 1,
+                  "leads_expected": 1,
+                  "facets": [
+                    {
+                      "dimension": "component",
+                      "name": "component:pgrb2a",
+                      "label": "pgrb2a",
+                      "status": "complete",
+                      "completion_pct": 1.0,
+                      "dependencies_available": 2,
+                      "dependencies_expected": 2
+                    },
+                    {
+                      "dimension": "component",
+                      "name": "component:pgrb2b",
+                      "label": "pgrb2b",
+                      "status": "complete",
+                      "completion_pct": 1.0,
+                      "dependencies_available": 2,
+                      "dependencies_expected": 2
+                    },
+                    {
+                      "dimension": "component",
+                      "name": "component:pgrb2s",
+                      "label": "pgrb2s",
+                      "status": "complete",
+                      "completion_pct": 1.0,
+                      "dependencies_available": 1,
+                      "dependencies_expected": 1
+                    },
+                    {
+                      "dimension": "member",
+                      "name": "members:control",
+                      "label": "control",
+                      "status": "complete",
+                      "completion_pct": 1.0,
+                      "dependencies_available": 1,
+                      "dependencies_expected": 1
+                    },
+                    {
+                      "dimension": "member",
+                      "name": "members:perturbed",
+                      "label": "perturbed",
+                      "status": "complete",
+                      "completion_pct": 1.0,
+                      "dependencies_available": 4,
+                      "dependencies_expected": 4
+                    }
+                  ]
+                },
+                {
+                  "name": "f024",
+                  "status": "complete",
+                  "timing": "on_time",
+                  "completion_pct": 1,
+                  "latency_s": 1810,
+                  "leads_available": 5,
+                  "leads_expected": 5,
+                  "facets": [
+                    {
+                      "dimension": "component",
+                      "name": "component:pgrb2a",
+                      "label": "pgrb2a",
+                      "status": "complete",
+                      "completion_pct": 1.0,
+                      "dependencies_available": 10,
+                      "dependencies_expected": 10
+                    },
+                    {
+                      "dimension": "component",
+                      "name": "component:pgrb2b",
+                      "label": "pgrb2b",
+                      "status": "complete",
+                      "completion_pct": 1.0,
+                      "dependencies_available": 10,
+                      "dependencies_expected": 10
+                    },
+                    {
+                      "dimension": "component",
+                      "name": "component:pgrb2s",
+                      "label": "pgrb2s",
+                      "status": "complete",
+                      "completion_pct": 1.0,
+                      "dependencies_available": 5,
+                      "dependencies_expected": 5
+                    },
+                    {
+                      "dimension": "member",
+                      "name": "members:control",
+                      "label": "control",
+                      "status": "complete",
+                      "completion_pct": 1.0,
+                      "dependencies_available": 5,
+                      "dependencies_expected": 5
+                    },
+                    {
+                      "dimension": "member",
+                      "name": "members:perturbed",
+                      "label": "perturbed",
+                      "status": "complete",
+                      "completion_pct": 1.0,
+                      "dependencies_available": 20,
+                      "dependencies_expected": 20
+                    }
+                  ]
+                },
+                {
+                  "name": "f072",
+                  "status": "complete",
+                  "timing": "on_time",
+                  "completion_pct": 1,
+                  "latency_s": 3610,
+                  "leads_available": 13,
+                  "leads_expected": 13,
+                  "facets": [
+                    {
+                      "dimension": "component",
+                      "name": "component:pgrb2a",
+                      "label": "pgrb2a",
+                      "status": "complete",
+                      "completion_pct": 1.0,
+                      "dependencies_available": 26,
+                      "dependencies_expected": 26
+                    },
+                    {
+                      "dimension": "component",
+                      "name": "component:pgrb2b",
+                      "label": "pgrb2b",
+                      "status": "complete",
+                      "completion_pct": 1.0,
+                      "dependencies_available": 26,
+                      "dependencies_expected": 26
+                    },
+                    {
+                      "dimension": "component",
+                      "name": "component:pgrb2s",
+                      "label": "pgrb2s",
+                      "status": "complete",
+                      "completion_pct": 1.0,
+                      "dependencies_available": 13,
+                      "dependencies_expected": 13
+                    },
+                    {
+                      "dimension": "member",
+                      "name": "members:control",
+                      "label": "control",
+                      "status": "complete",
+                      "completion_pct": 1.0,
+                      "dependencies_available": 13,
+                      "dependencies_expected": 13
+                    },
+                    {
+                      "dimension": "member",
+                      "name": "members:perturbed",
+                      "label": "perturbed",
+                      "status": "complete",
+                      "completion_pct": 1.0,
+                      "dependencies_available": 52,
+                      "dependencies_expected": 52
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "init_time": "2026-07-24T12:00:00Z",
+              "status": "complete",
+              "timing": "on_time",
+              "completion_pct": 1,
+              "latency_s": 3500,
+              "lead_groups": [
+                {
+                  "name": "f000",
+                  "status": "complete",
+                  "timing": "on_time",
+                  "completion_pct": 1,
+                  "latency_s": 800,
+                  "leads_available": 1,
+                  "leads_expected": 1,
+                  "facets": [
+                    {
+                      "dimension": "component",
+                      "name": "component:pgrb2a",
+                      "label": "pgrb2a",
+                      "status": "complete",
+                      "completion_pct": 1.0,
+                      "dependencies_available": 2,
+                      "dependencies_expected": 2
+                    },
+                    {
+                      "dimension": "component",
+                      "name": "component:pgrb2b",
+                      "label": "pgrb2b",
+                      "status": "complete",
+                      "completion_pct": 1.0,
+                      "dependencies_available": 2,
+                      "dependencies_expected": 2
+                    },
+                    {
+                      "dimension": "component",
+                      "name": "component:pgrb2s",
+                      "label": "pgrb2s",
+                      "status": "complete",
+                      "completion_pct": 1.0,
+                      "dependencies_available": 1,
+                      "dependencies_expected": 1
+                    },
+                    {
+                      "dimension": "member",
+                      "name": "members:control",
+                      "label": "control",
+                      "status": "complete",
+                      "completion_pct": 1.0,
+                      "dependencies_available": 1,
+                      "dependencies_expected": 1
+                    },
+                    {
+                      "dimension": "member",
+                      "name": "members:perturbed",
+                      "label": "perturbed",
+                      "status": "complete",
+                      "completion_pct": 1.0,
+                      "dependencies_available": 4,
+                      "dependencies_expected": 4
+                    }
+                  ]
+                },
+                {
+                  "name": "f024",
+                  "status": "complete",
+                  "timing": "on_time",
+                  "completion_pct": 1,
+                  "latency_s": 1760,
+                  "leads_available": 5,
+                  "leads_expected": 5,
+                  "facets": [
+                    {
+                      "dimension": "component",
+                      "name": "component:pgrb2a",
+                      "label": "pgrb2a",
+                      "status": "complete",
+                      "completion_pct": 1.0,
+                      "dependencies_available": 10,
+                      "dependencies_expected": 10
+                    },
+                    {
+                      "dimension": "component",
+                      "name": "component:pgrb2b",
+                      "label": "pgrb2b",
+                      "status": "complete",
+                      "completion_pct": 1.0,
+                      "dependencies_available": 10,
+                      "dependencies_expected": 10
+                    },
+                    {
+                      "dimension": "component",
+                      "name": "component:pgrb2s",
+                      "label": "pgrb2s",
+                      "status": "complete",
+                      "completion_pct": 1.0,
+                      "dependencies_available": 5,
+                      "dependencies_expected": 5
+                    },
+                    {
+                      "dimension": "member",
+                      "name": "members:control",
+                      "label": "control",
+                      "status": "complete",
+                      "completion_pct": 1.0,
+                      "dependencies_available": 5,
+                      "dependencies_expected": 5
+                    },
+                    {
+                      "dimension": "member",
+                      "name": "members:perturbed",
+                      "label": "perturbed",
+                      "status": "complete",
+                      "completion_pct": 1.0,
+                      "dependencies_available": 20,
+                      "dependencies_expected": 20
+                    }
+                  ]
+                },
+                {
+                  "name": "f072",
+                  "status": "complete",
+                  "timing": "on_time",
+                  "completion_pct": 1,
+                  "latency_s": 3500,
+                  "leads_available": 13,
+                  "leads_expected": 13,
+                  "facets": [
+                    {
+                      "dimension": "component",
+                      "name": "component:pgrb2a",
+                      "label": "pgrb2a",
+                      "status": "complete",
+                      "completion_pct": 1.0,
+                      "dependencies_available": 26,
+                      "dependencies_expected": 26
+                    },
+                    {
+                      "dimension": "component",
+                      "name": "component:pgrb2b",
+                      "label": "pgrb2b",
+                      "status": "complete",
+                      "completion_pct": 1.0,
+                      "dependencies_available": 26,
+                      "dependencies_expected": 26
+                    },
+                    {
+                      "dimension": "component",
+                      "name": "component:pgrb2s",
+                      "label": "pgrb2s",
+                      "status": "complete",
+                      "completion_pct": 1.0,
+                      "dependencies_available": 13,
+                      "dependencies_expected": 13
+                    },
+                    {
+                      "dimension": "member",
+                      "name": "members:control",
+                      "label": "control",
+                      "status": "complete",
+                      "completion_pct": 1.0,
+                      "dependencies_available": 13,
+                      "dependencies_expected": 13
+                    },
+                    {
+                      "dimension": "member",
+                      "name": "members:perturbed",
+                      "label": "perturbed",
+                      "status": "complete",
+                      "completion_pct": 1.0,
+                      "dependencies_available": 52,
+                      "dependencies_expected": 52
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "init_time": "2026-07-24T18:00:00Z",
+              "status": "complete",
+              "timing": "on_time",
+              "completion_pct": 1,
+              "latency_s": 3690,
+              "lead_groups": [
+                {
+                  "name": "f000",
+                  "status": "complete",
+                  "timing": "on_time",
+                  "completion_pct": 1,
+                  "latency_s": 840,
+                  "leads_available": 1,
+                  "leads_expected": 1,
+                  "facets": [
+                    {
+                      "dimension": "component",
+                      "name": "component:pgrb2a",
+                      "label": "pgrb2a",
+                      "status": "complete",
+                      "completion_pct": 1.0,
+                      "dependencies_available": 2,
+                      "dependencies_expected": 2
+                    },
+                    {
+                      "dimension": "component",
+                      "name": "component:pgrb2b",
+                      "label": "pgrb2b",
+                      "status": "complete",
+                      "completion_pct": 1.0,
+                      "dependencies_available": 2,
+                      "dependencies_expected": 2
+                    },
+                    {
+                      "dimension": "component",
+                      "name": "component:pgrb2s",
+                      "label": "pgrb2s",
+                      "status": "complete",
+                      "completion_pct": 1.0,
+                      "dependencies_available": 1,
+                      "dependencies_expected": 1
+                    },
+                    {
+                      "dimension": "member",
+                      "name": "members:control",
+                      "label": "control",
+                      "status": "complete",
+                      "completion_pct": 1.0,
+                      "dependencies_available": 1,
+                      "dependencies_expected": 1
+                    },
+                    {
+                      "dimension": "member",
+                      "name": "members:perturbed",
+                      "label": "perturbed",
+                      "status": "complete",
+                      "completion_pct": 1.0,
+                      "dependencies_available": 4,
+                      "dependencies_expected": 4
+                    }
+                  ]
+                },
+                {
+                  "name": "f024",
+                  "status": "complete",
+                  "timing": "on_time",
+                  "completion_pct": 1,
+                  "latency_s": 1830,
+                  "leads_available": 5,
+                  "leads_expected": 5,
+                  "facets": [
+                    {
+                      "dimension": "component",
+                      "name": "component:pgrb2a",
+                      "label": "pgrb2a",
+                      "status": "complete",
+                      "completion_pct": 1.0,
+                      "dependencies_available": 10,
+                      "dependencies_expected": 10
+                    },
+                    {
+                      "dimension": "component",
+                      "name": "component:pgrb2b",
+                      "label": "pgrb2b",
+                      "status": "complete",
+                      "completion_pct": 1.0,
+                      "dependencies_available": 10,
+                      "dependencies_expected": 10
+                    },
+                    {
+                      "dimension": "component",
+                      "name": "component:pgrb2s",
+                      "label": "pgrb2s",
+                      "status": "complete",
+                      "completion_pct": 1.0,
+                      "dependencies_available": 5,
+                      "dependencies_expected": 5
+                    },
+                    {
+                      "dimension": "member",
+                      "name": "members:control",
+                      "label": "control",
+                      "status": "complete",
+                      "completion_pct": 1.0,
+                      "dependencies_available": 5,
+                      "dependencies_expected": 5
+                    },
+                    {
+                      "dimension": "member",
+                      "name": "members:perturbed",
+                      "label": "perturbed",
+                      "status": "complete",
+                      "completion_pct": 1.0,
+                      "dependencies_available": 20,
+                      "dependencies_expected": 20
+                    }
+                  ]
+                },
+                {
+                  "name": "f072",
+                  "status": "complete",
+                  "timing": "on_time",
+                  "completion_pct": 1,
+                  "latency_s": 3690,
+                  "leads_available": 13,
+                  "leads_expected": 13,
+                  "facets": [
+                    {
+                      "dimension": "component",
+                      "name": "component:pgrb2a",
+                      "label": "pgrb2a",
+                      "status": "complete",
+                      "completion_pct": 1.0,
+                      "dependencies_available": 26,
+                      "dependencies_expected": 26
+                    },
+                    {
+                      "dimension": "component",
+                      "name": "component:pgrb2b",
+                      "label": "pgrb2b",
+                      "status": "complete",
+                      "completion_pct": 1.0,
+                      "dependencies_available": 26,
+                      "dependencies_expected": 26
+                    },
+                    {
+                      "dimension": "component",
+                      "name": "component:pgrb2s",
+                      "label": "pgrb2s",
+                      "status": "complete",
+                      "completion_pct": 1.0,
+                      "dependencies_available": 13,
+                      "dependencies_expected": 13
+                    },
+                    {
+                      "dimension": "member",
+                      "name": "members:control",
+                      "label": "control",
+                      "status": "complete",
+                      "completion_pct": 1.0,
+                      "dependencies_available": 13,
+                      "dependencies_expected": 13
+                    },
+                    {
+                      "dimension": "member",
+                      "name": "members:perturbed",
+                      "label": "perturbed",
+                      "status": "complete",
+                      "completion_pct": 1.0,
+                      "dependencies_available": 52,
+                      "dependencies_expected": 52
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "init_time": "2026-07-25T00:00:00Z",
+              "status": "complete",
+              "timing": "delayed",
+              "completion_pct": 1,
+              "latency_s": 5700,
+              "lead_groups": [
+                {
+                  "name": "f000",
+                  "status": "complete",
+                  "timing": "on_time",
+                  "completion_pct": 1,
+                  "latency_s": 850,
+                  "leads_available": 1,
+                  "leads_expected": 1,
+                  "facets": [
+                    {
+                      "dimension": "component",
+                      "name": "component:pgrb2a",
+                      "label": "pgrb2a",
+                      "status": "complete",
+                      "completion_pct": 1.0,
+                      "dependencies_available": 2,
+                      "dependencies_expected": 2
+                    },
+                    {
+                      "dimension": "component",
+                      "name": "component:pgrb2b",
+                      "label": "pgrb2b",
+                      "status": "complete",
+                      "completion_pct": 1.0,
+                      "dependencies_available": 2,
+                      "dependencies_expected": 2
+                    },
+                    {
+                      "dimension": "component",
+                      "name": "component:pgrb2s",
+                      "label": "pgrb2s",
+                      "status": "complete",
+                      "completion_pct": 1.0,
+                      "dependencies_available": 1,
+                      "dependencies_expected": 1
+                    },
+                    {
+                      "dimension": "member",
+                      "name": "members:control",
+                      "label": "control",
+                      "status": "complete",
+                      "completion_pct": 1.0,
+                      "dependencies_available": 1,
+                      "dependencies_expected": 1
+                    },
+                    {
+                      "dimension": "member",
+                      "name": "members:perturbed",
+                      "label": "perturbed",
+                      "status": "complete",
+                      "completion_pct": 1.0,
+                      "dependencies_available": 4,
+                      "dependencies_expected": 4
+                    }
+                  ]
+                },
+                {
+                  "name": "f024",
+                  "status": "complete",
+                  "timing": "on_time",
+                  "completion_pct": 1,
+                  "latency_s": 1900,
+                  "leads_available": 5,
+                  "leads_expected": 5,
+                  "facets": [
+                    {
+                      "dimension": "component",
+                      "name": "component:pgrb2a",
+                      "label": "pgrb2a",
+                      "status": "complete",
+                      "completion_pct": 1.0,
+                      "dependencies_available": 10,
+                      "dependencies_expected": 10
+                    },
+                    {
+                      "dimension": "component",
+                      "name": "component:pgrb2b",
+                      "label": "pgrb2b",
+                      "status": "complete",
+                      "completion_pct": 1.0,
+                      "dependencies_available": 10,
+                      "dependencies_expected": 10
+                    },
+                    {
+                      "dimension": "component",
+                      "name": "component:pgrb2s",
+                      "label": "pgrb2s",
+                      "status": "complete",
+                      "completion_pct": 1.0,
+                      "dependencies_available": 5,
+                      "dependencies_expected": 5
+                    },
+                    {
+                      "dimension": "member",
+                      "name": "members:control",
+                      "label": "control",
+                      "status": "complete",
+                      "completion_pct": 1.0,
+                      "dependencies_available": 5,
+                      "dependencies_expected": 5
+                    },
+                    {
+                      "dimension": "member",
+                      "name": "members:perturbed",
+                      "label": "perturbed",
+                      "status": "complete",
+                      "completion_pct": 1.0,
+                      "dependencies_available": 20,
+                      "dependencies_expected": 20
+                    }
+                  ]
+                },
+                {
+                  "name": "f072",
+                  "status": "complete",
+                  "timing": "delayed",
+                  "completion_pct": 1,
+                  "latency_s": 5700,
+                  "leads_available": 13,
+                  "leads_expected": 13,
+                  "facets": [
+                    {
+                      "dimension": "component",
+                      "name": "component:pgrb2a",
+                      "label": "pgrb2a",
+                      "status": "complete",
+                      "completion_pct": 1.0,
+                      "dependencies_available": 26,
+                      "dependencies_expected": 26
+                    },
+                    {
+                      "dimension": "component",
+                      "name": "component:pgrb2b",
+                      "label": "pgrb2b",
+                      "status": "complete",
+                      "completion_pct": 1.0,
+                      "dependencies_available": 26,
+                      "dependencies_expected": 26
+                    },
+                    {
+                      "dimension": "component",
+                      "name": "component:pgrb2s",
+                      "label": "pgrb2s",
+                      "status": "complete",
+                      "completion_pct": 1.0,
+                      "dependencies_available": 13,
+                      "dependencies_expected": 13
+                    },
+                    {
+                      "dimension": "member",
+                      "name": "members:control",
+                      "label": "control",
+                      "status": "complete",
+                      "completion_pct": 1.0,
+                      "dependencies_available": 13,
+                      "dependencies_expected": 13
+                    },
+                    {
+                      "dimension": "member",
+                      "name": "members:perturbed",
+                      "label": "perturbed",
+                      "status": "complete",
+                      "completion_pct": 1.0,
+                      "dependencies_available": 52,
+                      "dependencies_expected": 52
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "init_time": "2026-07-25T06:00:00Z",
+              "status": "failed",
+              "completion_pct": 0.38,
+              "lead_groups": [
+                {
+                  "name": "f000",
+                  "status": "complete",
+                  "timing": "on_time",
+                  "completion_pct": 1,
+                  "latency_s": 900,
+                  "leads_available": 1,
+                  "leads_expected": 1,
+                  "facets": [
+                    {
+                      "dimension": "component",
+                      "name": "component:pgrb2a",
+                      "label": "pgrb2a",
+                      "status": "complete",
+                      "completion_pct": 1.0,
+                      "dependencies_available": 2,
+                      "dependencies_expected": 2
+                    },
+                    {
+                      "dimension": "component",
+                      "name": "component:pgrb2b",
+                      "label": "pgrb2b",
+                      "status": "complete",
+                      "completion_pct": 1.0,
+                      "dependencies_available": 2,
+                      "dependencies_expected": 2
+                    },
+                    {
+                      "dimension": "component",
+                      "name": "component:pgrb2s",
+                      "label": "pgrb2s",
+                      "status": "complete",
+                      "completion_pct": 1.0,
+                      "dependencies_available": 1,
+                      "dependencies_expected": 1
+                    },
+                    {
+                      "dimension": "member",
+                      "name": "members:control",
+                      "label": "control",
+                      "status": "complete",
+                      "completion_pct": 1.0,
+                      "dependencies_available": 1,
+                      "dependencies_expected": 1
+                    },
+                    {
+                      "dimension": "member",
+                      "name": "members:perturbed",
+                      "label": "perturbed",
+                      "status": "complete",
+                      "completion_pct": 1.0,
+                      "dependencies_available": 4,
+                      "dependencies_expected": 4
+                    }
+                  ]
+                },
+                {
+                  "name": "f024",
+                  "status": "complete",
+                  "timing": "delayed",
+                  "completion_pct": 1,
+                  "latency_s": 3000,
+                  "leads_available": 5,
+                  "leads_expected": 5,
+                  "facets": [
+                    {
+                      "dimension": "component",
+                      "name": "component:pgrb2a",
+                      "label": "pgrb2a",
+                      "status": "complete",
+                      "completion_pct": 1.0,
+                      "dependencies_available": 10,
+                      "dependencies_expected": 10
+                    },
+                    {
+                      "dimension": "component",
+                      "name": "component:pgrb2b",
+                      "label": "pgrb2b",
+                      "status": "complete",
+                      "completion_pct": 1.0,
+                      "dependencies_available": 10,
+                      "dependencies_expected": 10
+                    },
+                    {
+                      "dimension": "component",
+                      "name": "component:pgrb2s",
+                      "label": "pgrb2s",
+                      "status": "complete",
+                      "completion_pct": 1.0,
+                      "dependencies_available": 5,
+                      "dependencies_expected": 5
+                    },
+                    {
+                      "dimension": "member",
+                      "name": "members:control",
+                      "label": "control",
+                      "status": "complete",
+                      "completion_pct": 1.0,
+                      "dependencies_available": 5,
+                      "dependencies_expected": 5
+                    },
+                    {
+                      "dimension": "member",
+                      "name": "members:perturbed",
+                      "label": "perturbed",
+                      "status": "complete",
+                      "completion_pct": 1.0,
+                      "dependencies_available": 20,
+                      "dependencies_expected": 20
+                    }
+                  ]
+                },
+                {
+                  "name": "f072",
+                  "status": "failed",
+                  "completion_pct": 0.38,
+                  "leads_available": 5,
+                  "leads_expected": 13,
+                  "facets": [
+                    {
+                      "dimension": "component",
+                      "name": "component:pgrb2a",
+                      "label": "pgrb2a",
+                      "status": "failed",
+                      "completion_pct": 0.5385,
+                      "dependencies_available": 14,
+                      "dependencies_expected": 26
+                    },
+                    {
+                      "dimension": "component",
+                      "name": "component:pgrb2b",
+                      "label": "pgrb2b",
+                      "status": "failed",
+                      "completion_pct": 0.5385,
+                      "dependencies_available": 14,
+                      "dependencies_expected": 26
+                    },
+                    {
+                      "dimension": "component",
+                      "name": "component:pgrb2s",
+                      "label": "pgrb2s",
+                      "status": "failed",
+                      "completion_pct": 0.8462,
+                      "dependencies_available": 11,
+                      "dependencies_expected": 13
+                    },
+                    {
+                      "dimension": "member",
+                      "name": "members:control",
+                      "label": "control",
+                      "status": "failed",
+                      "completion_pct": 0.8462,
+                      "dependencies_available": 11,
+                      "dependencies_expected": 13
+                    },
+                    {
+                      "dimension": "member",
+                      "name": "members:perturbed",
+                      "label": "perturbed",
+                      "status": "failed",
+                      "completion_pct": 0.3077,
+                      "dependencies_available": 16,
+                      "dependencies_expected": 52
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "init_time": "2026-07-25T12:00:00Z",
+              "status": "in_flight",
+              "timing": "delayed",
+              "completion_pct": 0.38,
+              "lead_groups": [
+                {
+                  "name": "f000",
+                  "status": "complete",
+                  "timing": "on_time",
+                  "completion_pct": 1,
+                  "latency_s": 920,
+                  "leads_available": 1,
+                  "leads_expected": 1,
+                  "facets": [
+                    {
+                      "dimension": "component",
+                      "name": "component:pgrb2a",
+                      "label": "pgrb2a",
+                      "status": "complete",
+                      "completion_pct": 1.0,
+                      "dependencies_available": 2,
+                      "dependencies_expected": 2
+                    },
+                    {
+                      "dimension": "component",
+                      "name": "component:pgrb2b",
+                      "label": "pgrb2b",
+                      "status": "complete",
+                      "completion_pct": 1.0,
+                      "dependencies_available": 2,
+                      "dependencies_expected": 2
+                    },
+                    {
+                      "dimension": "component",
+                      "name": "component:pgrb2s",
+                      "label": "pgrb2s",
+                      "status": "complete",
+                      "completion_pct": 1.0,
+                      "dependencies_available": 1,
+                      "dependencies_expected": 1
+                    },
+                    {
+                      "dimension": "member",
+                      "name": "members:control",
+                      "label": "control",
+                      "status": "complete",
+                      "completion_pct": 1.0,
+                      "dependencies_available": 1,
+                      "dependencies_expected": 1
+                    },
+                    {
+                      "dimension": "member",
+                      "name": "members:perturbed",
+                      "label": "perturbed",
+                      "status": "complete",
+                      "completion_pct": 1.0,
+                      "dependencies_available": 4,
+                      "dependencies_expected": 4
+                    }
+                  ]
+                },
+                {
+                  "name": "f024",
+                  "status": "complete",
+                  "timing": "delayed",
+                  "completion_pct": 1,
+                  "latency_s": 3100,
+                  "leads_available": 5,
+                  "leads_expected": 5,
+                  "facets": [
+                    {
+                      "dimension": "component",
+                      "name": "component:pgrb2a",
+                      "label": "pgrb2a",
+                      "status": "complete",
+                      "completion_pct": 1.0,
+                      "dependencies_available": 10,
+                      "dependencies_expected": 10
+                    },
+                    {
+                      "dimension": "component",
+                      "name": "component:pgrb2b",
+                      "label": "pgrb2b",
+                      "status": "complete",
+                      "completion_pct": 1.0,
+                      "dependencies_available": 10,
+                      "dependencies_expected": 10
+                    },
+                    {
+                      "dimension": "component",
+                      "name": "component:pgrb2s",
+                      "label": "pgrb2s",
+                      "status": "complete",
+                      "completion_pct": 1.0,
+                      "dependencies_available": 5,
+                      "dependencies_expected": 5
+                    },
+                    {
+                      "dimension": "member",
+                      "name": "members:control",
+                      "label": "control",
+                      "status": "complete",
+                      "completion_pct": 1.0,
+                      "dependencies_available": 5,
+                      "dependencies_expected": 5
+                    },
+                    {
+                      "dimension": "member",
+                      "name": "members:perturbed",
+                      "label": "perturbed",
+                      "status": "complete",
+                      "completion_pct": 1.0,
+                      "dependencies_available": 20,
+                      "dependencies_expected": 20
+                    }
+                  ]
+                },
+                {
+                  "name": "f072",
+                  "status": "in_flight",
+                  "timing": "delayed",
+                  "completion_pct": 0.38,
+                  "leads_available": 5,
+                  "leads_expected": 13,
+                  "facets": [
+                    {
+                      "dimension": "component",
+                      "name": "component:pgrb2a",
+                      "label": "pgrb2a",
+                      "status": "in_flight",
+                      "completion_pct": 0.5385,
+                      "dependencies_available": 14,
+                      "dependencies_expected": 26
+                    },
+                    {
+                      "dimension": "component",
+                      "name": "component:pgrb2b",
+                      "label": "pgrb2b",
+                      "status": "in_flight",
+                      "completion_pct": 0.5385,
+                      "dependencies_available": 14,
+                      "dependencies_expected": 26
+                    },
+                    {
+                      "dimension": "component",
+                      "name": "component:pgrb2s",
+                      "label": "pgrb2s",
+                      "status": "in_flight",
+                      "completion_pct": 0.8462,
+                      "dependencies_available": 11,
+                      "dependencies_expected": 13
+                    },
+                    {
+                      "dimension": "member",
+                      "name": "members:control",
+                      "label": "control",
+                      "status": "in_flight",
+                      "completion_pct": 0.8462,
+                      "dependencies_available": 11,
+                      "dependencies_expected": 13
+                    },
+                    {
+                      "dimension": "member",
+                      "name": "members:perturbed",
+                      "label": "perturbed",
+                      "status": "in_flight",
+                      "completion_pct": 0.3077,
+                      "dependencies_available": 16,
+                      "dependencies_expected": 52
+                    }
+                  ]
+                }
+              ],
+              "facets": [
+                {
+                  "dimension": "component",
+                  "name": "component:pgrb2a",
+                  "label": "pgrb2a",
+                  "dependencies_available": 30,
+                  "dependencies_expected": 40,
+                  "completion_pct": 0.75,
+                  "status": "in_flight"
+                },
+                {
+                  "dimension": "component",
+                  "name": "component:pgrb2b",
+                  "label": "pgrb2b",
+                  "dependencies_available": 20,
+                  "dependencies_expected": 40,
+                  "completion_pct": 0.5,
+                  "status": "in_flight"
+                },
+                {
+                  "dimension": "component",
+                  "name": "component:pgrb2s",
+                  "label": "pgrb2s",
+                  "dependencies_available": 40,
+                  "dependencies_expected": 40,
+                  "completion_pct": 1,
+                  "status": "complete"
+                },
+                {
+                  "dimension": "member",
+                  "name": "members:control",
+                  "label": "control",
+                  "dependencies_available": 8,
+                  "dependencies_expected": 8,
+                  "completion_pct": 1,
+                  "status": "complete"
+                },
+                {
+                  "dimension": "member",
+                  "name": "members:perturbed",
+                  "label": "perturbed",
+                  "dependencies_available": 82,
+                  "dependencies_expected": 96,
+                  "completion_pct": 0.8542,
+                  "status": "in_flight"
+                }
+              ]
+            }
           ],
           "next_expected_init": "2026-07-25T18:00:00Z",
           "next_expected_completion_at": "2026-07-25T19:30:00Z"

--- a/test/pipeline.test.mjs
+++ b/test/pipeline.test.mjs
@@ -23,6 +23,7 @@ import {
   displaySource,
   etaLineText,
   facetRows,
+  initColumnPx,
   initParts,
   selectedTimeZone,
   validateDashboard,
@@ -370,19 +371,26 @@ test("orders the lead axis shortest horizon first, and the bands from the floor 
   );
 });
 
+test("gives an init column room for its own label", () => {
+  // "08-12" is five characters; a zone abbreviation makes local mode wider
+  assert.equal(initColumnPx(false), 30);
+  assert.equal(initColumnPx(true), 36);
+});
+
 test("fits the run count to the width the row actually has", () => {
   const flat = facetedProduct();
 
-  // production middle column is 390px; one square per run is 10px of pitch, so
-  // everything the payload carries fits
-  assert.equal(runsThatFit(flat, 390), 10);
-  // squeeze it: 66px of gutter leaves 74px, and a run costs 12px plus a 2px gap
-  assert.equal(runsThatFit(flat, 150), 5);
+  // production middle column is 390px, less 66px of gutter; a labelled column
+  // costs 30px in UTC plus a 6px gap, and 36px in local
+  assert.equal(runsThatFit(flat, 390, false), 8);
+  assert.equal(runsThatFit(flat, 390, true), 7);
+  // squeeze it
+  assert.equal(runsThatFit(flat, 200, false), 3);
   // never zero, however cramped, and never more than the payload carries
-  assert.equal(runsThatFit(flat, 40), 1);
-  assert.equal(runsThatFit(flat, 4000), 10);
+  assert.equal(runsThatFit(flat, 40, false), 1);
+  assert.equal(runsThatFit(flat, 4000, false), 10);
   // an unmeasurable row shows everything rather than nothing
-  assert.equal(runsThatFit(flat, 0), 10);
+  assert.equal(runsThatFit(flat, 0, false), 10);
 });
 
 test("moves facets out of their own bands once the joint is published", () => {

--- a/test/pipeline.test.mjs
+++ b/test/pipeline.test.mjs
@@ -8,10 +8,11 @@ import {
   cellOf,
   cellTitle,
   facetRowsOf,
+  leadAxis,
   usesFacetRows,
   facetsAt,
   hasJointFacets,
-  bandGutterCh,
+  gutterPx,
   runsThatFit,
   runsThatFitFacetRows,
   clockTime,
@@ -344,45 +345,51 @@ function jointProduct() {
   return product;
 }
 
-test("sizes the label gutter to the labels a product actually renders", () => {
-  // "pgrb2a.0p50" is the widest of the flat product's band labels
-  assert.equal(bandGutterCh(facetedProduct()), 11);
-  // with the joint there are no facet bands, so only "10d" has to fit
-  assert.equal(bandGutterCh(jointProduct()), 3);
+test("sizes the label gutter to the labels beside it", () => {
+  // "pgrb2a.0p50" is 11 characters, the widest of the flat product's bands
+  assert.equal(gutterPx(bandsOf(facetedProduct())), 66);
+  // with the joint the bands are lead-only, so only "10d" has to fit
+  assert.equal(gutterPx(bandsOf(jointProduct())), 18);
+  // its facet rows carry the long labels instead
+  assert.equal(gutterPx(facetRowsOf(jointProduct())), 66);
+});
+
+test("orders the lead axis shortest horizon first, and the bands from the floor up", () => {
+  assert.deepEqual(
+    leadAxis(facetedProduct()).map((lead) => lead.label),
+    ["1d", "10d"],
+  );
+  assert.deepEqual(
+    bandsOf(facetedProduct())
+      .filter((band) => band.kind === "lead")
+      .map((band) => band.label),
+    ["10d", "1d"],
+  );
 });
 
 test("fits the run count to the width the row actually has", () => {
   const flat = facetedProduct();
-  const joint = jointProduct();
 
   // production middle column is 390px; one square per run is 10px of pitch, so
-  // everything the payload carries fits either way
+  // everything the payload carries fits
   assert.equal(runsThatFit(flat, 390), 10);
-  assert.equal(runsThatFit(joint, 390), 10);
-  // squeeze it: a clump of two facets is 17px plus a 6px gap
-  assert.equal(runsThatFit(joint, 240), 9);
+  // squeeze it: 66px of gutter leaves 314px, then 274px, then 74px
   assert.equal(runsThatFit(flat, 150), 7);
   // never zero, however cramped, and never more than the payload carries
-  assert.equal(runsThatFit(joint, 100), 3);
-  assert.equal(runsThatFit(joint, 40), 1);
   assert.equal(runsThatFit(flat, 40), 1);
   assert.equal(runsThatFit(flat, 4000), 10);
   // an unmeasurable row shows everything rather than nothing
   assert.equal(runsThatFit(flat, 0), 10);
 });
 
-test("nests facets inside their lead group once the joint is published", () => {
+test("moves facets out of their own bands once the joint is published", () => {
   const flat = facetedProduct();
   assert.equal(hasJointFacets(flat), false);
-  assert.deepEqual(
-    bandsOf(flat).map((band) => band.kind),
-    ["lead", "lead", "facet", "facet"],
-  );
 
   const joint = jointProduct();
   assert.equal(hasJointFacets(joint), true);
-  // facets live in the lead bands now, so a band of their own would only
-  // repeat the run total
+  // facets own their own rows now, so a band of their own would only repeat
+  // the run total the details table already carries
   assert.deepEqual(
     bandsOf(joint).map((band) => `${band.kind}:${band.label}`),
     ["lead:10d", "lead:1d"],

--- a/test/pipeline.test.mjs
+++ b/test/pipeline.test.mjs
@@ -37,7 +37,7 @@ import { localZoneLabel } from "../public/status-time.mjs";
 
 function dashboard() {
   return {
-    v: 1,
+    v: 2,
     generated_at: "2026-07-25T18:00:00Z",
     window_days: 90,
     advisories: [],
@@ -57,13 +57,21 @@ function dashboard() {
   };
 }
 
-test("accepts the versioned dashboard contract", () => {
+test("accepts the granular dashboard contract", () => {
   assert.equal(validateDashboard(dashboard()).groups[0].id, "noaa-gfs");
 });
 
-test("accepts dashboard v2 facets while retaining dashboard v1", () => {
+test("rejects the lead-only schema it replaced", () => {
+  // wxopticon#158 cut the representative/lead-only writer over; this frontend
+  // consumes the granular schema only, so old JSON must fail loudly rather
+  // than render as though it were complete
+  const legacy = dashboard();
+  legacy.v = 1;
+  assert.throws(() => validateDashboard(legacy), /invalid pipeline dashboard/i);
+});
+
+test("accepts a product's facets", () => {
   const current = dashboard();
-  current.v = 2;
   const [product] = current.groups[0].products;
   product.facet_groups = [
     { dimension: "component", name: "component:pgrb2a", label: "pgrb2a" },
@@ -87,7 +95,6 @@ test("accepts dashboard v2 facets while retaining dashboard v1", () => {
   ];
 
   assert.equal(validateDashboard(current), current);
-  assert.equal(validateDashboard(dashboard()).v, 1);
 });
 
 test("rejects empty, unknown, and oversized dashboards", () => {
@@ -108,7 +115,6 @@ test("rejects empty, unknown, and oversized dashboards", () => {
   assert.throws(() => validateDashboard(tooMany), /invalid pipeline product/i);
 
   const malformedFacet = dashboard();
-  malformedFacet.v = 2;
   malformedFacet.groups[0].products[0].facet_groups = [
     { dimension: "component", name: "component:pgrb2a", label: "pgrb2a" },
   ];
@@ -285,19 +291,20 @@ function facetedProduct() {
   };
 }
 
-test("bands the field by lead group from the floor up, then by facet dimension", () => {
+test("bands the lead grid from the floor up, and only by lead group", () => {
+  // facets have their own views now, so the lead grid stays lead-only whether
+  // or not a product reports them
   assert.deepEqual(
     bandsOf(facetedProduct()).map((band) => `${band.kind}:${band.label}`),
-    ["lead:10d", "lead:1d", "facet:pgrb2a.0p50", "facet:control"],
+    ["lead:10d", "lead:1d"],
   );
 
-  // a v1 product reports no facets at all and gets lead bands only
   const noFacets = facetedProduct();
   delete noFacets.facet_groups;
   for (const init of noFacets.recent_inits) delete init.facets;
   assert.deepEqual(
-    bandsOf(noFacets).map((band) => band.kind),
-    ["lead", "lead"],
+    bandsOf(noFacets).map((band) => `${band.kind}:${band.label}`),
+    ["lead:10d", "lead:1d"],
   );
 });
 
@@ -350,11 +357,10 @@ function jointProduct() {
 }
 
 test("sizes the label gutter to the labels beside it", () => {
-  // "pgrb2a.0p50" is 11 characters, the widest of the flat product's bands
-  assert.equal(gutterPx(bandsOf(facetedProduct())), 66);
-  // with the joint the bands are lead-only, so only "10d" has to fit
+  // the lead grid's bands are lead-only, so only "10d" has to fit
+  assert.equal(gutterPx(bandsOf(facetedProduct())), 18);
   assert.equal(gutterPx(bandsOf(jointProduct())), 18);
-  // its facet rows carry the long labels instead
+  // the facet views carry the long labels instead
   assert.equal(gutterPx(facetRowsOf(jointProduct())), 66);
 });
 
@@ -380,12 +386,12 @@ test("gives an init column room for its own label", () => {
 test("fits the run count to the width the row actually has", () => {
   const flat = facetedProduct();
 
-  // production middle column is 390px, less 66px of gutter; a labelled column
-  // costs 30px in UTC plus a 6px gap, and 36px in local
-  assert.equal(runsThatFit(flat, 390, false), 8);
-  assert.equal(runsThatFit(flat, 390, true), 7);
+  // production middle column is 390px, less 18px of lead gutter; a labelled
+  // column costs 30px in UTC plus a 6px gap, and 36px in local
+  assert.equal(runsThatFit(flat, 390, false), 10);
+  assert.equal(runsThatFit(flat, 390, true), 8);
   // squeeze it
-  assert.equal(runsThatFit(flat, 200, false), 3);
+  assert.equal(runsThatFit(flat, 200, false), 4);
   // never zero, however cramped, and never more than the payload carries
   assert.equal(runsThatFit(flat, 40, false), 1);
   assert.equal(runsThatFit(flat, 4000, false), 10);
@@ -490,23 +496,27 @@ test("gives every facet in the joint its own labelled row", () => {
   );
 });
 
-test("keeps the lead field when a joint reports nothing", () => {
+test("keeps the lead grid usable when a joint reports nothing", () => {
   // the validator accepts an empty facets array, so this is supported input
   const empty = jointProduct();
   for (const group of empty.recent_inits[0].lead_groups) group.facets = [];
   assert.equal(hasJointFacets(empty), false);
   assert.equal(usesFacetRows(empty), false);
-  // and the field still carries every measurement it did before
+  // no facet views to cycle to, and the lead measurements still render
+  assert.deepEqual(
+    viewsOf(empty).map((view) => view.rows),
+    ["lead time"],
+  );
   assert.deepEqual(
     bandsOf(empty).map((band) => `${band.kind}:${band.label}`),
-    ["lead:10d", "lead:1d", "facet:pgrb2a.0p50", "facet:control"],
+    ["lead:10d", "lead:1d"],
   );
 
   // a rollback drops the key entirely
   const rolledBack = jointProduct();
   for (const group of rolledBack.recent_inits[0].lead_groups) delete group.facets;
   assert.equal(usesFacetRows(rolledBack), false);
-  assert.equal(bandsOf(rolledBack).length, 4);
+  assert.equal(bandsOf(rolledBack).length, 2);
 });
 
 test("draws a facet row for anything the joint reported in the window", () => {
@@ -620,10 +630,14 @@ test("rejects a malformed joint the same way as run-level facets", () => {
   broken.groups[0].products[0].recent_inits[0].lead_groups[0].facets[0].dependencies_available = 99;
   assert.throws(() => validateDashboard(broken), /invalid pipeline facet/i);
 
+  // the schema itself is checked before its facets, so old JSON carrying a
+  // joint is still rejected as the wrong schema
   const wrongVersion = JSON.parse(JSON.stringify(current));
   wrongVersion.v = 1;
-  delete wrongVersion.groups[0].products[0].facet_groups;
-  assert.throws(() => validateDashboard(wrongVersion), /invalid pipeline facet/i);
+  assert.throws(
+    () => validateDashboard(wrongVersion),
+    /invalid pipeline dashboard/i,
+  );
 });
 
 test("bands a history snapshot, which declares neither list up front", () => {
@@ -637,7 +651,7 @@ test("bands a history snapshot, which declares neither list up front", () => {
 
   assert.deepEqual(
     bandsOf(snapshot).map((band) => `${band.kind}:${band.label}`),
-    ["lead:10d", "lead:1d", "facet:pgrb2a.0p50", "facet:control"],
+    ["lead:10d", "lead:1d"],
   );
   // and still measures, rather than rendering an empty field
   const [longest] = bandsOf(snapshot);
@@ -657,14 +671,18 @@ test("measures a lead band by its own share, not the cumulative count", () => {
 test("names what a square measured, facet first, in its hover label", () => {
   const product = facetedProduct();
   const init = product.recent_inits[0];
-  const bands = bandsOf(product);
-  const facetBand = bands.find((band) => band.label === "pgrb2a.0p50");
+  const facetBand = {
+    kind: "facet",
+    key: "component:pgrb2a",
+    label: "pgrb2a.0p50",
+    dimension: "component",
+  };
   assert.equal(
     cellTitle(facetBand, init, cellOf(facetBand, init), false),
     "pgrb2a.0p50 (component) · 07-26 00z · 200 / 400 files · processing · delayed",
   );
 
-  const leadBand = bands.find((band) => band.label === "1d");
+  const leadBand = bandsOf(product).find((band) => band.label === "1d");
   assert.equal(
     cellTitle(leadBand, init, cellOf(leadBand, init), false),
     "lead 1d · 07-26 00z · 100% · complete · on time",
@@ -673,7 +691,12 @@ test("names what a square measured, facet first, in its hover label", () => {
 
 test("reads an unreported band as unobserved rather than a failure", () => {
   const product = facetedProduct();
-  const band = bandsOf(product).find((entry) => entry.kind === "facet");
+  const band = {
+    kind: "facet",
+    key: "component:pgrb2a",
+    label: "pgrb2a.0p50",
+    dimension: "component",
+  };
   const blind = { ...product.recent_inits[0], status: "unobserved" };
   assert.equal(cellOf(band, blind).state, "unobserved");
   assert.match(
@@ -1010,7 +1033,9 @@ test("pipeline page uses the shared subnav without a separate footer", () => {
   );
 
   assert.match(subnav, /https:\/\/status\.dynamical\.org\/webhooks/);
+  assert.match(template, /part arrived/);
   assert.match(template, /still expected/);
+  assert.match(template, /no monitoring data/);
   assert.match(template, /hover a square for what it measured/);
   assert.match(template, /no monitoring data/);
   assert.doesNotMatch(template, /pipeline-footer|window-days/);
@@ -1019,9 +1044,18 @@ test("pipeline page uses the shared subnav without a separate footer", () => {
   assert.match(template, /status-page-updated[\s\S]*status-time-toggle/);
   assert.doesNotMatch(template, /Local time|Coordinated Universal Time/);
   assert.doesNotMatch(template, /Data product pipeline|Forecast-run arrival/);
+  // "expected, nothing yet" and "no evidence either way" must not look alike
   assert.match(
     pipelineCss,
-    /\.pipeline-cell\.g-pending,[\s\S]*\.pipeline-cell\.g-unobserved\s*{\s*border: 1px dotted var\(--pipeline-unobserved\)/,
+    /\.pipeline-cell\.g-pending\s*{\s*border: 1px solid var\(--pipeline-unobserved\);\s*}/,
+  );
+  assert.match(
+    pipelineCss,
+    /\.pipeline-cell\.g-unobserved\s*{[\s\S]*?repeating-linear-gradient/,
+  );
+  assert.doesNotMatch(
+    pipelineCss,
+    /\.pipeline-cell\.g-pending,\s*\.pipeline-cell\.g-unobserved/,
   );
   assert.match(
     pipelineCss,

--- a/test/pipeline.test.mjs
+++ b/test/pipeline.test.mjs
@@ -4,7 +4,9 @@ import test from "node:test";
 
 import {
   agencySummary,
-  barTooltip,
+  bandsOf,
+  cellOf,
+  cellTitle,
   clockTime,
   detailRows,
   displaySource,
@@ -211,35 +213,139 @@ test("shortens displayed web sources without changing other schemes", () => {
   assert.equal(displaySource("s3://noaa-gfs-bdp-pds"), "s3://noaa-gfs-bdp-pds");
 });
 
-test("preserves run and lead-group detail in bar tooltips", () => {
-  assert.equal(
-    barTooltip(
+function facetedProduct() {
+  return {
+    id: "external-noaa-gefs-long-aws",
+    row_label: "AWS",
+    lead_groups: [
+      { name: "f000", label: "1d" },
+      { name: "f240", label: "10d" },
+    ],
+    facet_groups: [
+      { dimension: "component", name: "component:pgrb2a", label: "pgrb2a.0p50" },
+      { dimension: "member", name: "members:control", label: "control" },
+    ],
+    recent_inits: [
       {
         init_time: "2026-07-26T00:00:00Z",
         status: "in_flight",
-        timing: "on_time",
-        completion_pct: 0.5,
-        latency_s: 3600,
+        timing: "delayed",
         lead_groups: [
           {
-            name: "1d",
+            name: "f000",
             status: "complete",
             timing: "on_time",
             completion_pct: 1,
+            leads_available: 100,
+            leads_expected: 100,
           },
           {
-            name: "3d",
+            name: "f240",
             status: "in_flight",
             timing: "delayed",
             completion_pct: 0.25,
+            leads_available: 175,
+            leads_expected: 400,
+          },
+        ],
+        facets: [
+          {
+            dimension: "component",
+            name: "component:pgrb2a",
+            label: "pgrb2a.0p50",
+            status: "in_flight",
+            completion_pct: 0.5,
+            dependencies_available: 200,
+            dependencies_expected: 400,
+          },
+          {
+            dimension: "member",
+            name: "members:control",
+            label: "control",
+            status: "complete",
+            completion_pct: 1,
+            dependencies_available: 400,
+            dependencies_expected: 400,
           },
         ],
       },
-      false,
-    ),
-    "07-26 00z · in_flight · on_time · 50% · latency 1h\n" +
-      "1d complete · on_time · 3d in_flight · delayed 25%",
+    ],
+  };
+}
+
+test("bands the field by lead group from the floor up, then by facet dimension", () => {
+  assert.deepEqual(
+    bandsOf(facetedProduct()).map((band) => `${band.kind}:${band.label}`),
+    ["lead:10d", "lead:1d", "facet:pgrb2a.0p50", "facet:control"],
   );
+
+  // a v1 product reports no facets at all and gets lead bands only
+  const noFacets = facetedProduct();
+  delete noFacets.facet_groups;
+  for (const init of noFacets.recent_inits) delete init.facets;
+  assert.deepEqual(
+    bandsOf(noFacets).map((band) => band.kind),
+    ["lead", "lead"],
+  );
+});
+
+test("bands a history snapshot, which declares neither list up front", () => {
+  const snapshot = facetedProduct();
+  delete snapshot.lead_groups;
+  delete snapshot.facet_groups;
+  snapshot.lead_group_stats = [
+    { name: "f000", label: "1d" },
+    { name: "f240", label: "10d" },
+  ];
+
+  assert.deepEqual(
+    bandsOf(snapshot).map((band) => `${band.kind}:${band.label}`),
+    ["lead:10d", "lead:1d", "facet:pgrb2a.0p50", "facet:control"],
+  );
+  // and still measures, rather than rendering an empty field
+  const [longest] = bandsOf(snapshot);
+  assert.equal(cellOf(longest, snapshot.recent_inits[0]).state, "in_flight");
+});
+
+test("measures a lead band by its own share, not the cumulative count", () => {
+  const product = facetedProduct();
+  const [longest] = bandsOf(product);
+  const cell = cellOf(longest, product.recent_inits[0]);
+  // 175/400 cumulative becomes 75/300 once the band below it is taken out
+  assert.equal(cell.state, "in_flight");
+  assert.equal(cell.timing, "delayed");
+  assert.equal(cell.completion, 0.25);
+});
+
+test("names what a square measured, facet first, in its hover label", () => {
+  const product = facetedProduct();
+  const init = product.recent_inits[0];
+  const bands = bandsOf(product);
+  const facetBand = bands.find((band) => band.label === "pgrb2a.0p50");
+  assert.equal(
+    cellTitle(facetBand, init, cellOf(facetBand, init), false),
+    "pgrb2a.0p50 (component) · 07-26 00z · 200 / 400 files · processing · delayed",
+  );
+
+  const leadBand = bands.find((band) => band.label === "1d");
+  assert.equal(
+    cellTitle(leadBand, init, cellOf(leadBand, init), false),
+    "lead 1d · 07-26 00z · 100% · complete · on time",
+  );
+});
+
+test("reads an unreported band as unobserved rather than a failure", () => {
+  const product = facetedProduct();
+  const band = bandsOf(product).find((entry) => entry.kind === "facet");
+  const blind = { ...product.recent_inits[0], status: "unobserved" };
+  assert.equal(cellOf(band, blind).state, "unobserved");
+  assert.match(
+    cellTitle(band, blind, cellOf(band, blind), false),
+    /no probe visibility; not a publication failure/,
+  );
+
+  const missing = { ...product.recent_inits[0], facets: [] };
+  assert.equal(cellOf(band, missing).state, "unobserved");
 });
 
 test("shows exact and relative ETA in the selected timezone", () => {
@@ -556,7 +662,8 @@ test("pipeline page uses the shared subnav without a separate footer", () => {
   );
 
   assert.match(subnav, /https:\/\/status\.dynamical\.org\/webhooks/);
-  assert.match(template, /forecast hours still expected/);
+  assert.match(template, /still expected/);
+  assert.match(template, /hover a square for what it measured/);
   assert.match(template, /no monitoring data/);
   assert.doesNotMatch(template, /pipeline-footer|window-days/);
   assert.doesNotMatch(pipelineScript, /window-days/);
@@ -566,12 +673,13 @@ test("pipeline page uses the shared subnav without a separate footer", () => {
   assert.doesNotMatch(template, /Data product pipeline|Forecast-run arrival/);
   assert.match(
     pipelineCss,
-    /\.pipeline-bar-segment\.g-pending,[\s\S]*\.pipeline-bar-segment\.g-unobserved\s*{\s*border: 1px dotted var\(--pipeline-unobserved\)/,
+    /\.pipeline-cell\.g-pending,[\s\S]*\.pipeline-cell\.g-unobserved\s*{\s*border: 1px dotted var\(--pipeline-unobserved\)/,
   );
   assert.match(
     pipelineCss,
-    /\.pipeline-bar\[data-status="unobserved"\] \.pipeline-bar-track\s*{\s*border: 1px dotted/,
+    /\.pipeline-cell\.g-failed \.pipeline-cell-fill\s*{\s*height: 100%/,
   );
+  assert.doesNotMatch(pipelineCss, /pipeline-bar|pipeline-lead-labels/);
   assert.doesNotMatch(
     mainCss,
     /\.status-subnav\s*{[^}]*font-size:/s,

--- a/test/pipeline.test.mjs
+++ b/test/pipeline.test.mjs
@@ -374,14 +374,14 @@ test("groups component and member readiness for the displayed init", () => {
       label: "pgrb2a",
       status: "processing",
       completion: 0.75,
-      count: "3 / 4 files",
+      count: "3 / 4 observed",
     },
     {
       dimension: "member",
       label: "control",
       status: "complete",
       completion: 1,
-      count: "4 / 4 files",
+      count: "4 / 4 observed",
     },
   ]);
 });

--- a/test/pipeline.test.mjs
+++ b/test/pipeline.test.mjs
@@ -9,6 +9,9 @@ import {
   cellTitle,
   facetRowsOf,
   leadAxis,
+  leadExtents,
+  viewAt,
+  viewsOf,
   usesFacetRows,
   facetsAt,
   hasJointFacets,
@@ -373,8 +376,8 @@ test("fits the run count to the width the row actually has", () => {
   // production middle column is 390px; one square per run is 10px of pitch, so
   // everything the payload carries fits
   assert.equal(runsThatFit(flat, 390), 10);
-  // squeeze it: 66px of gutter leaves 314px, then 274px, then 74px
-  assert.equal(runsThatFit(flat, 150), 7);
+  // squeeze it: 66px of gutter leaves 74px, and a run costs 12px plus a 2px gap
+  assert.equal(runsThatFit(flat, 150), 5);
   // never zero, however cramped, and never more than the payload carries
   assert.equal(runsThatFit(flat, 40), 1);
   assert.equal(runsThatFit(flat, 4000), 10);
@@ -394,6 +397,71 @@ test("moves facets out of their own bands once the joint is published", () => {
     bandsOf(joint).map((band) => `${band.kind}:${band.label}`),
     ["lead:10d", "lead:1d"],
   );
+});
+
+test("sizes a lead group by its share of the run, never below its label", () => {
+  // counts arrive cumulative: f000 owns 100 of the run's 400, f240 the other
+  // 300. Each group starts at the 12px a two-character label needs, then shares
+  // an allowance the size of the axis again.
+  const extents = leadExtents(facetedProduct());
+  assert.equal(extents.get("f000"), 12 + 0.25 * 24);
+  assert.equal(extents.get("f240"), 12 + 0.75 * 24);
+  assert.ok(extents.get("f240") > extents.get("f000"));
+
+  // even a group that is a rounding error keeps room to name itself
+  const lopsided = facetedProduct();
+  const [init] = lopsided.recent_inits;
+  init.lead_groups[0].leads_expected = 1;
+  init.lead_groups[0].leads_available = 1;
+  init.lead_groups[1].leads_expected = 4000;
+  init.lead_groups[1].leads_available = 1;
+  const floored = leadExtents(lopsided);
+  assert.ok(floored.get("f000") >= 12);
+  assert.ok(floored.get("f240") > floored.get("f000") * 2);
+
+  // a product that reports no counts splits the allowance evenly
+  const uncounted = facetedProduct();
+  for (const group of uncounted.recent_inits[0].lead_groups) {
+    delete group.leads_expected;
+    delete group.leads_available;
+  }
+  assert.deepEqual([...leadExtents(uncounted).values()], [24, 24]);
+});
+
+test("offers one view per facet dimension, opening on the lead grid", () => {
+  // nothing to cycle without a joint: the lead grid is the only view
+  assert.deepEqual(
+    viewsOf(facetedProduct()).map((view) => view.rows),
+    ["lead time"],
+  );
+
+  const joint = jointProduct();
+  assert.deepEqual(
+    viewsOf(joint).map((view) => view.rows),
+    ["lead time", "component", "member"],
+  );
+  // clicking wraps back to the lead grid, in both directions
+  assert.equal(viewAt(joint, 0).dimension, null);
+  assert.equal(viewAt(joint, 1).dimension, "component");
+  assert.equal(viewAt(joint, 2).dimension, "member");
+  assert.equal(viewAt(joint, 3).dimension, null);
+  assert.equal(viewAt(joint, -1).dimension, "member");
+});
+
+test("a facet view shows only its own dimension's rows", () => {
+  const joint = jointProduct();
+  assert.deepEqual(
+    facetRowsOf(joint, "component").map((facet) => facet.label),
+    ["pgrb2a.0p50"],
+  );
+  assert.deepEqual(
+    facetRowsOf(joint, "member").map((facet) => facet.label),
+    ["control"],
+  );
+  // and the fit follows the rows it will actually draw: "pgrb2a.0p50" needs a
+  // 66px gutter where "control" needs 42px, so the member view fits one more run
+  assert.equal(runsThatFitFacetRows(joint, 390, "component"), 5);
+  assert.equal(runsThatFitFacetRows(joint, 390, "member"), 6);
 });
 
 test("gives every facet in the joint its own labelled row", () => {
@@ -464,12 +532,11 @@ test("draws a facet row for anything the joint reported in the window", () => {
 
 test("fits run blocks of lead columns to the width, once facets own the rows", () => {
   const joint = jointProduct();
-  // "pgrb2a.0p50" is 11ch of gutter; a block is 2 leads at 12px plus a 2px gap,
-  // so 32px of pitch — the payload's ten runs still fit the production column
-  assert.equal(runsThatFitFacetRows(joint, 390), 10);
-  assert.equal(runsThatFitFacetRows(joint, 240), 5);
-  assert.equal(runsThatFitFacetRows(joint, 200), 4);
-  assert.equal(runsThatFitFacetRows(joint, 150), 2);
+  // a block is its lead columns at proportional widths (18px + 30px) plus the
+  // 2px between them, so 50px of block and 56px of pitch
+  assert.equal(runsThatFitFacetRows(joint, 390), 5);
+  assert.equal(runsThatFitFacetRows(joint, 240), 3);
+  assert.equal(runsThatFitFacetRows(joint, 200), 2);
   assert.equal(runsThatFitFacetRows(joint, 1200), 10);
   // never zero, and an unmeasured row shows everything rather than nothing
   assert.equal(runsThatFitFacetRows(joint, 80), 1);

--- a/test/pipeline.test.mjs
+++ b/test/pipeline.test.mjs
@@ -9,10 +9,12 @@ import {
   detailRows,
   displaySource,
   etaLineText,
+  facetRows,
   initParts,
   selectedTimeZone,
   validateDashboard,
 } from "../public/pipeline.mjs";
+import { onRequestGet } from "../functions/pipeline-staging/[[path]].js";
 import {
   agencyHealth,
   systemHealth,
@@ -45,10 +47,39 @@ test("accepts the versioned dashboard contract", () => {
   assert.equal(validateDashboard(dashboard()).groups[0].id, "noaa-gfs");
 });
 
+test("accepts dashboard v2 facets while retaining dashboard v1", () => {
+  const current = dashboard();
+  current.v = 2;
+  const [product] = current.groups[0].products;
+  product.facet_groups = [
+    { dimension: "component", name: "component:pgrb2a", label: "pgrb2a" },
+  ];
+  product.recent_inits = [
+    {
+      init_time: "2026-07-25T12:00:00Z",
+      status: "in_flight",
+      facets: [
+        {
+          dimension: "component",
+          name: "component:pgrb2a",
+          label: "pgrb2a",
+          dependencies_available: 9,
+          dependencies_expected: 10,
+          completion_pct: 0.9,
+          status: "in_flight",
+        },
+      ],
+    },
+  ];
+
+  assert.equal(validateDashboard(current), current);
+  assert.equal(validateDashboard(dashboard()).v, 1);
+});
+
 test("rejects empty, unknown, and oversized dashboards", () => {
   assert.throws(() => validateDashboard({}), /invalid pipeline dashboard/i);
   assert.throws(
-    () => validateDashboard({ ...dashboard(), v: 2 }),
+    () => validateDashboard({ ...dashboard(), v: 3 }),
     /invalid pipeline dashboard/i,
   );
   assert.throws(
@@ -61,6 +92,19 @@ test("rejects empty, unknown, and oversized dashboards", () => {
     (_, index) => ({ init_time: String(index) }),
   );
   assert.throws(() => validateDashboard(tooMany), /invalid pipeline product/i);
+
+  const malformedFacet = dashboard();
+  malformedFacet.v = 2;
+  malformedFacet.groups[0].products[0].facet_groups = [
+    { dimension: "component", name: "component:pgrb2a", label: "pgrb2a" },
+  ];
+  malformedFacet.groups[0].products[0].recent_inits = [
+    { facets: [{ completion_pct: 2 }] },
+  ];
+  assert.throws(
+    () => validateDashboard(malformedFacet),
+    /invalid pipeline facet/i,
+  );
 });
 
 test("summarizes upstream agency advisories without changing pipeline state", () => {
@@ -294,6 +338,112 @@ test("shows the previous init details while waiting for the next init", () => {
       { status: "complete", time: "06:45", duration: "45m" },
     ],
   );
+});
+
+test("groups component and member readiness for the displayed init", () => {
+  const product = {
+    recent_inits: [
+      {
+        init_time: "2026-07-26T12:00:00Z",
+        status: "in_flight",
+        facets: [
+          {
+            dimension: "component",
+            label: "pgrb2a",
+            status: "in_flight",
+            completion_pct: 0.75,
+            dependencies_available: 3,
+            dependencies_expected: 4,
+          },
+          {
+            dimension: "member",
+            label: "control",
+            status: "complete",
+            completion_pct: 1,
+            dependencies_available: 4,
+            dependencies_expected: 4,
+          },
+        ],
+      },
+    ],
+  };
+
+  assert.deepEqual(facetRows(product), [
+    {
+      dimension: "component",
+      label: "pgrb2a",
+      status: "processing",
+      completion: 0.75,
+      count: "3 / 4 files",
+    },
+    {
+      dimension: "member",
+      label: "control",
+      status: "complete",
+      completion: 1,
+      count: "4 / 4 files",
+    },
+  ]);
+});
+
+test("local preview fixture exercises dashboard v2 facet rendering", () => {
+  const fixture = JSON.parse(
+    readFileSync(
+      new URL("./fixtures/pipeline-dashboard.json", import.meta.url),
+      "utf8",
+    ),
+  );
+  validateDashboard(fixture);
+  const [product] = fixture.groups[0].products;
+  assert.equal(fixture.v, 2);
+  assert.equal(product.facet_groups.length, 5);
+  assert.equal(facetRows(product).length, 5);
+});
+
+test("preview pipeline route exposes only allowlisted staging JSON", async () => {
+  const requested = [];
+  const bucket = {
+    async get(key) {
+      requested.push(key);
+      return key === "wxopticon/dashboard.json"
+        ? { body: '{"v":2}', httpEtag: '"etag"' }
+        : null;
+    },
+  };
+
+  const response = await onRequestGet({
+    env: { WXOPTICON_STAGING: bucket },
+    params: { path: ["wxopticon", "dashboard.json"] },
+  });
+  assert.equal(response.status, 200);
+  assert.equal(await response.text(), '{"v":2}');
+  assert.equal(
+    response.headers.get("content-type"),
+    "application/json; charset=utf-8",
+  );
+  assert.deepEqual(requested, ["wxopticon/dashboard.json"]);
+
+  const unavailable = await onRequestGet({
+    env: {},
+    params: { path: ["wxopticon", "dashboard.json"] },
+  });
+  assert.equal(unavailable.status, 503);
+
+  const denied = await onRequestGet({
+    env: { WXOPTICON_STAGING: bucket },
+    params: { path: ["wxopticon", "events.jsonl"] },
+  });
+  assert.equal(denied.status, 404);
+  assert.deepEqual(requested, ["wxopticon/dashboard.json"]);
+});
+
+test("preview branches select the private staging route", () => {
+  const source = readFileSync(
+    new URL("../_data/pipelineAssetsBase.js", import.meta.url),
+    "utf8",
+  );
+  assert.match(source, /process\.env\.CF_PAGES_BRANCH/);
+  assert.match(source, /\/pipeline-staging\/wxopticon/);
 });
 
 test("status pages share the uptime, pipeline, and pipeline webhooks subnav", () => {

--- a/test/pipeline.test.mjs
+++ b/test/pipeline.test.mjs
@@ -12,9 +12,7 @@ import {
   leadExtents,
   viewAt,
   viewsOf,
-  usesFacetRows,
   facetsAt,
-  hasJointFacets,
   gutterPx,
   runsThatFit,
   runsThatFitFacetRows,
@@ -377,19 +375,26 @@ test("orders the lead axis shortest horizon first, and the bands from the floor 
   );
 });
 
-test("gives an init column room for its own label", () => {
-  // "08-12" is five characters; a zone abbreviation makes local mode wider
-  assert.equal(initColumnPx(false), 30);
-  assert.equal(initColumnPx(true), 36);
+test("gives an init column room for its own label, in any zone", () => {
+  const product = facetedProduct();
+  // "08-12" is five characters, and a UTC time is three
+  assert.equal(initColumnPx(product, "UTC"), 30);
+  // a zone with a letter abbreviation is six: "19 CDT"
+  assert.equal(initColumnPx(product, "America/Chicago"), 36);
+  // en-US has no abbreviation for these, so it renders a GMT offset — the case a
+  // local/UTC guess got wrong, at nearly twice the width
+  assert.equal(initColumnPx(product, "Europe/Berlin"), 48);
+  assert.equal(initColumnPx(product, "Asia/Kolkata"), 66);
 });
 
 test("fits the run count to the width the row actually has", () => {
   const flat = facetedProduct();
 
-  // production middle column is 390px, less 18px of lead gutter; a labelled
-  // column costs 30px in UTC plus a 6px gap, and 36px in local
+  // production middle column is 390px, less 18px of lead gutter; a UTC-labelled
+  // column costs 30px plus a 6px gap. The local-zone widths are asserted
+  // separately, with explicit zones — asserting them through `local: true` here
+  // would only test whatever zone the test machine happens to be in.
   assert.equal(runsThatFit(flat, 390, false), 10);
-  assert.equal(runsThatFit(flat, 390, true), 8);
   // squeeze it
   assert.equal(runsThatFit(flat, 200, false), 4);
   // never zero, however cramped, and never more than the payload carries
@@ -401,10 +406,10 @@ test("fits the run count to the width the row actually has", () => {
 
 test("moves facets out of their own bands once the joint is published", () => {
   const flat = facetedProduct();
-  assert.equal(hasJointFacets(flat), false);
+  assert.deepEqual(facetRowsOf(flat), []);
 
   const joint = jointProduct();
-  assert.equal(hasJointFacets(joint), true);
+  assert.ok(facetRowsOf(joint).length > 0);
   // facets own their own rows now, so a band of their own would only repeat
   // the run total the details table already carries
   assert.deepEqual(
@@ -500,8 +505,7 @@ test("keeps the lead grid usable when a joint reports nothing", () => {
   // the validator accepts an empty facets array, so this is supported input
   const empty = jointProduct();
   for (const group of empty.recent_inits[0].lead_groups) group.facets = [];
-  assert.equal(hasJointFacets(empty), false);
-  assert.equal(usesFacetRows(empty), false);
+  assert.deepEqual(facetRowsOf(empty), []);
   // no facet views to cycle to, and the lead measurements still render
   assert.deepEqual(
     viewsOf(empty).map((view) => view.rows),
@@ -515,7 +519,10 @@ test("keeps the lead grid usable when a joint reports nothing", () => {
   // a rollback drops the key entirely
   const rolledBack = jointProduct();
   for (const group of rolledBack.recent_inits[0].lead_groups) delete group.facets;
-  assert.equal(usesFacetRows(rolledBack), false);
+  assert.deepEqual(
+    viewsOf(rolledBack).map((view) => view.rows),
+    ["lead time"],
+  );
   assert.equal(bandsOf(rolledBack).length, 2);
 });
 
@@ -528,7 +535,7 @@ test("draws a facet row for anything the joint reported in the window", () => {
   for (const group of newest.lead_groups) group.facets = [];
   mixed.recent_inits = [older, newest];
 
-  assert.equal(usesFacetRows(mixed), true);
+  assert.ok(facetRowsOf(mixed).length > 0);
   // rows come from the whole window, not just the newest run
   assert.deepEqual(
     facetRowsOf(mixed).map((facet) => facet.label),

--- a/test/pipeline.test.mjs
+++ b/test/pipeline.test.mjs
@@ -8,6 +8,7 @@ import {
   cellOf,
   cellTitle,
   facetRowsOf,
+  usesFacetRows,
   facetsAt,
   hasJointFacets,
   bandGutterCh,
@@ -406,6 +407,54 @@ test("gives every facet in the joint its own labelled row", () => {
   );
 });
 
+test("keeps the lead field when a joint reports nothing", () => {
+  // the validator accepts an empty facets array, so this is supported input
+  const empty = jointProduct();
+  for (const group of empty.recent_inits[0].lead_groups) group.facets = [];
+  assert.equal(hasJointFacets(empty), false);
+  assert.equal(usesFacetRows(empty), false);
+  // and the field still carries every measurement it did before
+  assert.deepEqual(
+    bandsOf(empty).map((band) => `${band.kind}:${band.label}`),
+    ["lead:10d", "lead:1d", "facet:pgrb2a.0p50", "facet:control"],
+  );
+
+  // a rollback drops the key entirely
+  const rolledBack = jointProduct();
+  for (const group of rolledBack.recent_inits[0].lead_groups) delete group.facets;
+  assert.equal(usesFacetRows(rolledBack), false);
+  assert.equal(bandsOf(rolledBack).length, 4);
+});
+
+test("draws a facet row for anything the joint reported in the window", () => {
+  // a rollout leaves the window mixed: the newest run has not reported yet
+  const mixed = jointProduct();
+  const older = mixed.recent_inits[0];
+  const newest = JSON.parse(JSON.stringify(older));
+  newest.init_time = "2026-07-26T06:00:00Z";
+  for (const group of newest.lead_groups) group.facets = [];
+  mixed.recent_inits = [older, newest];
+
+  assert.equal(usesFacetRows(mixed), true);
+  // rows come from the whole window, not just the newest run
+  assert.deepEqual(
+    facetRowsOf(mixed).map((facet) => facet.label),
+    ["pgrb2a.0p50", "control"],
+  );
+  // and the newest run's own cells read as unobserved rather than vanishing
+  assert.deepEqual(facetsAt(mixed, newest, "f240"), []);
+
+  // a facet the schema never declared still earns a row, since it was measured
+  const undeclared = jointProduct();
+  undeclared.facet_groups = undeclared.facet_groups.filter(
+    (facet) => facet.dimension === "component",
+  );
+  assert.deepEqual(
+    facetRowsOf(undeclared).map((facet) => facet.label),
+    ["pgrb2a.0p50", "control"],
+  );
+});
+
 test("fits run blocks of lead columns to the width, once facets own the rows", () => {
   const joint = jointProduct();
   // "pgrb2a.0p50" is 11ch of gutter; a block is 2 leads at 12px plus a 2px gap,
@@ -756,6 +805,17 @@ test("preview branches select the private staging route", () => {
   );
   assert.match(source, /process\.env\.CF_PAGES_BRANCH/);
   assert.match(source, /\/pipeline-staging\/wxopticon/);
+});
+
+test("a resize re-fits without re-timing a scrubbed snapshot", () => {
+  const script = readFileSync("public/pipeline.mjs", "utf8");
+  const handler = script.slice(
+    script.indexOf('window.addEventListener("resize"'),
+    script.indexOf("function setTimeMode"),
+  );
+  assert.match(handler, /displaySnapshot\(/);
+  assert.match(handler, /mode === "live" \? Date\.now\(\) : displayedAt/);
+  assert.doesNotMatch(handler, /displaySnapshot\(\s*displayedSnapshot,\s*Date\.now\(\)/);
 });
 
 test("status pages share the uptime, pipeline, and pipeline webhooks subnav", () => {

--- a/test/pipeline.test.mjs
+++ b/test/pipeline.test.mjs
@@ -9,6 +9,7 @@ import {
   cellTitle,
   facetsAt,
   hasJointFacets,
+  runsThatFit,
   clockTime,
   detailRows,
   displaySource,
@@ -338,6 +339,24 @@ function jointProduct() {
   ];
   return product;
 }
+
+test("fits the run count to the width the row actually has", () => {
+  const flat = facetedProduct();
+  const joint = jointProduct();
+
+  // production middle column: 390px, less the 140px gutter and the 6px band gap
+  // one square per run is 10px of pitch, so everything the payload carries fits
+  assert.equal(runsThatFit(flat, 390), 10);
+  // a clump of two facets is 17px plus a 6px gap, so fewer runs fit
+  assert.equal(runsThatFit(joint, 390), 10);
+  assert.equal(runsThatFit(joint, 240), 4);
+  assert.equal(runsThatFit(flat, 240), 9);
+  // never zero, however cramped, and never more than the payload carries
+  assert.equal(runsThatFit(joint, 150), 1);
+  assert.equal(runsThatFit(flat, 4000), 10);
+  // an unmeasurable row shows everything rather than nothing
+  assert.equal(runsThatFit(flat, 0), 10);
+});
 
 test("nests facets inside their lead group once the joint is published", () => {
   const flat = facetedProduct();

--- a/test/pipeline.test.mjs
+++ b/test/pipeline.test.mjs
@@ -7,9 +7,12 @@ import {
   bandsOf,
   cellOf,
   cellTitle,
+  facetRowsOf,
   facetsAt,
   hasJointFacets,
+  bandGutterCh,
   runsThatFit,
+  runsThatFitFacetRows,
   clockTime,
   detailRows,
   displaySource,
@@ -340,19 +343,28 @@ function jointProduct() {
   return product;
 }
 
+test("sizes the label gutter to the labels a product actually renders", () => {
+  // "pgrb2a.0p50" is the widest of the flat product's band labels
+  assert.equal(bandGutterCh(facetedProduct()), 11);
+  // with the joint there are no facet bands, so only "10d" has to fit
+  assert.equal(bandGutterCh(jointProduct()), 3);
+});
+
 test("fits the run count to the width the row actually has", () => {
   const flat = facetedProduct();
   const joint = jointProduct();
 
-  // production middle column: 390px, less the 140px gutter and the 6px band gap
-  // one square per run is 10px of pitch, so everything the payload carries fits
+  // production middle column is 390px; one square per run is 10px of pitch, so
+  // everything the payload carries fits either way
   assert.equal(runsThatFit(flat, 390), 10);
-  // a clump of two facets is 17px plus a 6px gap, so fewer runs fit
   assert.equal(runsThatFit(joint, 390), 10);
-  assert.equal(runsThatFit(joint, 240), 4);
-  assert.equal(runsThatFit(flat, 240), 9);
+  // squeeze it: a clump of two facets is 17px plus a 6px gap
+  assert.equal(runsThatFit(joint, 240), 9);
+  assert.equal(runsThatFit(flat, 150), 7);
   // never zero, however cramped, and never more than the payload carries
-  assert.equal(runsThatFit(joint, 150), 1);
+  assert.equal(runsThatFit(joint, 100), 3);
+  assert.equal(runsThatFit(joint, 40), 1);
+  assert.equal(runsThatFit(flat, 40), 1);
   assert.equal(runsThatFit(flat, 4000), 10);
   // an unmeasurable row shows everything rather than nothing
   assert.equal(runsThatFit(flat, 0), 10);
@@ -374,6 +386,38 @@ test("nests facets inside their lead group once the joint is published", () => {
     bandsOf(joint).map((band) => `${band.kind}:${band.label}`),
     ["lead:10d", "lead:1d"],
   );
+});
+
+test("gives every facet in the joint its own labelled row", () => {
+  const joint = jointProduct();
+  assert.deepEqual(
+    facetRowsOf(joint).map((facet) => facet.label),
+    ["pgrb2a.0p50", "control"],
+  );
+
+  // a facet the joint never reports gets no row
+  const partial = jointProduct();
+  for (const group of partial.recent_inits[0].lead_groups) {
+    group.facets = group.facets.filter((facet) => facet.dimension === "component");
+  }
+  assert.deepEqual(
+    facetRowsOf(partial).map((facet) => facet.label),
+    ["pgrb2a.0p50"],
+  );
+});
+
+test("fits run blocks of lead columns to the width, once facets own the rows", () => {
+  const joint = jointProduct();
+  // "pgrb2a.0p50" is 11ch of gutter; a block is 2 leads at 12px plus a 2px gap,
+  // so 32px of pitch — the payload's ten runs still fit the production column
+  assert.equal(runsThatFitFacetRows(joint, 390), 10);
+  assert.equal(runsThatFitFacetRows(joint, 240), 5);
+  assert.equal(runsThatFitFacetRows(joint, 200), 4);
+  assert.equal(runsThatFitFacetRows(joint, 150), 2);
+  assert.equal(runsThatFitFacetRows(joint, 1200), 10);
+  // never zero, and an unmeasured row shows everything rather than nothing
+  assert.equal(runsThatFitFacetRows(joint, 80), 1);
+  assert.equal(runsThatFitFacetRows(joint, 0), 10);
 });
 
 test("orders a lead group's facets as the product declares them", () => {

--- a/test/pipeline.test.mjs
+++ b/test/pipeline.test.mjs
@@ -7,6 +7,8 @@ import {
   bandsOf,
   cellOf,
   cellTitle,
+  facetsAt,
+  hasJointFacets,
   clockTime,
   detailRows,
   displaySource,
@@ -287,6 +289,147 @@ test("bands the field by lead group from the floor up, then by facet dimension",
     bandsOf(noFacets).map((band) => band.kind),
     ["lead", "lead"],
   );
+});
+
+function jointProduct() {
+  const product = facetedProduct();
+  const [init] = product.recent_inits;
+  const [shortLead, longLead] = init.lead_groups;
+  shortLead.facets = [
+    {
+      dimension: "component",
+      name: "component:pgrb2a",
+      label: "pgrb2a.0p50",
+      status: "complete",
+      completion_pct: 1,
+      dependencies_available: 100,
+      dependencies_expected: 100,
+    },
+    {
+      dimension: "member",
+      name: "members:control",
+      label: "control",
+      status: "complete",
+      completion_pct: 1,
+      dependencies_available: 100,
+      dependencies_expected: 100,
+    },
+  ];
+  longLead.facets = [
+    // declared second in facet_groups, reported first here
+    {
+      dimension: "member",
+      name: "members:control",
+      label: "control",
+      status: "in_flight",
+      completion_pct: 0.5,
+      dependencies_available: 150,
+      dependencies_expected: 300,
+    },
+    {
+      dimension: "component",
+      name: "component:pgrb2a",
+      label: "pgrb2a.0p50",
+      status: "pending",
+      completion_pct: 0,
+      dependencies_available: 0,
+      dependencies_expected: 300,
+    },
+  ];
+  return product;
+}
+
+test("nests facets inside their lead group once the joint is published", () => {
+  const flat = facetedProduct();
+  assert.equal(hasJointFacets(flat), false);
+  assert.deepEqual(
+    bandsOf(flat).map((band) => band.kind),
+    ["lead", "lead", "facet", "facet"],
+  );
+
+  const joint = jointProduct();
+  assert.equal(hasJointFacets(joint), true);
+  // facets live in the lead bands now, so a band of their own would only
+  // repeat the run total
+  assert.deepEqual(
+    bandsOf(joint).map((band) => `${band.kind}:${band.label}`),
+    ["lead:10d", "lead:1d"],
+  );
+});
+
+test("orders a lead group's facets as the product declares them", () => {
+  const joint = jointProduct();
+  const init = joint.recent_inits[0];
+  assert.deepEqual(
+    facetsAt(joint, init, "f240").map((facet) => facet.label),
+    ["pgrb2a.0p50", "control"],
+  );
+  assert.deepEqual(
+    facetsAt(joint, init, "f000").map((facet) => facet.label),
+    ["pgrb2a.0p50", "control"],
+  );
+  // a product without the joint has nothing to nest
+  const flat = facetedProduct();
+  assert.deepEqual(facetsAt(flat, flat.recent_inits[0], "f240"), []);
+});
+
+test("a nested square names its facet and the lead it arrived under", () => {
+  const joint = jointProduct();
+  const init = joint.recent_inits[0];
+  const [facet] = facetsAt(joint, init, "f240");
+  const band = {
+    kind: "facet",
+    key: facet.name,
+    label: facet.label,
+    dimension: facet.dimension,
+    lead: "10d",
+  };
+  assert.equal(
+    cellTitle(band, init, cellOf({ ...band, kind: "facet" }, init), false),
+    "pgrb2a.0p50 (component) · lead 10d · 07-26 00z · 200 / 400 files · processing · delayed",
+  );
+});
+
+test("rejects a malformed joint the same way as run-level facets", () => {
+  const current = dashboard();
+  current.v = 2;
+  const [product] = current.groups[0].products;
+  product.facet_groups = [
+    { dimension: "component", name: "component:pgrb2a", label: "pgrb2a" },
+  ];
+  product.recent_inits = [
+    {
+      init_time: "2026-07-25T12:00:00Z",
+      status: "in_flight",
+      lead_groups: [
+        {
+          name: "f000",
+          status: "in_flight",
+          facets: [
+            {
+              dimension: "component",
+              name: "component:pgrb2a",
+              label: "pgrb2a",
+              status: "in_flight",
+              completion_pct: 0.5,
+              dependencies_available: 5,
+              dependencies_expected: 10,
+            },
+          ],
+        },
+      ],
+    },
+  ];
+  assert.equal(validateDashboard(current), current);
+
+  const broken = JSON.parse(JSON.stringify(current));
+  broken.groups[0].products[0].recent_inits[0].lead_groups[0].facets[0].dependencies_available = 99;
+  assert.throws(() => validateDashboard(broken), /invalid pipeline facet/i);
+
+  const wrongVersion = JSON.parse(JSON.stringify(current));
+  wrongVersion.v = 1;
+  delete wrongVersion.groups[0].products[0].facet_groups;
+  assert.throws(() => validateDashboard(wrongVersion), /invalid pipeline facet/i);
 });
 
 test("bands a history snapshot, which declares neither list up front", () => {


### PR DESCRIPTION
# PR 186 — staging pipeline facets

## Success criteria

- [x] Cloudflare Pages previews read wxopticon data from the private staging R2 bucket through a read-only, allowlisted route.
- [x] Production continues to read dashboard v1 from `assets.dynamical.org` unchanged.
- [x] The pipeline page accepts dashboard v1 and v2 and rejects malformed facet data.
- [x] Component and member progress appears in the existing details disclosure without changing the lead-time bars.
- [x] The local pipeline fixture exercises dashboard v2.
- [x] Unit tests and the full Eleventy build pass.
- [x] The deployed PR preview is checked against live staging data.

## Plan

- [x] Add contract and staging-route tests.
- [x] Implement v1/v2 validation and minimal facet detail rows.
- [x] Add a preview-only Pages R2 route and select it during branch builds.
- [x] Update the local fixture and styles.
- [x] Run tests/build and push the implementation.
- [x] Configure the preview R2 binding and validate the deployed preview.

## Assumptions

- The final facet visualization remains intentionally undecided; this PR uses the existing details disclosure as a reversible staging presentation.
- The Pages preview environment will bind `WXOPTICON_STAGING` to `web-assets-staging`. No credentials are added to the site.
- Only dashboard and history JSON are exposed by the staging route.

### 2026-08-07 — plan opened

Draft PR opened from an isolated worktree after wxopticon PR 145 produced and validated dashboard v2 in staging.

### 2026-08-07 — implementation validation

The route exposes only dashboard and history JSON through a preview-only R2 binding. Dashboard v1 remains supported for production and older history. All 118 unit tests, the Eleventy build, seven browser tests, and the official Wrangler Pages Functions compiler pass.

### 2026-08-07 — deployed preview gate

Commit `8bc4a7f` deployed successfully at `https://9892413c.dynamical-org.pages.dev`. The allowlisted dashboard route returns the intended `503 Staging data unavailable` until the Cloudflare Pages **Preview** environment binds `WXOPTICON_STAGING` to the `web-assets-staging` R2 bucket. Redeploy the PR after adding the binding, then validate the live dashboard and history UI before marking the PR ready.

### 2026-08-08 — live preview validation

The binding was added and commit `936d35c` redeployed at `https://57ef67ac.dynamical-org.pages.dev`. The live route serves dashboard v2 with five facets for each of the four GEFS products. Browser validation rendered all four facet tables, exercised 380 history snapshots, and found no page errors, console errors, history error, or fallback banner.

### 2026-08-08 — retro

Keeping facets additive and presenting them inside the existing details disclosure preserved the lead-time UI and production v1 contract. A same-origin, allowlisted Pages Function gave the preview private R2 access without credentials or a public staging bucket. The only infrastructure-specific step was the preview R2 binding, which now remains available for subsequent staging PRs.


### 2026-08-11 — partial-history parity gate

The current partial staging corpus was regenerated before the full backfill so schema and presentation problems would surface early. Dashboard v2 contains all 14 external sources across nine model groups; 11 sources publish 44 component/member facet rows. All 135 recent runs have unique declared facet membership, valid dependency counts, and four-decimal percentages consistent with those counts; 105 runs carry facets.

A real-browser check of commit `9f6706e` rendered all sources and facets, loaded all 1,187 history snapshots, and found no console, page, or history errors. The check exposed one semantic issue: ECMWF member readiness uses logical shared-index evidence, so calling every count a physical “file” was inaccurate. The UI now says “arrival coverage” and “observed” without expanding the backend schema. All 118 unit tests and the 2,808-page Eleventy build pass, and GitHub/Cloudflare checks are green.

No backend schema redesign is required before completing history. GFS and AIFS-single intentionally remain lead-faceted only: their sidecars contribute to readiness at each lead but do not form an independently useful user-facing dimension.

### 2026-08-12 — arrival squares replace the bars

The facet visualization this PR deliberately left undecided is now decided. The details
disclosure was a placeholder; commit `dbd6a42` replaces the lead-time bars themselves with
a field of uniform squares — a band per lead group and per facet, one square per run, time
running left to right like a commit history.

**Why not subdivide the bars.** Measured against live staging at production geometry, a bar
is **30.4px wide** and its smallest lead band **0.9px tall** (f000 is 186 of GEFS long's
27,466 expected files, and band height is proportional to file count). Dicing that by facet
lands blocks at 6.1px for five facets and 0.4px once nested, and area-proportional sizing
gives the GEFS control member a **0.5px sliver** because it is 1/31 of the ensemble. Five
treemap variants and three square variants were rendered against real staging data before
choosing.

**Why squares are also more correct.** Component and member facets are independent
partitions of the *same* file set — both sum to 27,466 for GEFS long — so five slices of one
bar double-count the run. A square counts a measurement rather than dividing a whole, which
is what lets both dimensions appear at once without either claiming to be a share.

**Scope kept to measured values.** v2 publishes two marginals per run, `init.lead_groups[]`
and `init.facets[]`, never their intersection, so nothing here infers a per-cell number:
lead bands and facet bands each get one square per run. `bandsOf` / `cellOf` are structured
so that publishing `lead_groups[].facets[]` upgrades the field to facet clumps inside each
lead band without a rewrite.

Every square carries an HTML `title` naming what it measured, facet first:

```
pgrb2a.0p50 (component) · 08-11 19 CDT · 11,222 / 11,222 files · complete · on time
lead 35d · 08-11 19 CDT · 100% · complete · on time
```

**Verification.** Real-browser check against live staging in both themes: 14 products,
1,152 squares, zero untitled, no console or page errors; ETA column, ribbon, advisories,
details tables, and the 1,190-snapshot history scrub all still work. 122 unit tests and the
2,808-page build pass.

Two defects the browser caught that unit tests would not have:

1. `history/{ts}.json` carries `lead_group_stats` and per-init `lead_groups` but no
   product-level `lead_groups` / `facet_groups`, so the first cut emptied the field on scrub
   (980 cells → 0). `bandsOf` now falls back to the newest run's own lists. The same fallback
   fixed DWD ICON-EU in the live dashboard, which reports facets per init without declaring
   `facet_groups`.
2. The band gutter needed 14rem, not 8 — "precipitation and snow" clipped. The field is
   308px of the 358px column, so ten runs still fit with room for more.

**For review:** a product with five facets grows from a 130px row to 214px, since each facet
is its own band. Worth deciding whether facet bands should collapse into the details
disclosure by default on the busiest products.


### 2026-08-12 — facet rows, run blocks, and a fitted axis

The nested display is now the default for any faceted product, replacing the four-run
field and the standalone facet bands. Shape, chosen by iterating on rendered variants
against the fixture rather than on description:

- **A run is a block**, holding one square per lead group; **each facet is a labelled
  row**. The lead order (`0h · 1d · 3d`) is named once over the first block since it
  repeats, and facet names sit permanently in the gutter instead of behind a hover.
- **Two label tiers under the blocks**: the init time on every block, the date only where
  it turns over, each tier one block wide so both centre on the block axis — measured
  0.0px offset at 1440 and 1100.
- **The run count is fitted, not fixed.** `runsThatFit` / `runsThatFitFacetRows` derive it
  from the measured row body and the product's shape, so the payload's ten runs show when
  they fit and the field never overflows. A debounced resize re-fits.
- **Payloads with only the marginals are unchanged**: production v1 and today's staging v2
  keep the lead-banded field, verified against the live staging payload (10 runs, 5 facet
  bands, no clumps).

Two defects fixed along the way, both caught by measuring rather than by tests:

1. `--band-gutter` was stated in `ch`, which CSS resolves against the band's inherited
   font (~8px) while the fit arithmetic assumed the label's 6px character. The gutter
   rendered wider than the fit expected, the strip overflowed its container, and because
   squares have a hard minimum width while text spans do not, only the labels shrank —
   drifting out from under the squares they name, worst at the rightmost date. The gutter
   is now stated in px from the same constant, and the strip's parts are `flex: none` so a
   future squeeze overflows visibly instead of silently misaligning.
2. The gutter was a fixed 14rem sized for `precipitation and snow`, leaving ~120px empty on
   lead-only rows. It is now sized per product from the labels actually rendered.

130 unit tests and the 2,808-page build pass. `test/fixtures/pipeline-dashboard.json`
carries the joint, so `npm run start:pipeline` shows the shipped layout locally.

**Still blocked on wxopticon** for real data: `init.lead_groups[].facets[]` is not
published yet, so staging renders the banded fallback. A hand-off brief for that change
(contract, per-group rather than cumulative counts, the files it touches, and an invariant
check) is ready.


### 2026-08-12 — adversarial review fixes

An adversarial review of the branch surfaced two defects, both real and both fixed in
`542cb33`.

**A joint that reports nothing blanked the product field (high).** `hasJointFacets` treated
any `facets` array as a joint — including the empty array `validateDashboard` explicitly
accepts — while `facetRowsOf` derived rows from the newest run alone. A run that had not
reported yet, a partial rollout, or a rollback therefore switched the product to facet rows
and then drew none, hiding lead and run measurements that were perfectly good. That is
precisely the window this PR lives in, since wxopticon will emit the joint product by
product.

- A joint now requires a non-empty array.
- Rows collect every facet the joint mentions anywhere in the displayed runs, so a mixed
  window still draws them and cells without a measurement render as unobserved. Declared
  `facet_groups` keep owning the order; a measured facet the schema never declared gets a
  row rather than disappearing.
- `usesFacetRows(product)` — a joint *and* rows to draw — is now the single gate every
  layout branch passes through, so the transposition cannot hide what it replaces.

**A resize re-timed a scrubbed snapshot to the present (medium).** The resize handler passed
`Date.now()` unconditionally, so resizing or rotating while scrubbed recomputed historical
ETAs and elapsed durations against the current clock. It now mirrors the adjacent time-mode
handler: `mode === "live" ? Date.now() : displayedAt`.

Regression tests were verified against the pre-fix code rather than assumed: restoring the
old `hasJointFacets` fails the empty-joint test, restoring the old resize handler fails the
timing test, and restoring newest-run-only rows fails six tests. The three payload states a
rollout passes through were checked in a browser:

| payload | layout | squares | unobserved |
|---|---|---|---|
| joint everywhere | facet rows | 105 | 0 |
| newest run reports nothing yet | facet rows | 105 | 15 |
| every run empty (rollback) | lead bands | 80 | 45 |

133 unit tests and the 2,808-page build pass.


### 2026-08-12 — a lead grid by default, facet grids on click

Final shape of the visualisation.

**The field opens on the reading `main` had**: lead groups as rows, init times as columns,
one cell per run per lead group. **Clicking it cycles the rows** through each facet
dimension the joint reports — component, then member, then back to lead time — with lead
groups as the columns and runs still grouped into blocks. The view index lives on the row,
the listener is delegated to the group container so it survives every re-render, Enter and
Space work against a visible focus ring, and a product without a joint gets no affordance
because it has nothing to cycle. A hint line names both axes and the next view, since a
click target that changes what a chart means should say so.

**One cell size everywhere.** The lead grid drew 8px cells and the facet grids 12px, so a
cell meant different things in different views. Both are 12px now.

**The lead dimension is sized by group**, as the bar segments were: whichever axis lead time
owns is proportional to each group's share of the run's expected files. Every group starts
at the width its own label needs (12px — what "0h" takes) and shares an allowance the size
of the axis again, so the biggest group reads as biggest without the smallest becoming a
sliver that cannot name itself. GEFS long spans 0h at 12.6px to 35d at 40.8px, with 16d
correctly narrower than 10d because its group is smaller. Column labels render only where
the column can hold them; the rest keep their name on hover.

Verified in a browser across all three views and against the real staging payload: cells
constant on the non-lead axis, proportional on the lead axis, nothing overflowing the 390px
column, and the cycle wrapping correctly by click and by keyboard. 137 tests and the
2,808-page build pass.


### 2026-08-12 — labelled init columns

The default view's columns are now as wide as the label beneath them, at main's spacing, so
every init names itself rather than the field carrying one range line.

`initColumnPx(local)` sizes a column from the label it must hold — 30px for `08-12` in UTC,
36px in local where the zone abbreviation is wider — and the gap is main's 6px. Both layouts
share one init axis: the time under every column, the date only where it turns over, aligned
to the first column of that date. `.pipeline-axis` is gone, since nothing emits it now.

The lead rows keep their own scale, so widening the init axis left the proportions alone
(0h 14.8px, 1d 23.1px, 3d 34.1px). The fit takes the timezone mode because a local column is
wider: at the production 390px column, **8 runs fit in UTC and 7 in local**, against ten
unlabelled cells before — the same trade main made for a readable axis.

Measured: 36px columns with 6px gaps in local mode, all eight time labels centred on their
column at 0.0px offset, dates aligned to their first column, 390px of the 390px available
with no overflow, facet views unaffected. 138 tests and the build pass.


---

### 2026-08-12 — this PR now does dynamical.org#194

wxopticon #159/#160 closed and staging publishes the lead × facet joint, so this stops being
a staged prototype and becomes the replacement frontend. Closes #194.

**The live payload was checked against the contract before any code changed**: zero
violations across 2,128 joint rows — every facet name resolves against `facet_groups`, no
`dependencies_expected` of zero, and per dimension the facet counts sum to the lead group's
own expected count. The per-group-rather-than-cumulative semantics that the hand-off brief
flagged as the one real trap came through correctly: GEFS long f840 reports own expected
9,424 with pgrb2a at 4,712, while the sibling `leads_expected` reads 27,466 cumulative.

Per the issue's decisions:

- **The granular schema is the only contract.** `DASHBOARD_VERSION = 2`; a v1 payload is
  rejected as the wrong schema rather than rendered as though it were complete. There is an
  explicit test for that rejection.
- **The lead grid is lead-only.** Facet bands in the marginal field were the compatibility
  shape for a staging state that no longer exists.
- **Unknown and partial read differently**, which the issue requires and the previous CSS did
  not do — `pending` and `unobserved` were both dotted-and-empty. Now `pending` (expected,
  nothing yet) is a solid empty outline, `unobserved` (no evidence either way) is hatched, and
  partial keeps its part-filled bar. The legend gained a "part arrived" mark.

**Validated against real staging artifacts for every expanded source**, which is the issue's
gate: 14 products, 944 cells, every view each product offers, heights constant across a
product's views, nothing overflowing its column, no console errors, and all four arrival
states present in live data (pending 203, unobserved 22, partial 16, failed 43).

| product | views | field |
|---|---|---|
| GFS ×2, AIFS-single | 1 — lead only, as designed | 185px |
| GEFS long ×2 | 3 — lead, component, member | 211px |
| GEFS short ×2 | 3 | 185px |
| HRRR ×2, ICON-EU ×2 | 2 — lead, component | 133px |
| ECMWF ens ×3 | 2 — lead, member | 185px |

**Merge order: decided.** This frontend cannot read production's current JSON by design — the
issue's "no backward compatibility" decision — so merging before wxopticon#163 leaves
`/status/pipeline/` on its error banner until the backend cuts over, because Pages deploys on
merge to `main`. That brief error state is accepted, so this does not wait for #163.

What the error window looks like: the page renders normally — subnav, system health, upstream
advisories — with `Couldn't load pipeline status (Invalid pipeline dashboard)` in the banner
slot where the field would be. It clears itself on the first poll after the cutover, with no
redeploy needed.

Two things the error window does *not* cover, both verified against live staging:

- **The history scrub keeps working.** Snapshots are rendered without validation, so rejecting
  v1 does not affect them: 1,201 snapshots, scrubbed 5 and 400 back, no scrub error and no
  banner, 594 and 468 cells rendering.
- **Scrubbed snapshots have no facet views.** History snapshots carry no
  `lead_groups[].facets`, so a scrubbed row falls back to the lead grid with no click
  affordance. The facet cycle is live-data-only until the backfill (wxopticon#161/#162)
  regenerates history — a longer-lived gap than the merge window itself.

**One trade left open for review:** with proportional lead columns and a label-width floor, a
product with seven lead groups fits only one run block per facet view at the production 390px
column (180px block + 6px gap against 314px usable). Uniform 12px lead columns in the facet
views would fit three runs instead. The default lead grid is unaffected either way.

