### PR TITLE
Route outside comments to Slack #feedback

### DIFF
--- a/.github/workflows/outside-comment-notify.yml
+++ b/.github/workflows/outside-comment-notify.yml
@@ -1,0 +1,67 @@
+name: Notify #feedback on outside comments
+
+# Canonical copy lives in dynamical-org/meta at automation/outside-comment-notify.yml.
+# Edit there, then sync to each public repo.
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted]
+  discussion_comment:
+    types: [created]
+  issues:
+    types: [opened]
+  discussion:
+    types: [created]
+
+permissions: {}
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    # Anyone in the org is OWNER/MEMBER/COLLABORATOR, so this needs no username list.
+    if: >-
+      github.event.sender.type != 'Bot' &&
+      !contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'),
+        github.event.comment.author_association ||
+        github.event.review.author_association ||
+        github.event.issue.author_association ||
+        github.event.discussion.author_association)
+    steps:
+      # Everything from the event goes through env, never string-interpolated into
+      # the script -- a comment body is attacker-controlled text.
+      - name: Post to #feedback
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_FEEDBACK_WEBHOOK }}
+          ACTOR: ${{ github.event.sender.login }}
+          REPO: ${{ github.repository }}
+          KIND: ${{ github.event_name }}
+          URL: ${{ github.event.comment.html_url || github.event.review.html_url || github.event.issue.html_url || github.event.discussion.html_url }}
+          TITLE: ${{ github.event.issue.title || github.event.pull_request.title || github.event.discussion.title }}
+          BODY: ${{ github.event.comment.body || github.event.review.body || github.event.issue.body || github.event.discussion.body }}
+        run: |
+          set -euo pipefail
+
+          case "$KIND" in
+            issue_comment)               WHAT="commented" ;;
+            pull_request_review_comment) WHAT="commented on a diff" ;;
+            pull_request_review)         WHAT="reviewed a PR" ;;
+            discussion_comment)          WHAT="commented on a discussion" ;;
+            issues)                      WHAT="opened an issue" ;;
+            discussion)                  WHAT="started a discussion" ;;
+            *)                           WHAT="posted" ;;
+          esac
+
+          BODY_TRIM=$(printf '%s' "$BODY" | head -c 600)
+          [ "${#BODY}" -gt 600 ] && BODY_TRIM="$BODY_TRIM…"
+
+          jq -n \
+            --arg actor "$ACTOR" --arg what "$WHAT" --arg url "$URL" \
+            --arg repo "$REPO" --arg title "$TITLE" --arg body "$BODY_TRIM" \
+            '{ text: ("*<" + $url + "|" + $actor + " " + $what + ">* in `" + $repo + "`"
+                      + (if $title == "" then "" else "\n*" + $title + "*" end)
+                      + (if $body  == "" then "" else "\n>" + ($body | gsub("\n"; "\n>")) end)) }' \
+            | curl -sS -f -X POST -H 'Content-type: application/json' --data @- "$SLACK_WEBHOOK"


### PR DESCRIPTION
Sends comments from people outside the org to Slack `#feedback`, keeping the day-to-day GitHub feed in `#ops`.

The Slack GitHub app filters on event type, branch, and label only — no author filter — so this needs a workflow. Outside is determined by `author_association` (skips `OWNER`/`MEMBER`/`COLLABORATOR` and bots), so there is no username list to maintain.

Canonical copy and rationale: dynamical-org/meta `automation/outside-comment-notify.yml` (dynamical-org/meta#184). Needs the org secret `SLACK_FEEDBACK_WEBHOOK`.