### PR TITLE
Fix uncaught exceptions on /status/pipeline/ and /scorecard/

### DIFF
--- a/public/pipeline.mjs
+++ b/public/pipeline.mjs
@@ -121,8 +121,28 @@ export function initParts(timestamp, timeZone = "UTC") {
   };
 }
 
-function selectedTimeZone(local) {
-  return local ? Intl.DateTimeFormat().resolvedOptions().timeZone : "UTC";
+const validTimeZoneCache = new Map();
+
+// Some browsers report a non-standard IANA zone (e.g. "Etc/Unknown") from
+// resolvedOptions().timeZone, which Intl.DateTimeFormat itself rejects.
+function isValidTimeZone(timeZone) {
+  let valid = validTimeZoneCache.get(timeZone);
+  if (valid === undefined) {
+    try {
+      new Intl.DateTimeFormat("en-US", { timeZone });
+      valid = true;
+    } catch {
+      valid = false;
+    }
+    validTimeZoneCache.set(timeZone, valid);
+  }
+  return valid;
+}
+
+export function selectedTimeZone(local) {
+  if (!local) return "UTC";
+  const resolved = Intl.DateTimeFormat().resolvedOptions().timeZone;
+  return isValidTimeZone(resolved) ? resolved : "UTC";
 }
 
 function initShort(timestamp, local) {

--- a/public/scorecard.js
+++ b/public/scorecard.js
@@ -88,9 +88,17 @@ function captureError(error, context) {
 
 let _dbReady = null;
 
-function initDB() {
+export function initDB() {
   if (_dbReady) return _dbReady;
   _dbReady = (async () => {
+    // duckdb-wasm's bundle selection references the global WebAssembly object
+    // unconditionally (via wasm-feature-detect's exceptions() check), which
+    // throws an uncaught ReferenceError rather than reporting "unsupported"
+    // on a browser context where WebAssembly is absent entirely (e.g. Safari
+    // Lockdown Mode). Fail fast with a catchable error instead.
+    if (typeof WebAssembly === "undefined") {
+      throw new Error("WebAssembly is not available in this browser");
+    }
     const duckdb = await import(
       "https://cdn.jsdelivr.net/npm/@duckdb/duckdb-wasm@1.28.0/+esm"
     );

--- a/test/pipeline.test.mjs
+++ b/test/pipeline.test.mjs
@@ -10,6 +10,7 @@ import {
   displaySource,
   etaLineText,
   initParts,
+  selectedTimeZone,
   validateDashboard,
 } from "../public/pipeline.mjs";
 import {
@@ -135,6 +136,29 @@ test("formats init labels in UTC and the selected local timezone", () => {
     date: "07-25",
     time: "19 CDT",
   });
+});
+
+test("falls back to UTC when the browser reports a non-IANA local timezone", () => {
+  // Some browsers resolve to non-standard zones (e.g. "Etc/Unknown") that
+  // Intl.DateTimeFormat itself rejects with a RangeError when passed explicitly.
+  const RealDateTimeFormat = Intl.DateTimeFormat;
+  function FakeDateTimeFormat(locale, options) {
+    if (options?.timeZone === "Etc/Unknown") {
+      throw new RangeError("Invalid time zone specified: Etc/Unknown");
+    }
+    const real = new RealDateTimeFormat(locale, options);
+    if (!options) {
+      const resolved = real.resolvedOptions();
+      real.resolvedOptions = () => ({ ...resolved, timeZone: "Etc/Unknown" });
+    }
+    return real;
+  }
+  Intl.DateTimeFormat = FakeDateTimeFormat;
+  try {
+    assert.equal(selectedTimeZone(true), "UTC");
+  } finally {
+    Intl.DateTimeFormat = RealDateTimeFormat;
+  }
 });
 
 test("shortens displayed web sources without changing other schemes", () => {

--- a/test/scorecard-config.test.mjs
+++ b/test/scorecard-config.test.mjs
@@ -21,6 +21,7 @@ const {
   VARIABLE_METRICS,
   DEFAULT_METRIC,
   encodedWindowValues,
+  initDB,
 } = await import(
   `data:text/javascript,${encodeURIComponent(readFileSync(SCORECARD_JS, "utf8"))}`
 );
@@ -45,6 +46,19 @@ test("every variable's default metric is one it offers", () => {
       `${variable} defaults to ${metric}, which is not in its metric list, so ` +
         "no dropdown option would be preselected",
     );
+  }
+});
+
+test("rejects with a catchable error, without reaching the CDN, when WebAssembly is unavailable", async () => {
+  // A browser context without WebAssembly at all (e.g. Safari Lockdown Mode)
+  // must not reach duckdb-wasm's unconditional feature-detection, which
+  // throws an uncaught ReferenceError instead of reporting "unsupported".
+  const originalWebAssembly = globalThis.WebAssembly;
+  delete globalThis.WebAssembly;
+  try {
+    await assert.rejects(initDB(), /WebAssembly/);
+  } finally {
+    globalThis.WebAssembly = originalWebAssembly;
   }
 });
 


### PR DESCRIPTION
## Summary

Two defensive fixes for client-side JS crashes seen in Sentry:

- **`public/pipeline.mjs`** — `selectedTimeZone()` passed the browser's
  `Intl.DateTimeFormat().resolvedOptions().timeZone` straight into another
  `Intl.DateTimeFormat` call. Some browsers/OSes resolve to the
  non-standard zone `"Etc/Unknown"`, which `Intl.DateTimeFormat` itself
  rejects with a `RangeError`, crashing rendering of the pipeline status
  page's live-updating rows. `selectedTimeZone()` now validates the
  resolved zone (via a small memoized `isValidTimeZone` helper) and falls
  back to `"UTC"` when it's invalid, so every downstream call site
  (tooltip, countdown, row hydration) gets a valid zone.
- **`public/scorecard.js`** — `initDB()` unconditionally imported
  `@duckdb/duckdb-wasm`, whose bundle-selection feature detection
  references the global `WebAssembly` object unconditionally. On a browser
  context where `WebAssembly` is entirely absent (e.g. Safari Lockdown
  Mode), this throws an uncaught `ReferenceError` instead of the library's
  own detection reporting "unsupported". `initDB()` now checks
  `typeof WebAssembly === "undefined"` up front and throws a normal,
  catchable `Error` instead, which flows into the same existing
  try/catch → `captureError` → "Error loading the plot" UI that
  `renderMetric`/`renderObs` already use for other failures.

Addresses Sentry issues DYNAMICAL-ORG-SITE-E, DYNAMICAL-ORG-SITE-F, and DYNAMICAL-ORG-SITE-G (plain references, not GitHub issues).

## Test plan

- [x] `npm test` — all offline unit tests pass (119/119), including two new
      regression tests: one that mocks `Intl.DateTimeFormat` to reject
      `"Etc/Unknown"` and asserts `selectedTimeZone(true)` falls back to
      `"UTC"`, and one that deletes `globalThis.WebAssembly` and asserts
      `initDB()` rejects with a catchable error rather than reaching the
      CDN.
- [x] `npm run build` — full static build completes without error.
- [ ] `npm run test:e2e` — not run (needs a browser + network); not required for this change per repo guidance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUCwRNFaKyEpV8nidNRHsa


---
_Generated by [Claude Code](https://claude.ai/code/session_01QUCwRNFaKyEpV8nidNRHsa)_