### PR TITLE
Replace pipeline frontend with granular schema

### DIFF
--- a/_data/pipelineAssetsBase.js
+++ b/_data/pipelineAssetsBase.js
@@ -1,3 +1,5 @@
 module.exports =
   process.env.PIPELINE_ASSETS_BASE ||
-  "https://assets.dynamical.org/wxopticon";
+  (process.env.CF_PAGES_BRANCH && process.env.CF_PAGES_BRANCH !== "main"
+    ? "/pipeline-staging/wxopticon"
+    : "https://assets.dynamical.org/wxopticon");

--- a/content/status-pipeline.njk
+++ b/content/status-pipeline.njk
@@ -30,17 +30,18 @@ pageStylesheet: /pipeline.css
   </div>
   <div data-slot="banners" aria-live="polite"></div>
 
-  <div class="pipeline-legend" aria-label="Pipeline bar legend">
+  <div class="pipeline-legend" aria-label="Pipeline legend">
     <span>
       <span class="pipeline-legend-mark pipeline-legend-mark--pending"
         aria-hidden="true"></span>
-      forecast hours still expected
+      still expected
     </span>
     <span>
       <span class="pipeline-legend-mark pipeline-legend-mark--unobserved"
         aria-hidden="true"></span>
       no monitoring data
     </span>
+    <span>one square per run · hover a square for what it measured</span>
   </div>
 
   <div id="pipeline-history-panel" hidden>

--- a/functions/package.json
+++ b/functions/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/functions/pipeline-staging/[[path]].js
+++ b/functions/pipeline-staging/[[path]].js
@@ -1,0 +1,31 @@
+const DASHBOARD_KEY = "wxopticon/dashboard.json";
+const HISTORY_INDEX_KEY = "wxopticon/history/index.json";
+const HISTORY_SNAPSHOT_KEY =
+  /^wxopticon\/history\/\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}Z\.json$/;
+
+function isAllowed(key) {
+  return (
+    key === DASHBOARD_KEY ||
+    key === HISTORY_INDEX_KEY ||
+    HISTORY_SNAPSHOT_KEY.test(key)
+  );
+}
+
+export async function onRequestGet(context) {
+  const key = (context.params.path ?? []).join("/");
+  if (!isAllowed(key)) return new Response("Not found", { status: 404 });
+  if (!context.env.WXOPTICON_STAGING) {
+    return new Response("Staging data unavailable", { status: 503 });
+  }
+
+  const object = await context.env.WXOPTICON_STAGING.get(key);
+  if (!object) return new Response("Not found", { status: 404 });
+
+  const headers = new Headers({
+    "cache-control": "public, max-age=15",
+    "content-type": "application/json; charset=utf-8",
+    "x-content-type-options": "nosniff",
+  });
+  if (object.httpEtag) headers.set("etag", object.httpEtag);
+  return new Response(object.body, { headers });
+}

--- a/public/pipeline.css
+++ b/public/pipeline.css
@@ -299,6 +299,16 @@
   text-align: left;
 }
 
+.pipeline-facets {
+  margin-top: 1.2rem;
+}
+
+.pipeline-facets progress {
+  width: 8rem;
+  accent-color: var(--pipeline-ok);
+  vertical-align: middle;
+}
+
 .pipeline-time-local .pipeline-time-utc,
 body:not(.pipeline-time-local) .pipeline-time-local-only {
   display: none;

--- a/public/pipeline.css
+++ b/public/pipeline.css
@@ -120,123 +120,103 @@
   min-width: 0;
 }
 
-.pipeline-lead-labels {
-  position: relative;
-  flex: none;
-  width: 2.6rem;
-  height: 13rem;
-  color: var(--muted-text);
-  font-size: 1rem;
-  line-height: 1;
-}
+/* The field: a band per measurement, a square per run, time to the right. */
 
