### PR TITLE
Clarify SLA material breach

### DIFF
--- a/content/sla-terms.html
+++ b/content/sla-terms.html
@@ -9,7 +9,7 @@ eleventyExcludeFromCollections: true
 
 <div class="content">
   <h1 style="margin-top: 4rem; margin-bottom: 1rem;">Commercial SLA Terms</h1>
-  <p class="metadata-comment">Last updated: August 8, 2026</p>
+  <p class="metadata-comment">Last updated: August 10, 2026</p>
 
   <p>
     These terms govern commercial SLA services purchased from Dynamical
@@ -53,11 +53,14 @@ eleventyExcludeFromCollections: true
 
   <h3>4. Termination</h3>
   <p>
-    Either party may terminate this agreement for a material breach that remains
-    uncured 30 days after written notice. Fees are non-refundable except for
-    credits or refunds expressly provided by the applicable SLA. Termination
-    ends the SLA Services, but does not affect public catalog access under each
-    data product's license. Accrued and unpaid fees remain due.
+    Either party may terminate this agreement if the other materially breaches an
+    obligation under the invoice, these Terms, or the applicable SLA and does not
+    cure the breach within 30 days after written notice describing it. Failure to
+    meet an SLA target is governed by the SLA's credits and termination rights and
+    is not, by itself, a material breach. Fees are non-refundable except for
+    credits or refunds expressly provided by the applicable SLA. Termination ends
+    the SLA Services, but does not affect public catalog access under each data
+    product's license. Accrued and unpaid fees remain due.
   </p>
 
   <h3>5. Warranty Disclaimer</h3>

--- a/test/sla-terms.test.mjs
+++ b/test/sla-terms.test.mjs
@@ -28,3 +28,9 @@ test("keeps commercial SLA services separate from catalog data licenses", () => 
   assert.match(TERMS, /commercial SLA services/i);
   assert.doesNotMatch(TERMS, /\bOrder\b/);
 });
+
+test("keeps ordinary SLA target misses within the SLA remedies", () => {
+  assert.match(TERMS, /written notice describing (?:the breach|it)/i);
+  assert.match(TERMS, /SLA's credits and termination rights/i);
+  assert.match(TERMS, /not, by itself, a material breach/i);
+});


### PR DESCRIPTION
## Summary

Clarify what the Commercial SLA Terms mean by a curable material breach.

## Changes

- Require the termination notice to describe the breached obligation under the invoice, Terms, or applicable SLA.
- State that an ordinary SLA target miss is governed by SLA credits and termination rights and is not, by itself, a material breach.
- Update the Terms' last-updated date.
- Add a regression test for that distinction.

This follows up on #187.

## Validation

- `node --test test/sla-terms.test.mjs`
- `npm test` — 117 passing
- `npm run build`