### PR TITLE
Note the granularity migration on the pipeline page

### DIFF
--- a/content/status-pipeline.njk
+++ b/content/status-pipeline.njk
@@ -25,6 +25,14 @@ pageStylesheet: /pipeline.css
     </p>
   {% endcall %}
 
+  {# Remove once wxopticon's granular cutover and history backfill are done:
+     dynamical-org/wxopticon#163 (cutover), #161 and #162 (backfill). #}
+  <p class="pipeline-notice">
+    We are increasing the granularity of arrival monitoring and rebuilding its
+    history. During the migration and backfill, this page may be intermittent or
+    show arrival states that appear incorrect.
+  </p>
+
   <div class="pipeline-ribbon" data-slot="ribbon" hidden>
     Pipeline data is more than 10 minutes old — it may be stalled.
   </div>

--- a/public/pipeline.css
+++ b/public/pipeline.css
@@ -48,6 +48,16 @@
   );
 }
 
+/* A migration notice, not a fault: dotted and muted so it reads as context
+   rather than competing with the ribbon's live staleness warning. */
+.pipeline-notice {
+  margin: 0 0 1.6rem;
+  padding: 0.8rem 1.2rem;
+  border: 1px dotted var(--border-muted-color);
+  color: var(--muted-text);
+  font-size: 1.2rem;
+}
+
 .pipeline-ribbon:not([hidden]),
 .pipeline-banner {
   margin-bottom: 1.5rem;

--- a/test/e2e/pipeline.spec.mjs
+++ b/test/e2e/pipeline.spec.mjs
@@ -22,10 +22,16 @@ const FIXTURE = JSON.parse(
 
 const JSON_HEADERS = { "access-control-allow-origin": "*" };
 
+/* Match by filename, not by base: the dev server points the page at the published
+   assets under `npm start` but at `/pipeline-preview/` under `npm run
+   start:pipeline`, and a stub that only matched one of those would silently stop
+   applying — leaving a test asserting against whatever the server happened to
+   serve. */
+
 /** Serve the pipeline page its data, optionally reshaped for one test. */
 async function stubPipeline(page, mutate = (payload) => payload) {
   const payload = mutate(structuredClone(FIXTURE));
-  await page.route("**/wxopticon/dashboard.json", (route) =>
+  await page.route("**/dashboard.json", (route) =>
     route.fulfill({
       status: 200,
       contentType: "application/json",
@@ -35,7 +41,7 @@ async function stubPipeline(page, mutate = (payload) => payload) {
   );
   // the shared health strip and the history index are separate feeds; stub them
   // so the spec neither waits on the network nor reports their failures as ours
-  await page.route("**/status/status.json", (route) =>
+  await page.route("**/status.json", (route) =>
     route.fulfill({
       status: 200,
       contentType: "application/json",
@@ -43,7 +49,7 @@ async function stubPipeline(page, mutate = (payload) => payload) {
       body: JSON.stringify({ endpoints: [{ status: "operational" }] }),
     }),
   );
-  await page.route("**/wxopticon/history/index.json", (route) =>
+  await page.route("**/history/index.json", (route) =>
     route.fulfill({
       status: 200,
       contentType: "application/json",

--- a/test/pipeline.test.mjs
+++ b/test/pipeline.test.mjs
@@ -1040,6 +1040,11 @@ test("pipeline page uses the shared subnav without a separate footer", () => {
   );
 
   assert.match(subnav, /https:\/\/status\.dynamical\.org\/webhooks/);
+  // the migration notice is deliberate copy, not decoration: it should leave
+  // with the cutover and backfill it describes
+  assert.match(template, /increasing the granularity of arrival monitoring/);
+  assert.match(template, /intermittent or\s+show arrival states that appear incorrect/);
+  assert.match(pipelineCss, /\.pipeline-notice \{/);
   assert.match(template, /part arrived/);
   assert.match(template, /still expected/);
   assert.match(template, /no monitoring data/);


### PR DESCRIPTION
Arrival monitoring is being cut over to finer granularity (wxopticon#163) and its history rebuilt (wxopticon#161, #162). Until that lands, readers can see intermittent behaviour and arrival states that look wrong through no fault of their own — including, right now, the error banner while production still serves the pre-cutover schema.

> We are increasing the granularity of arrival monitoring and rebuilding its history. During the migration and backfill, this page may be intermittent or show arrival states that appear incorrect.

It sits directly above the field, below the subnav and health strip. Styling is one rule using existing tokens — dotted `--border-muted-color` on `--muted-text` — so it reads as context rather than competing with the ribbon's live staleness warning, which stays solid and amber. Verified in both themes.

The template carries a comment naming the three issues whose completion should remove it, so it does not outlive the migration by default.

## Also in here

Verifying the notice surfaced a fragility in the browser spec merged in #197: its stubs matched only `**/wxopticon/dashboard.json`, the base `npm start` produces. With a fixture-mode server already on port 8081 — which `reuseExistingServer` will happily reuse — the page fetches `/pipeline-preview/dashboard.json` instead, so the stubs never matched and the tests asserted against whatever that server served rather than the payload each test constructs. One test failed for that reason and would have failed misleadingly for anyone running the specs after `npm run start:pipeline`.

Stubs now match by filename, and the spec passes both ways: 3.1s reusing a fixture server, 11.5s booting its own.