-.pipeline-lead-labels span {
-  position: absolute;
-  right: 0;
-  transform: translateY(50%);
-  white-space: nowrap;
-}
-
-.pipeline-grid {
-  display: grid;
-  grid-template-columns: repeat(10, minmax(0, 1fr));
+.pipeline-field {
+  display: flex;
   flex: 1;
-  gap: 0.6rem;
+  flex-direction: column;
+  gap: 2px;
   min-width: 0;
 }
 
-.pipeline-bar {
-  display: flex;
-  flex-direction: column;
+.pipeline-band {
+  display: grid;
+  grid-template-columns: 14rem minmax(0, max-content);
   align-items: center;
-  gap: 0.4rem;
+  gap: 0 0.6rem;
 }
 
-.pipeline-bar-track {
-  position: relative;
-  width: 100%;
-  height: 13rem;
+.pipeline-band-label {
   overflow: hidden;
+  color: var(--muted-text);
+  font-size: 1rem;
+  line-height: 1;
+  text-align: right;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.pipeline-band[data-kind="lead"] .pipeline-band-label {
+  color: var(--text-color);
+}
+
+/* names a facet dimension once, where its bands start */
+.pipeline-dimension {
+  margin: 0.6rem 0 0.1rem;
+  padding-left: 14.6rem;
+  color: var(--muted-text-2);
+  font-size: 1rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.pipeline-cells {
+  display: flex;
+  gap: 2px;
+}
+
+.pipeline-cell {
+  position: relative;
+  width: 8px;
+  height: 8px;
   border: 1px solid var(--text-color);
 }
 
-.pipeline-bar-fill,
-.pipeline-bar-segment,
-.pipeline-bar-segment-fill {
+.pipeline-cell-fill {
   position: absolute;
   right: 0;
   bottom: 0;
   left: 0;
-}
-
-.pipeline-bar-fill {
   height: var(--fill, 0%);
 }
 
-.pipeline-bar-segment {
-  bottom: var(--band-bottom, 0%);
-  height: var(--band-height, 0%);
-}
-
-.pipeline-bar-segment
-  + .pipeline-bar-segment:not(:last-child, .g-pending, .g-unobserved) {
-  border-top: 1px solid var(--text-color);
-}
-
-.pipeline-bar-segment-fill {
-  height: var(--fill, 0%);
-}
-
-.pipeline-bar[data-status="complete"] .pipeline-bar-fill,
-.pipeline-bar-segment.g-complete .pipeline-bar-segment-fill {
+.pipeline-cell.g-complete .pipeline-cell-fill {
   background: var(--pipeline-ok);
 }
 
-.pipeline-bar[data-status="complete"][data-timing="delayed"] .pipeline-bar-fill,
-.pipeline-bar[data-status="in_flight"] .pipeline-bar-fill,
-.pipeline-bar-segment.g-complete[data-timing="delayed"] .pipeline-bar-segment-fill,
-.pipeline-bar-segment.g-in_flight .pipeline-bar-segment-fill {
+.pipeline-cell.g-complete[data-timing="delayed"] .pipeline-cell-fill,
+.pipeline-cell.g-in_flight .pipeline-cell-fill {
   background: var(--pipeline-progress);
 }
 
-.pipeline-bar[data-status="in_flight"][data-timing="on_time"] .pipeline-bar-fill,
-.pipeline-bar-segment.g-in_flight[data-timing="on_time"] .pipeline-bar-segment-fill {
+.pipeline-cell.g-in_flight[data-timing="on_time"] .pipeline-cell-fill {
   background: var(--pipeline-ok);
 }
 
-.pipeline-bar[data-status="failed"] .pipeline-bar-fill,
-.pipeline-bar-segment.g-failed .pipeline-bar-segment-fill {
+.pipeline-cell.g-failed .pipeline-cell-fill {
   height: 100%;
   background: var(--pipeline-failed);
 }
 
-.pipeline-bar-segment.g-pending,
-.pipeline-bar-segment.g-unobserved {
+.pipeline-cell.g-pending,
+.pipeline-cell.g-unobserved {
   border: 1px dotted var(--pipeline-unobserved);
 }
 
-.pipeline-bar[data-status="unobserved"] .pipeline-bar-track {
-  border: 1px dotted var(--pipeline-unobserved);
-}
-
-.pipeline-bar[data-status="unobserved"] .pipeline-bar-fill,
-.pipeline-bar[data-status="unobserved"] .pipeline-bar-segment,
-.pipeline-bar-segment.g-pending .pipeline-bar-segment-fill,
-.pipeline-bar-segment.g-unobserved .pipeline-bar-segment-fill {
+.pipeline-cell.g-pending .pipeline-cell-fill,
+.pipeline-cell.g-unobserved .pipeline-cell-fill {
   display: none;
 }
 
-.pipeline-bar-label {
-  min-height: 2.4em;
-  color: var(--muted-text);
+.pipeline-axis {
+  display: grid;
+  grid-template-columns: 14rem minmax(0, max-content);
+  gap: 0 0.6rem;
+  margin-top: 0.4rem;
+  color: var(--muted-text-2);
   font-size: 1rem;
-  line-height: 1.2;
-  text-align: center;
-}
-
-.pipeline-bar-label strong {
-  display: block;
-  color: var(--text-color);
+  white-space: nowrap;
 }
 
 .pipeline-stats {
@@ -325,11 +305,12 @@ body:not(.pipeline-time-local) .pipeline-time-local-only {
 }
 
 @media (max-width: 680px) {
-  .pipeline-grid {
-    gap: 0.3rem;
+  .pipeline-band,
+  .pipeline-axis {
+    grid-template-columns: 8rem minmax(0, max-content);
   }
 
-  .pipeline-bar-label {
-    font-size: 0.8rem;
+  .pipeline-dimension {
+    padding-left: 8.6rem;
   }
 }

--- a/public/pipeline.mjs
+++ b/public/pipeline.mjs
@@ -174,11 +174,6 @@ function initShort(timestamp, local) {
   return `${date} ${time}`;
 }
 
-function initLabel(timestamp, local) {
-  const { date, time } = initParts(timestamp, selectedTimeZone(local));
-  return element("span", null, [element("strong", null, date), time]);
-}
-
 function formatTime(timestamp, local, includeZone = true) {
   const options = {
     month: "short",
@@ -217,8 +212,11 @@ function timeNode(timestamp) {
   ]);
 }
 
-function groupSlices(groups) {
-  const total = groups.at(-1)?.leads_expected ?? 0;
+/* One square per measurement. Lead-group counts arrive cumulative, so a band's
+   own share is the difference from the band below it — the same arithmetic the
+   bars used for segment heights. */
+
+function leadSlices(groups) {
   let previousAvailable = 0;
   let previousExpected = 0;
   return groups.map((group) => {
@@ -227,86 +225,165 @@ function groupSlices(groups) {
     previousExpected = group.leads_expected;
     previousAvailable = group.leads_available;
     return {
-      ...group,
-      height: total ? (expected / total) * 100 : 0,
-      fill: expected ? Math.max(0, Math.min(100, (available / expected) * 100)) : 0,
+      name: group.name,
+      status: group.status,
+      timing: group.timing,
+      available,
+      expected,
+      completion: expected
+        ? Math.max(0, Math.min(1, available / expected))
+        : (group.completion_pct ?? 0),
     };
   });
 }
 
-export function barTooltip(init, local) {
-  if (init.status === "unobserved") {
-    return `${initShort(init.init_time, local)} · no probe visibility; not a publication failure`;
+/* The bands of a product's field, top row first: longest horizon down to the
+   floor, then a band per facet grouped by dimension. Bands come from the
+   product rather than a single run so the field keeps its shape as runs
+   scroll through it. */
+
+export function bandsOf(product) {
+  const newest = product.recent_inits?.at(-1);
+  // history snapshots carry the same runs but declare neither list up front
+  const labelOf = new Map(
+    (product.lead_group_stats ?? []).map((stats) => [stats.name, stats.label]),
+  );
+  const declaredLeads = product.lead_groups?.length
+    ? product.lead_groups
+    : (newest?.lead_groups ?? []);
+  const leads = declaredLeads.map((group) => ({
+    kind: "lead",
+    key: group.name,
+    label: group.label ?? labelOf.get(group.name) ?? group.name,
+  }));
+  leads.reverse();
+
+  const declaredFacets = product.facet_groups?.length
+    ? product.facet_groups
+    : (newest?.facets ?? []);
+  const facets = declaredFacets.map((facet) => ({
+    kind: "facet",
+    key: facet.name,
+    label: facet.label,
+    dimension: facet.dimension,
+  }));
+  return [...leads, ...facets];
+}
+
+/* What one run measured for one band. A band the run never reported reads as
+   unobserved rather than as a failure. */
+
+export function cellOf(band, init) {
+  if (!init) return { state: "unobserved" };
+  if (init.status === "unobserved") return { state: "unobserved" };
+
+  if (band.kind === "lead") {
+    const slice = leadSlices(init.lead_groups ?? []).find(
+      (group) => group.name === band.key,
+    );
+    if (!slice) return { state: "unobserved" };
+    return {
+      state: slice.status,
+      timing: slice.timing,
+      completion: slice.completion,
+    };
   }
-  const state = init.timing ? `${init.status} · ${init.timing}` : init.status;
-  const run = [
-    initShort(init.init_time, local),
-    state,
-    init.completion_pct == null
-      ? null
-      : `${Math.round(init.completion_pct * 100)}%`,
-    init.latency_s == null ? null : `latency ${formatLatency(init.latency_s)}`,
+
+  const facet = (init.facets ?? []).find((entry) => entry.name === band.key);
+  if (!facet) return { state: "unobserved" };
+  return {
+    state: facet.status,
+    timing: init.timing,
+    completion: facet.completion_pct ?? 0,
+    available: facet.dependencies_available,
+    expected: facet.dependencies_expected,
+  };
+}
+
+/* The hover label. What the square stands for comes first, then when, then how
+   much of it arrived — a facet names itself and its dimension. */
+
+export function cellTitle(band, init, cell, local) {
+  if (!init) return `${band.label} · not reported`;
+  const when = initShort(init.init_time, local);
+  if (cell.state === "unobserved") {
+    return `${band.label} · ${when} · no probe visibility; not a publication failure`;
+  }
+  const volume =
+    cell.expected != null
+      ? `${cell.available.toLocaleString("en-US")} / ${cell.expected.toLocaleString("en-US")} files`
+      : `${Math.round((cell.completion ?? 0) * 100)}%`;
+  return [
+    band.kind === "facet" ? `${band.label} (${band.dimension})` : `lead ${band.label}`,
+    when,
+    volume,
+    statusLabel(cell.state),
+    cell.timing ? cell.timing.replaceAll("_", " ") : null,
   ]
     .filter(Boolean)
     .join(" · ");
-  if (!init.lead_groups?.length) return run;
-  const groups = init.lead_groups.map((group) => {
-    const groupState = group.timing
-      ? `${group.status} · ${group.timing}`
-      : group.status;
-    const progress =
-      group.status === "in_flight" && group.completion_pct != null
-        ? ` ${Math.round(group.completion_pct * 100)}%`
-        : "";
-    return `${group.name} ${groupState}${progress}`;
-  });
-  return `${run}\n${groups.join(" · ")}`;
 }
 
-function renderBar(init, local) {
-  const track = element("div", { class: "pipeline-bar-track" });
-  if (init.lead_groups?.length) {
-    let bottom = 0;
-    for (const group of groupSlices(init.lead_groups)) {
-      const segment = element(
-        "div",
-        {
-          class: `pipeline-bar-segment g-${group.status}`,
-          "data-group": group.name,
-          "data-timing": group.timing,
-          style: `--band-height:${group.height}%;--band-bottom:${bottom}%;--fill:${group.fill}%`,
-        },
-        element("div", { class: "pipeline-bar-segment-fill" }),
-      );
-      track.append(segment);
-      bottom += group.height;
-    }
-  } else {
-    track.append(
-      element("div", {
-        class: "pipeline-bar-fill",
-        style: `--fill:${Math.max(0, Math.min(100, (init.completion_pct ?? 0) * 100))}%`,
-      }),
-    );
-  }
+function renderCell(band, init, local) {
+  const cell = cellOf(band, init);
   return element(
     "div",
     {
-      class: "pipeline-bar",
-      "data-init-time": init.init_time,
-      "data-status": init.status,
-      "data-timing": init.timing,
-      title: barTooltip(init, local),
+      class: `pipeline-cell g-${cell.state}`,
+      "data-init-time": init?.init_time,
+      "data-timing": cell.timing,
+      title: cellTitle(band, init, cell, local),
     },
-    [
-      track,
-      element(
-        "div",
-        { class: "pipeline-bar-label" },
-        initLabel(init.init_time, local),
-      ),
-    ],
+    element("div", {
+      class: "pipeline-cell-fill",
+      style: `--fill:${Math.max(0, Math.min(100, (cell.completion ?? 0) * 100))}%`,
+    }),
   );
+}
+
+function renderField(product, local) {
+  const runs = product.recent_inits.slice(-10);
+  const field = element("div", { class: "pipeline-field" });
+  let dimension = null;
+
+  for (const band of bandsOf(product)) {
+    // name each facet dimension once, where it starts
+    if (band.kind === "facet" && band.dimension !== dimension) {
+      field.append(
+        element("div", { class: "pipeline-dimension" }, band.dimension),
+      );
+    }
+    dimension = band.kind === "facet" ? band.dimension : null;
+
+    const cells = element("div", { class: "pipeline-cells" });
+    for (const init of runs) cells.append(renderCell(band, init, local));
+    field.append(
+      element("div", { class: "pipeline-band", "data-kind": band.kind }, [
+        element(
+          "span",
+          { class: "pipeline-band-label", title: band.label },
+          band.label,
+        ),
+        cells,
+      ]),
+    );
+  }
+
+  const first = runs[0];
+  const last = runs.at(-1);
+  if (first && last) {
+    field.append(
+      element("div", { class: "pipeline-axis" }, [
+        element("span"),
+        element(
+          "span",
+          null,
+          `${initShort(first.init_time, local)} → ${initShort(last.init_time, local)}`,
+        ),
+      ]),
+    );
+  }
+  return field;
 }
 
 function renderStructure(app, dashboard, rows) {
@@ -319,20 +396,6 @@ function renderStructure(app, dashboard, rows) {
       element("h3", null, group.label),
     ]);
     for (const product of group.products) {
-      const leadLabels = element("div", {
-        class: "pipeline-lead-labels",
-        "aria-hidden": "true",
-      });
-      for (const lead of product.lead_groups?.slice(1) ?? []) {
-        leadLabels.append(
-          element(
-            "span",
-            { style: `bottom:${lead.center_pct}%` },
-            lead.label,
-          ),
-        );
-      }
-
       const advisory = element("div", {
         class: "pipeline-row-advisory",
         "data-slot": "row-advisory",
@@ -352,8 +415,7 @@ function renderStructure(app, dashboard, rows) {
             ]),
           ]),
           element("div", { class: "pipeline-row-body" }, [
-            leadLabels,
-            element("div", { class: "pipeline-grid", "data-slot": "grid" }),
+            element("div", { "data-slot": "field" }),
           ]),
           element("div", { class: "pipeline-stats" }, [
             element("strong", { "data-slot": "eta-init" }, "—"),
@@ -559,9 +621,9 @@ function buildDetails(product, now, local) {
 }
 
 function hydrateRow(row, product, now, local) {
-  row.querySelector('[data-slot="grid"]').replaceChildren(
-    ...product.recent_inits.slice(-10).map((init) => renderBar(init, local)),
-  );
+  row
+    .querySelector('[data-slot="field"]')
+    .replaceChildren(renderField(product, local));
   hydrateEta(row, product, now, local);
 
   const button = row.querySelector('[data-slot="details-button"]');

--- a/public/pipeline.mjs
+++ b/public/pipeline.mjs
@@ -480,7 +480,7 @@ export function facetRows(product) {
     label: facet.label,
     status: statusLabel(facet.status),
     completion: facet.completion_pct,
-    count: `${facet.dependencies_available.toLocaleString("en-US")} / ${facet.dependencies_expected.toLocaleString("en-US")} files`,
+    count: `${facet.dependencies_available.toLocaleString("en-US")} / ${facet.dependencies_expected.toLocaleString("en-US")} observed`,
   }));
 }
 
@@ -543,7 +543,7 @@ function buildDetails(product, now, local) {
   const facetTable = element("table", { class: "pipeline-facets" }, [
     element("thead", null, [
       element("tr", null, [
-        element("th", { colspan: "5" }, "file arrival coverage"),
+        element("th", { colspan: "5" }, "arrival coverage"),
       ]),
       element("tr", null, [
         element("th", null, "dimension"),

--- a/public/pipeline.mjs
+++ b/public/pipeline.mjs
@@ -9,7 +9,7 @@ const POLL_INTERVAL_MS = 15_000;
 const HEALTH_REFRESH_INTERVAL_MS = 5 * 60 * 1000;
 const STALE_AFTER_MS = 10 * 60 * 1000;
 const FETCH_TIMEOUT_MS = 10_000;
-const DASHBOARD_VERSION = 1;
+const DASHBOARD_VERSIONS = new Set([1, 2]);
 
 function hasTimestamp(value) {
   return (
@@ -22,7 +22,7 @@ function hasTimestamp(value) {
 export function validateDashboard(data) {
   if (
     !data ||
-    data.v !== DASHBOARD_VERSION ||
+    !DASHBOARD_VERSIONS.has(data.v) ||
     !hasTimestamp(data.generated_at) ||
     !Array.isArray(data.groups) ||
     data.groups.length === 0 ||
@@ -30,6 +30,7 @@ export function validateDashboard(data) {
   ) {
     throw new TypeError("Invalid pipeline dashboard");
   }
+  let hasFacetGroups = false;
   for (const group of data.groups) {
     if (
       typeof group.id !== "string" ||
@@ -48,7 +49,50 @@ export function validateDashboard(data) {
       ) {
         throw new TypeError("Invalid pipeline product");
       }
+      if (product.facet_groups != null) {
+        if (
+          data.v !== 2 ||
+          !Array.isArray(product.facet_groups) ||
+          product.facet_groups.length === 0 ||
+          !product.facet_groups.every(
+            (facet) =>
+              typeof facet.dimension === "string" &&
+              typeof facet.name === "string" &&
+              typeof facet.label === "string",
+          )
+        ) {
+          throw new TypeError("Invalid pipeline facet group");
+        }
+        hasFacetGroups = true;
+      }
+      for (const init of product.recent_inits) {
+        if (init.facets == null) continue;
+        if (
+          data.v !== 2 ||
+          !Array.isArray(init.facets) ||
+          !init.facets.every(
+            (facet) =>
+              typeof facet.dimension === "string" &&
+              typeof facet.name === "string" &&
+              typeof facet.label === "string" &&
+              Number.isInteger(facet.dependencies_available) &&
+              facet.dependencies_available >= 0 &&
+              Number.isInteger(facet.dependencies_expected) &&
+              facet.dependencies_expected > 0 &&
+              facet.dependencies_available <= facet.dependencies_expected &&
+              Number.isFinite(facet.completion_pct) &&
+              facet.completion_pct >= 0 &&
+              facet.completion_pct <= 1 &&
+              typeof facet.status === "string",
+          )
+        ) {
+          throw new TypeError("Invalid pipeline facet");
+        }
+      }
     }
+  }
+  if (data.v === 2 && !hasFacetGroups) {
+    throw new TypeError("Invalid pipeline dashboard");
   }
   return data;
 }
@@ -393,7 +437,7 @@ export function detailRows(product, now, local) {
       : displayed
         ? `${initShort(displayed.init_time, local)} · previous init`
         : "waiting for next init",
-    rows: product.lead_group_stats.map((stats, index) => {
+    rows: (product.lead_group_stats ?? []).map((stats, index) => {
       const live = groups[index];
       let time = "—";
       let duration = "—";
@@ -426,6 +470,20 @@ export function detailRows(product, now, local) {
   };
 }
 
+export function facetRows(product) {
+  const running = product.recent_inits.findLast(
+    (init) => init.status === "in_flight",
+  );
+  const displayed = running ?? product.recent_inits.at(-1);
+  return (displayed?.facets ?? []).map((facet) => ({
+    dimension: facet.dimension,
+    label: facet.label,
+    status: statusLabel(facet.status),
+    completion: facet.completion_pct,
+    count: `${facet.dependencies_available.toLocaleString("en-US")} / ${facet.dependencies_expected.toLocaleString("en-US")} files`,
+  }));
+}
+
 function buildDetails(product, now, local) {
   const details = detailRows(product, now, local);
   const groupHead = element("tr", null, [
@@ -456,10 +514,48 @@ function buildDetails(product, now, local) {
       ]),
     );
   }
-  return element("table", null, [
+  const leadTable = element("table", null, [
     element("thead", null, [groupHead, head]),
     body,
   ]);
+  const facets = facetRows(product);
+  if (facets.length === 0) return leadTable;
+
+  const facetBody = element("tbody");
+  for (const facet of facets) {
+    facetBody.append(
+      element("tr", null, [
+        element("td", null, facet.dimension),
+        element("td", null, facet.label),
+        element("td", null, facet.status),
+        element("td", null, facet.count),
+        element("td", null, [
+          element("progress", {
+            max: "1",
+            value: String(facet.completion),
+            "aria-label": `${Math.round(facet.completion * 100)}% complete`,
+          }),
+          ` ${Math.round(facet.completion * 100)}%`,
+        ]),
+      ]),
+    );
+  }
+  const facetTable = element("table", { class: "pipeline-facets" }, [
+    element("thead", null, [
+      element("tr", null, [
+        element("th", { colspan: "5" }, "file arrival coverage"),
+      ]),
+      element("tr", null, [
+        element("th", null, "dimension"),
+        element("th", null, "group"),
+        element("th", null, "status"),
+        element("th", null, "files"),
+        element("th", null, "complete"),
+      ]),
+    ]),
+    facetBody,
+  ]);
+  return element("div", null, [leadTable, facetTable]);
 }
 
 function hydrateRow(row, product, now, local) {
@@ -470,7 +566,7 @@ function hydrateRow(row, product, now, local) {
 
   const button = row.querySelector('[data-slot="details-button"]');
   const details = row.querySelector('[data-slot="details"]');
-  if (product.lead_group_stats?.length) {
+  if (product.lead_group_stats?.length || facetRows(product).length) {
     button.hidden = false;
     details.replaceChildren(buildDetails(product, now, local));
   } else {

--- a/public/pipeline.mjs
+++ b/public/pipeline.mjs
@@ -9,7 +9,7 @@ const POLL_INTERVAL_MS = 15_000;
 const HEALTH_REFRESH_INTERVAL_MS = 5 * 60 * 1000;
 const STALE_AFTER_MS = 10 * 60 * 1000;
 const FETCH_TIMEOUT_MS = 10_000;
-const DASHBOARD_VERSIONS = new Set([1, 2]);
+const DASHBOARD_VERSION = 2;
 
 function hasTimestamp(value) {
   return (
@@ -22,7 +22,7 @@ function hasTimestamp(value) {
 export function validateDashboard(data) {
   if (
     !data ||
-    !DASHBOARD_VERSIONS.has(data.v) ||
+    data.v !== DASHBOARD_VERSION ||
     !hasTimestamp(data.generated_at) ||
     !Array.isArray(data.groups) ||
     data.groups.length === 0 ||
@@ -51,7 +51,6 @@ export function validateDashboard(data) {
       }
       if (product.facet_groups != null) {
         if (
-          data.v !== 2 ||
           !Array.isArray(product.facet_groups) ||
           product.facet_groups.length === 0 ||
           !product.facet_groups.every(
@@ -68,7 +67,6 @@ export function validateDashboard(data) {
       for (const init of product.recent_inits) {
         if (init.facets == null) continue;
         if (
-          data.v !== 2 ||
           !Array.isArray(init.facets) ||
           !init.facets.every(
             (facet) =>
@@ -91,7 +89,7 @@ export function validateDashboard(data) {
       }
     }
   }
-  if (data.v === 2 && !hasFacetGroups) {
+  if (!hasFacetGroups) {
     throw new TypeError("Invalid pipeline dashboard");
   }
   return data;

--- a/test/fixtures/pipeline-dashboard.json
+++ b/test/fixtures/pipeline-dashboard.json
@@ -1,5 +1,5 @@
 {
-  "v": 1,
+  "v": 2,
   "generated_at": "2026-07-25T18:00:00Z",
   "window_days": 90,
   "advisories": [
@@ -30,6 +30,13 @@
             {"name": "f024", "label": "1d", "leads_in_group": 5, "center_pct": 1.5},
             {"name": "f072", "label": "3d", "leads_in_group": 13, "center_pct": 4.5}
           ],
+          "facet_groups": [
+            {"dimension": "component", "name": "component:pgrb2a", "label": "pgrb2a"},
+            {"dimension": "component", "name": "component:pgrb2b", "label": "pgrb2b"},
+            {"dimension": "component", "name": "component:pgrb2s", "label": "pgrb2s"},
+            {"dimension": "member", "name": "members:control", "label": "control"},
+            {"dimension": "member", "name": "members:perturbed", "label": "perturbed"}
+          ],
           "latency_stats": {
             "p50_s": 3600,
             "p95_s": 5400,
@@ -51,7 +58,7 @@
             {"init_time": "2026-07-24T18:00:00Z", "status": "complete", "timing": "on_time", "completion_pct": 1, "latency_s": 3690, "lead_groups": [{"name": "f000", "status": "complete", "timing": "on_time", "completion_pct": 1, "latency_s": 840, "leads_available": 1, "leads_expected": 1}, {"name": "f024", "status": "complete", "timing": "on_time", "completion_pct": 1, "latency_s": 1830, "leads_available": 5, "leads_expected": 5}, {"name": "f072", "status": "complete", "timing": "on_time", "completion_pct": 1, "latency_s": 3690, "leads_available": 13, "leads_expected": 13}]},
             {"init_time": "2026-07-25T00:00:00Z", "status": "complete", "timing": "delayed", "completion_pct": 1, "latency_s": 5700, "lead_groups": [{"name": "f000", "status": "complete", "timing": "on_time", "completion_pct": 1, "latency_s": 850, "leads_available": 1, "leads_expected": 1}, {"name": "f024", "status": "complete", "timing": "on_time", "completion_pct": 1, "latency_s": 1900, "leads_available": 5, "leads_expected": 5}, {"name": "f072", "status": "complete", "timing": "delayed", "completion_pct": 1, "latency_s": 5700, "leads_available": 13, "leads_expected": 13}]},
             {"init_time": "2026-07-25T06:00:00Z", "status": "failed", "completion_pct": 0.38, "lead_groups": [{"name": "f000", "status": "complete", "timing": "on_time", "completion_pct": 1, "latency_s": 900, "leads_available": 1, "leads_expected": 1}, {"name": "f024", "status": "complete", "timing": "delayed", "completion_pct": 1, "latency_s": 3000, "leads_available": 5, "leads_expected": 5}, {"name": "f072", "status": "failed", "completion_pct": 0.38, "leads_available": 5, "leads_expected": 13}]},
-            {"init_time": "2026-07-25T12:00:00Z", "status": "in_flight", "timing": "delayed", "completion_pct": 0.38, "lead_groups": [{"name": "f000", "status": "complete", "timing": "on_time", "completion_pct": 1, "latency_s": 920, "leads_available": 1, "leads_expected": 1}, {"name": "f024", "status": "complete", "timing": "delayed", "completion_pct": 1, "latency_s": 3100, "leads_available": 5, "leads_expected": 5}, {"name": "f072", "status": "in_flight", "timing": "delayed", "completion_pct": 0.38, "leads_available": 5, "leads_expected": 13}]}
+            {"init_time": "2026-07-25T12:00:00Z", "status": "in_flight", "timing": "delayed", "completion_pct": 0.38, "lead_groups": [{"name": "f000", "status": "complete", "timing": "on_time", "completion_pct": 1, "latency_s": 920, "leads_available": 1, "leads_expected": 1}, {"name": "f024", "status": "complete", "timing": "delayed", "completion_pct": 1, "latency_s": 3100, "leads_available": 5, "leads_expected": 5}, {"name": "f072", "status": "in_flight", "timing": "delayed", "completion_pct": 0.38, "leads_available": 5, "leads_expected": 13}], "facets": [{"dimension": "component", "name": "component:pgrb2a", "label": "pgrb2a", "dependencies_available": 30, "dependencies_expected": 40, "completion_pct": 0.75, "status": "in_flight"}, {"dimension": "component", "name": "component:pgrb2b", "label": "pgrb2b", "dependencies_available": 20, "dependencies_expected": 40, "completion_pct": 0.5, "status": "in_flight"}, {"dimension": "component", "name": "component:pgrb2s", "label": "pgrb2s", "dependencies_available": 40, "dependencies_expected": 40, "completion_pct": 1, "status": "complete"}, {"dimension": "member", "name": "members:control", "label": "control", "dependencies_available": 8, "dependencies_expected": 8, "completion_pct": 1, "status": "complete"}, {"dimension": "member", "name": "members:perturbed", "label": "perturbed", "dependencies_available": 82, "dependencies_expected": 96, "completion_pct": 0.8542, "status": "in_flight"}]}
           ],
           "next_expected_init": "2026-07-25T18:00:00Z",
           "next_expected_completion_at": "2026-07-25T19:30:00Z"

--- a/test/pipeline.test.mjs
+++ b/test/pipeline.test.mjs
@@ -4,7 +4,9 @@ import test from "node:test";
 
 import {
   agencySummary,
-  barTooltip,
+  bandsOf,
+  cellOf,
+  cellTitle,
   clockTime,
   detailRows,
   displaySource,
@@ -187,35 +189,139 @@ test("shortens displayed web sources without changing other schemes", () => {
   assert.equal(displaySource("s3://noaa-gfs-bdp-pds"), "s3://noaa-gfs-bdp-pds");
 });
 
-test("preserves run and lead-group detail in bar tooltips", () => {
-  assert.equal(
-    barTooltip(
+function facetedProduct() {
+  return {
+    id: "external-noaa-gefs-long-aws",
+    row_label: "AWS",
+    lead_groups: [
+      { name: "f000", label: "1d" },
+      { name: "f240", label: "10d" },
+    ],
+    facet_groups: [
+      { dimension: "component", name: "component:pgrb2a", label: "pgrb2a.0p50" },
+      { dimension: "member", name: "members:control", label: "control" },
+    ],
+    recent_inits: [
       {
         init_time: "2026-07-26T00:00:00Z",
         status: "in_flight",
-        timing: "on_time",
-        completion_pct: 0.5,
-        latency_s: 3600,
+        timing: "delayed",
         lead_groups: [
           {
-            name: "1d",
+            name: "f000",
             status: "complete",
             timing: "on_time",
             completion_pct: 1,
+            leads_available: 100,
+            leads_expected: 100,
           },
           {
-            name: "3d",
+            name: "f240",
             status: "in_flight",
             timing: "delayed",
             completion_pct: 0.25,
+            leads_available: 175,
+            leads_expected: 400,
+          },
+        ],
+        facets: [
+          {
+            dimension: "component",
+            name: "component:pgrb2a",
+            label: "pgrb2a.0p50",
+            status: "in_flight",
+            completion_pct: 0.5,
+            dependencies_available: 200,
+            dependencies_expected: 400,
+          },
+          {
+            dimension: "member",
+            name: "members:control",
+            label: "control",
+            status: "complete",
+            completion_pct: 1,
+            dependencies_available: 400,
+            dependencies_expected: 400,
           },
         ],
       },
-      false,
-    ),
-    "07-26 00z · in_flight · on_time · 50% · latency 1h\n" +
-      "1d complete · on_time · 3d in_flight · delayed 25%",
+    ],
+  };
+}
+
+test("bands the field by lead group from the floor up, then by facet dimension", () => {
+  assert.deepEqual(
+    bandsOf(facetedProduct()).map((band) => `${band.kind}:${band.label}`),
+    ["lead:10d", "lead:1d", "facet:pgrb2a.0p50", "facet:control"],
   );
+
+  // a v1 product reports no facets at all and gets lead bands only
+  const noFacets = facetedProduct();
+  delete noFacets.facet_groups;
+  for (const init of noFacets.recent_inits) delete init.facets;
+  assert.deepEqual(
+    bandsOf(noFacets).map((band) => band.kind),
+    ["lead", "lead"],
+  );
+});
+
+test("bands a history snapshot, which declares neither list up front", () => {
+  const snapshot = facetedProduct();
+  delete snapshot.lead_groups;
+  delete snapshot.facet_groups;
+  snapshot.lead_group_stats = [
+    { name: "f000", label: "1d" },
+    { name: "f240", label: "10d" },
+  ];
+
+  assert.deepEqual(
+    bandsOf(snapshot).map((band) => `${band.kind}:${band.label}`),
+    ["lead:10d", "lead:1d", "facet:pgrb2a.0p50", "facet:control"],
+  );
+  // and still measures, rather than rendering an empty field
+  const [longest] = bandsOf(snapshot);
+  assert.equal(cellOf(longest, snapshot.recent_inits[0]).state, "in_flight");
+});
+
+test("measures a lead band by its own share, not the cumulative count", () => {
+  const product = facetedProduct();
+  const [longest] = bandsOf(product);
+  const cell = cellOf(longest, product.recent_inits[0]);
+  // 175/400 cumulative becomes 75/300 once the band below it is taken out
+  assert.equal(cell.state, "in_flight");
+  assert.equal(cell.timing, "delayed");
+  assert.equal(cell.completion, 0.25);
+});
+
+test("names what a square measured, facet first, in its hover label", () => {
+  const product = facetedProduct();
+  const init = product.recent_inits[0];
+  const bands = bandsOf(product);
+  const facetBand = bands.find((band) => band.label === "pgrb2a.0p50");
+  assert.equal(
+    cellTitle(facetBand, init, cellOf(facetBand, init), false),
+    "pgrb2a.0p50 (component) · 07-26 00z · 200 / 400 files · processing · delayed",
+  );
+
+  const leadBand = bands.find((band) => band.label === "1d");
+  assert.equal(
+    cellTitle(leadBand, init, cellOf(leadBand, init), false),
+    "lead 1d · 07-26 00z · 100% · complete · on time",
+  );
+});
+
+test("reads an unreported band as unobserved rather than a failure", () => {
+  const product = facetedProduct();
+  const band = bandsOf(product).find((entry) => entry.kind === "facet");
+  const blind = { ...product.recent_inits[0], status: "unobserved" };
+  assert.equal(cellOf(band, blind).state, "unobserved");
+  assert.match(
+    cellTitle(band, blind, cellOf(band, blind), false),
+    /no probe visibility; not a publication failure/,
+  );
+
+  const missing = { ...product.recent_inits[0], facets: [] };
+  assert.equal(cellOf(band, missing).state, "unobserved");
 });
 
 test("shows exact and relative ETA in the selected timezone", () => {
@@ -532,7 +638,8 @@ test("pipeline page uses the shared subnav without a separate footer", () => {
   );
 
   assert.match(subnav, /https:\/\/status\.dynamical\.org\/webhooks/);
-  assert.match(template, /forecast hours still expected/);
+  assert.match(template, /still expected/);
+  assert.match(template, /hover a square for what it measured/);
   assert.match(template, /no monitoring data/);
   assert.doesNotMatch(template, /pipeline-footer|window-days/);
   assert.doesNotMatch(pipelineScript, /window-days/);
@@ -542,12 +649,13 @@ test("pipeline page uses the shared subnav without a separate footer", () => {
   assert.doesNotMatch(template, /Data product pipeline|Forecast-run arrival/);
   assert.match(
     pipelineCss,
-    /\.pipeline-bar-segment\.g-pending,[\s\S]*\.pipeline-bar-segment\.g-unobserved\s*{\s*border: 1px dotted var\(--pipeline-unobserved\)/,
+    /\.pipeline-cell\.g-pending,[\s\S]*\.pipeline-cell\.g-unobserved\s*{\s*border: 1px dotted var\(--pipeline-unobserved\)/,
   );
   assert.match(
     pipelineCss,
-    /\.pipeline-bar\[data-status="unobserved"\] \.pipeline-bar-track\s*{\s*border: 1px dotted/,
+    /\.pipeline-cell\.g-failed \.pipeline-cell-fill\s*{\s*height: 100%/,
   );
+  assert.doesNotMatch(pipelineCss, /pipeline-bar|pipeline-lead-labels/);
   assert.doesNotMatch(
     mainCss,
     /\.status-subnav\s*{[^}]*font-size:/s,

--- a/test/pipeline.test.mjs
+++ b/test/pipeline.test.mjs
@@ -350,14 +350,14 @@ test("groups component and member readiness for the displayed init", () => {
       label: "pgrb2a",
       status: "processing",
       completion: 0.75,
-      count: "3 / 4 files",
+      count: "3 / 4 observed",
     },
     {
       dimension: "member",
       label: "control",
       status: "complete",
       completion: 1,
-      count: "4 / 4 files",
+      count: "4 / 4 observed",
     },
   ]);
 });

--- a/test/pipeline.test.mjs
+++ b/test/pipeline.test.mjs
@@ -24,7 +24,7 @@ import { localZoneLabel } from "../public/status-time.mjs";
 
 function dashboard() {
   return {
-    v: 1,
+    v: 2,
     generated_at: "2026-07-25T18:00:00Z",
     window_days: 90,
     advisories: [],
@@ -36,6 +36,13 @@ function dashboard() {
           {
             id: "external-noaa-gfs-aws",
             row_label: "AWS",
+            facet_groups: [
+              {
+                dimension: "component",
+                name: "component:data",
+                label: "data",
+              },
+            ],
             recent_inits: [],
           },
         ],
@@ -48,9 +55,8 @@ test("accepts the versioned dashboard contract", () => {
   assert.equal(validateDashboard(dashboard()).groups[0].id, "noaa-gfs");
 });
 
-test("accepts dashboard v2 facets while retaining dashboard v1", () => {
+test("accepts dashboard v2 facets and rejects dashboard v1", () => {
   const current = dashboard();
-  current.v = 2;
   const [product] = current.groups[0].products;
   product.facet_groups = [
     { dimension: "component", name: "component:pgrb2a", label: "pgrb2a" },
@@ -74,7 +80,11 @@ test("accepts dashboard v2 facets while retaining dashboard v1", () => {
   ];
 
   assert.equal(validateDashboard(current), current);
-  assert.equal(validateDashboard(dashboard()).v, 1);
+  assert.equal(validateDashboard(dashboard()).v, 2);
+  assert.throws(
+    () => validateDashboard({ ...dashboard(), v: 1 }),
+    /invalid pipeline dashboard/i,
+  );
 });
 
 test("rejects empty, unknown, and oversized dashboards", () => {

--- a/test/pipeline.test.mjs
+++ b/test/pipeline.test.mjs
@@ -9,9 +9,11 @@ import {
   detailRows,
   displaySource,
   etaLineText,
+  facetRows,
   initParts,
   validateDashboard,
 } from "../public/pipeline.mjs";
+import { onRequestGet } from "../functions/pipeline-staging/[[path]].js";
 import {
   agencyHealth,
   systemHealth,
@@ -44,10 +46,39 @@ test("accepts the versioned dashboard contract", () => {
   assert.equal(validateDashboard(dashboard()).groups[0].id, "noaa-gfs");
 });
 
+test("accepts dashboard v2 facets while retaining dashboard v1", () => {
+  const current = dashboard();
+  current.v = 2;
+  const [product] = current.groups[0].products;
+  product.facet_groups = [
+    { dimension: "component", name: "component:pgrb2a", label: "pgrb2a" },
+  ];
+  product.recent_inits = [
+    {
+      init_time: "2026-07-25T12:00:00Z",
+      status: "in_flight",
+      facets: [
+        {
+          dimension: "component",
+          name: "component:pgrb2a",
+          label: "pgrb2a",
+          dependencies_available: 9,
+          dependencies_expected: 10,
+          completion_pct: 0.9,
+          status: "in_flight",
+        },
+      ],
+    },
+  ];
+
+  assert.equal(validateDashboard(current), current);
+  assert.equal(validateDashboard(dashboard()).v, 1);
+});
+
 test("rejects empty, unknown, and oversized dashboards", () => {
   assert.throws(() => validateDashboard({}), /invalid pipeline dashboard/i);
   assert.throws(
-    () => validateDashboard({ ...dashboard(), v: 2 }),
+    () => validateDashboard({ ...dashboard(), v: 3 }),
     /invalid pipeline dashboard/i,
   );
   assert.throws(
@@ -60,6 +91,19 @@ test("rejects empty, unknown, and oversized dashboards", () => {
     (_, index) => ({ init_time: String(index) }),
   );
   assert.throws(() => validateDashboard(tooMany), /invalid pipeline product/i);
+
+  const malformedFacet = dashboard();
+  malformedFacet.v = 2;
+  malformedFacet.groups[0].products[0].facet_groups = [
+    { dimension: "component", name: "component:pgrb2a", label: "pgrb2a" },
+  ];
+  malformedFacet.groups[0].products[0].recent_inits = [
+    { facets: [{ completion_pct: 2 }] },
+  ];
+  assert.throws(
+    () => validateDashboard(malformedFacet),
+    /invalid pipeline facet/i,
+  );
 });
 
 test("summarizes upstream agency advisories without changing pipeline state", () => {
@@ -270,6 +314,112 @@ test("shows the previous init details while waiting for the next init", () => {
       { status: "complete", time: "06:45", duration: "45m" },
     ],
   );
+});
+
+test("groups component and member readiness for the displayed init", () => {
+  const product = {
+    recent_inits: [
+      {
+        init_time: "2026-07-26T12:00:00Z",
+        status: "in_flight",
+        facets: [
+          {
+            dimension: "component",
+            label: "pgrb2a",
+            status: "in_flight",
+            completion_pct: 0.75,
+            dependencies_available: 3,
+            dependencies_expected: 4,
+          },
+          {
+            dimension: "member",
+            label: "control",
+            status: "complete",
+            completion_pct: 1,
+            dependencies_available: 4,
+            dependencies_expected: 4,
+          },
+        ],
+      },
+    ],
+  };
+
+  assert.deepEqual(facetRows(product), [
+    {
+      dimension: "component",
+      label: "pgrb2a",
+      status: "processing",
+      completion: 0.75,
+      count: "3 / 4 files",
+    },
+    {
+      dimension: "member",
+      label: "control",
+      status: "complete",
+      completion: 1,
+      count: "4 / 4 files",
+    },
+  ]);
+});
+
+test("local preview fixture exercises dashboard v2 facet rendering", () => {
+  const fixture = JSON.parse(
+    readFileSync(
+      new URL("./fixtures/pipeline-dashboard.json", import.meta.url),
+      "utf8",
+    ),
+  );
+  validateDashboard(fixture);
+  const [product] = fixture.groups[0].products;
+  assert.equal(fixture.v, 2);
+  assert.equal(product.facet_groups.length, 5);
+  assert.equal(facetRows(product).length, 5);
+});
+
+test("preview pipeline route exposes only allowlisted staging JSON", async () => {
+  const requested = [];
+  const bucket = {
+    async get(key) {
+      requested.push(key);
+      return key === "wxopticon/dashboard.json"
+        ? { body: '{"v":2}', httpEtag: '"etag"' }
+        : null;
+    },
+  };
+
+  const response = await onRequestGet({
+    env: { WXOPTICON_STAGING: bucket },
+    params: { path: ["wxopticon", "dashboard.json"] },
+  });
+  assert.equal(response.status, 200);
+  assert.equal(await response.text(), '{"v":2}');
+  assert.equal(
+    response.headers.get("content-type"),
+    "application/json; charset=utf-8",
+  );
+  assert.deepEqual(requested, ["wxopticon/dashboard.json"]);
+
+  const unavailable = await onRequestGet({
+    env: {},
+    params: { path: ["wxopticon", "dashboard.json"] },
+  });
+  assert.equal(unavailable.status, 503);
+
+  const denied = await onRequestGet({
+    env: { WXOPTICON_STAGING: bucket },
+    params: { path: ["wxopticon", "events.jsonl"] },
+  });
+  assert.equal(denied.status, 404);
+  assert.deepEqual(requested, ["wxopticon/dashboard.json"]);
+});
+
+test("preview branches select the private staging route", () => {
+  const source = readFileSync(
+    new URL("../_data/pipelineAssetsBase.js", import.meta.url),
+    "utf8",
+  );
+  assert.match(source, /process\.env\.CF_PAGES_BRANCH/);
+  assert.match(source, /\/pipeline-staging\/wxopticon/);
 });
 
 test("status pages share the uptime, pipeline, and pipeline webhooks subnav", () => {


### PR DESCRIPTION
Closes #194

Stacked on #186 while wxopticon PR #165 completes its staging soak.

## Plan

- [x] Remove dashboard v1 compatibility and require the granular v2 contract.
- [x] Preserve distinct unknown, partial, failed, and complete facet rendering.
- [ ] Validate this branch's deployed preview against real staging artifacts for every expanded source.
- [x] Run unit tests and the production build.
- [x] Document coordinated-cutover requirements.

## Evidence — 2026-08-12

- Added the v2-only regression first; it failed because the prototype still accepted v1.
- The validator now accepts only dashboard v2 and removes redundant per-facet version branches.
- Existing square/facet rendering is unchanged, including explicit unobserved/unknown, partial, failed, and complete states.
- 122 unit tests pass.
- Production Eleventy build passes and generates 2,808 pages.
- The inherited PR #186 preview already rendered all 14 staging products, 1,152 squares, and 1,190 history snapshots without page or console errors. This branch still needs its own preview deployment check before it is ready.

## Cutover dependency

This frontend must deploy in the coordinated wxopticon #163 cutover after granular dashboard v2 is live. It intentionally cannot render the representative v1 payload, preventing a silent mixed-schema rollout.