### PR TITLE
Pin GitHub Actions to full-length commit SHAs

### DIFF
--- a/.github/workflows/scorecard-charts.yml
+++ b/.github/workflows/scorecard-charts.yml
@@ -36,8 +36,8 @@ jobs:
     # walks every window and metric option.
     timeout-minutes: 25
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
         with:
           node-version: 24
           # No `cache: npm`: package-lock.json is gitignored, so there is no
@@ -47,7 +47,7 @@ jobs:
       # Playwright starts the Eleventy dev server itself (see webServer in
       # playwright.config.mjs), so there is no separate build step.
       - run: npm run test:e2e
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         if: failure()
         with:
           name: playwright-report

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,8 +20,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
         with:
           node-version: 24
           # No `cache: npm`: package-lock.json is gitignored in this repo, so


### PR DESCRIPTION
Pins every tag-pinned `uses:` ref in this repo to the full-length commit SHA the tag currently points at, with the tag preserved as a trailing comment.

The org-level Actions policy now has **Require actions to be pinned to a full-length commit SHA** enabled. Tag-pinned refs are rejected at run startup with an opaque "workflow file issue" error, so this repo's workflows cannot run until they are pinned.

SHAs were resolved from the tags that were previously in use, so behaviour is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)