### PR TITLE
Hide the experimental wxopticon components on /status/

### DIFF
--- a/public/status.mjs
+++ b/public/status.mjs
@@ -108,6 +108,20 @@ export function validateStatusData(data) {
   };
 }
 
+// wxopticon keeps publishing into the feed — we still measure it — but it is
+// experimental, so its components stay off this page until they are stable
+// enough to sit behind an uptime claim.
+const EXPERIMENTAL_PREFIX = "wxopticon";
+
+export function withoutExperimentalComponents(data) {
+  return {
+    ...data,
+    endpoints: data.endpoints.filter(
+      (entry) => !entry.id.startsWith(EXPERIMENTAL_PREFIX),
+    ),
+  };
+}
+
 export function isStatusDataStale(generatedAt, now = new Date()) {
   const age = now.getTime() - Date.parse(generatedAt);
   return !Number.isFinite(age) || age > STALE_AFTER_MS;
@@ -687,7 +701,9 @@ async function loadStatus(root, render) {
     if (!response.ok) {
       throw new Error(`Status request failed: ${response.status}`);
     }
-    const data = validateStatusData(await response.json());
+    const data = withoutExperimentalComponents(
+      validateStatusData(await response.json()),
+    );
     render(data, await history);
   } catch (error) {
     console.error("Unable to load public status", error);

--- a/test/status.test.mjs
+++ b/test/status.test.mjs
@@ -15,7 +15,9 @@ import {
   summarizeOverallStatus,
   uptimeDescription,
   validateStatusData,
+  withoutExperimentalComponents,
 } from "../public/status.mjs";
+import { systemHealth } from "../public/status-health.mjs";
 
 const fixture = JSON.parse(
   readFileSync(new URL("./fixtures/status.json", import.meta.url), "utf8"),
@@ -65,6 +67,41 @@ test("accepts the published feed shape", () => {
   assert.deepEqual(summarizeOverallStatus(fixture), {
     status: "down",
     incidents: [{ name: "Data product reads", status: "down" }],
+  });
+});
+
+test("keeps the experimental wxopticon components off the page", () => {
+  // The publisher keeps measuring them; this page drops them until they are
+  // stable enough to sit behind an uptime claim.
+  const data = withoutExperimentalComponents(validateStatusData(fixture));
+  assert.deepEqual(
+    data.endpoints.map((entry) => entry.id),
+    ["stac-catalog", "data-product-reads", "scorecard", "dynamical-org"],
+  );
+  // Dropping them from the component list is what hides their bars and their
+  // incident-log entries; the rest of the document stays as published.
+  assert.deepEqual(data.datasets, fixture.datasets);
+  assert.deepEqual(data.component_aliases, fixture.component_aliases);
+});
+
+test("an experimental component's state does not move the rollup", () => {
+  const feed = structuredClone(operationalData);
+  feed.endpoints.push({
+    id: "wxopticon-arrivals",
+    name: "pipeline observability",
+    group: "tool",
+    status: "down",
+  });
+  const data = withoutExperimentalComponents(validateStatusData(feed));
+
+  assert.deepEqual(summarizeOverallStatus(data), {
+    status: "operational",
+    incidents: [],
+  });
+  assert.deepEqual(systemHealth(data), {
+    state: "operational",
+    label: "all systems",
+    value: "operational",
   });
 });
 


### PR DESCRIPTION
wxopticon keeps publishing into the status feed and we keep measuring it, but it is not stable enough yet to sit behind an uptime or performance guarantee. This hides its components on `/status/` until it stabilizes.

## What changed

`withoutExperimentalComponents()` in `public/status.mjs` drops any endpoint whose id starts with `wxopticon`, applied in `loadStatus` right after `validateStatusData`. Filtering once, at the document, is what makes the removal complete: everything downstream keys off `data.endpoints`, so the components leave together with

- their rows in **Tools & resources**,
- their 90-day uptime bars,
- their entries in the incident log (the log matches incidents against the names of rendered components, and the `wxopticon-pipeline` alias resolves to a target that is no longer there), and
- their weight in the **systems** health rollup — a wxopticon delay no longer turns the page yellow.

The prefix match covers any further wxopticon component the publisher adds, since it deploys separately from this page. `datasets` and `component_aliases` pass through untouched.

## What is deliberately unchanged

- The published feed still carries the components — this is a page-side hide, not a change to what we measure.
- `/status/pipeline/`, the pipeline and pipeline-webhooks subnav links, and the pipeline link at the foot of `/status/` all stay. Those present forecast-arrival data rather than a wxopticon uptime claim.

## Tests

Two cases in `test/status.test.mjs`: the fixture's endpoints come back without the wxopticon ids and with the rest of the document intact, and a `down` wxopticon component leaves both `summarizeOverallStatus` and `systemHealth` reading operational. `npm test` — 121 passing.