### PR TITLE
Add commercial SLA terms

### DIFF
--- a/content/sla-terms.html
+++ b/content/sla-terms.html
@@ -1,0 +1,99 @@
+---
+layout: base.njk
+title: commercial SLA terms
+socialTitle: Commercial SLA Terms
+description: The terms for commercial SLA services provided by Dynamical Technology PBC.
+permalink: /sla/terms/
+eleventyExcludeFromCollections: true
+---
+
+<div class="content">
+  <h1 style="margin-top: 4rem; margin-bottom: 1rem;">Commercial SLA Terms</h1>
+  <p class="metadata-comment">Last updated: August 8, 2026</p>
+
+  <p>
+    These terms govern commercial SLA services purchased from Dynamical
+    Technology PBC ("Dynamical"). Together with the applicable invoice and the
+    version or date of the <a href="/sla/">Commercial SLA</a> identified on that
+    invoice, they are the entire agreement between Dynamical and the customer
+    identified on the invoice ("Customer"). If they conflict, the invoice
+    controls, followed by the applicable SLA, then these terms.
+  </p>
+
+  <h3>1. Services &amp; Data Licenses</h3>
+  <p>
+    Customer purchases only the commercial support, operational commitments,
+    and remedies described in the invoice and applicable SLA (the "SLA
+    Services"). The invoice identifies the service tier, covered scope,
+    applicable SLA version or date, fees, term, and any renewal terms.
+  </p>
+  <p>
+    Customer does not purchase data products or data licenses under this
+    agreement. Data in the public <a href="/catalog/">catalog</a> remains
+    available separately and is governed by the license listed on its catalog
+    page. This agreement does not narrow or expand the rights granted by those
+    licenses.
+  </p>
+
+  <h3>2. Fees &amp; Payment</h3>
+  <p>
+    Fees are invoiced in advance according to the billing frequency and payment
+    terms on the invoice. Late payments accrue interest at 1.5% per month or the
+    maximum permitted by law, if lower. After written notice, Dynamical may
+    suspend commercial SLA services while an account is more than 30 days past
+    due.
+  </p>
+
+  <h3>3. Term &amp; Renewal</h3>
+  <p>
+    The agreement begins on the effective date stated on the invoice and
+    continues for the term stated there. It renews only as stated on the invoice
+    or as the parties otherwise agree in writing.
+  </p>
+
+  <h3>4. Termination</h3>
+  <p>
+    Either party may terminate this agreement for a material breach that remains
+    uncured 30 days after written notice. Fees are non-refundable except for
+    credits or refunds expressly provided by the applicable SLA. Termination
+    ends the SLA Services, but does not affect public catalog access under each
+    data product's license. Accrued and unpaid fees remain due.
+  </p>
+
+  <h3>5. Warranty Disclaimer</h3>
+  <p>
+    Except for the operational commitments in the applicable SLA, the SLA
+    Services are provided "as is," and Dynamical disclaims all warranties to the
+    maximum extent permitted by law. Data products are separate and remain
+    subject to the terms and disclaimers in their respective licenses.
+  </p>
+
+  <h3>6. Limitation of Liability</h3>
+  <p>
+    Neither party is liable for indirect, incidental, or consequential damages
+    arising from this agreement. Each party's aggregate liability is limited to
+    the fees paid or payable under the applicable invoice during the 12 months
+    before the event giving rise to the claim.
+  </p>
+
+  <h3>7. Confidentiality</h3>
+  <p>
+    Each party will protect the other's non-public information with reasonable
+    care and use it only to perform this agreement. This obligation does not
+    cover information that is public through no breach, independently developed,
+    or lawfully received without a duty of confidentiality. A party may disclose
+    information when legally required after giving notice where permitted.
+  </p>
+
+  <h3>8. General</h3>
+  <p>
+    Delaware law governs this agreement without regard to conflict-of-laws
+    principles. The state and federal courts in Delaware have exclusive venue,
+    and each party consents to personal jurisdiction there. Neither party may
+    assign this agreement without the other's consent, except in connection with
+    a merger, reorganization, or transfer of substantially all its assets. The
+    invoice, applicable SLA, and these terms supersede prior discussions about
+    the SLA Services. Amendments must be agreed in writing by both parties.
+    Notices may be sent by email to the contacts identified on the invoice.
+  </p>
+</div>

--- a/content/sla.html
+++ b/content/sla.html
@@ -21,6 +21,11 @@ eleventyExcludeFromCollections: true
   <h2 style="margin-top: 0; margin-bottom: 4rem;">Build critical training and operational infrastructure on dynamical.org</h2>
 
   <p>
+    See the <a href="/sla/terms/">Commercial SLA Terms</a> that apply to paid
+    SLA services.
+  </p>
+
+  <p>
     <strong>dynamical.org</strong> publishes an analysis-ready, multi-model
     Icechunk Zarr weather catalog. Our commercial SLA supports the operation and
     development of the dynamical.org catalog and services, and adds a dedicated

--- a/test/sla-terms.test.mjs
+++ b/test/sla-terms.test.mjs
@@ -1,0 +1,30 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const SLA = readFileSync(new URL("../content/sla.html", import.meta.url), "utf8");
+const TERMS = readFileSync(
+  new URL("../content/sla-terms.html", import.meta.url),
+  "utf8",
+);
+
+test("publishes commercial SLA terms with shared page metadata", () => {
+  assert.match(TERMS, /layout: base\.njk/);
+  assert.match(TERMS, /title: commercial SLA terms/);
+  assert.match(TERMS, /socialTitle: Commercial SLA Terms/);
+  assert.match(TERMS, /permalink: \/sla\/terms\//);
+  assert.match(TERMS, /eleventyExcludeFromCollections: true/);
+});
+
+test("cross-links the SLA and its terms", () => {
+  assert.match(SLA, /href="\/sla\/terms\/"/);
+  assert.match(TERMS, /href="\/sla\/"/);
+});
+
+test("keeps commercial SLA services separate from catalog data licenses", () => {
+  assert.match(TERMS, /Dynamical Technology PBC/);
+  assert.match(TERMS, /does not purchase data products or data licenses/i);
+  assert.match(TERMS, /license listed on (?:its|each) catalog\s+page/i);
+  assert.match(TERMS, /commercial SLA services/i);
+  assert.doesNotMatch(TERMS, /\bOrder\b/);
+});


### PR DESCRIPTION
## Summary

Add minimal terms at `/sla/terms/` for commercial SLA customers. The terms cover paid service commitments from Dynamical Technology PBC and expressly leave public catalog data under each product's existing license.

## Plan

- [x] Add the Commercial SLA Terms page with the shared layout and metadata.
- [x] Make the Invoice authoritative for scope, SLA version, term, renewal, and pricing.
- [x] State that customers buy SLA services, not data products or data licenses.
- [x] Add reciprocal SLA/Terms links.
- [x] Add focused contract-page tests.
- [x] Run the full test suite and production build.

## Decisions

- The contracting entity is Dynamical Technology PBC.
- The page applies only to commercial SLA customers, not ordinary catalog visitors.
- Every Invoice identifies the applicable SLA version or date.
- The Invoice controls term and renewal; there is no default automatic renewal.

### 2026-08-08 — Implementation

- Added `/sla/terms/` with the shared layout, canonical/social metadata, and reciprocal SLA link.
- Added source-level tests for metadata, cross-links, provider identity, invoice terminology, and the separation between SLA services and catalog licenses.
- Validated with `npm test` (116 passing) and `npm run build`.

### 2026-08-08 — Retro

Keeping data access explicitly outside the commercial agreement removed the draft's conflicting redistribution restriction and made termination and suspension apply only to paid SLA services. The shared layout required no duplicated navigation or footer markup.