### PR TITLE
Catch duckdb-wasm worker load failures in the scorecard

### DIFF
--- a/public/scorecard.js
+++ b/public/scorecard.js
@@ -90,7 +90,7 @@ let _dbReady = null;
 
 export function initDB() {
   if (_dbReady) return _dbReady;
-  _dbReady = (async () => {
+  const ready = (async () => {
     // duckdb-wasm's bundle selection references the global WebAssembly object
     // unconditionally (via wasm-feature-detect's exceptions() check), which
     // throws an uncaught ReferenceError rather than reporting "unsupported"
@@ -110,12 +110,32 @@ export function initDB() {
       })
     );
     const worker = new Worker(workerUrl);
+    // A CDN hiccup serving the worker script throws inside the worker's own
+    // global scope: uncaught there, invisible to this function's try/catch,
+    // and left as a permanently pending instantiate() below without a
+    // listener that turns it into a rejection.
+    const workerFailure = new Promise((_resolve, reject) => {
+      worker.onerror = (event) => {
+        event.preventDefault();
+        reject(new Error(`duckdb-wasm worker failed to load: ${event.message}`));
+      };
+    });
     const logger = new duckdb.ConsoleLogger(duckdb.LogLevel.WARNING);
     const db = new duckdb.AsyncDuckDB(logger, worker);
-    await db.instantiate(bundle.mainModule, bundle.pthreadWorker);
+    await Promise.race([
+      db.instantiate(bundle.mainModule, bundle.pthreadWorker),
+      workerFailure,
+    ]);
     URL.revokeObjectURL(workerUrl);
     return db;
   })();
+  // Memoize the promise, but never the rejection: caching a failed worker
+  // load would leave every later chart on the page permanently stuck, since
+  // this database instance is shared across all of them.
+  ready.catch(() => {
+    if (_dbReady === ready) _dbReady = null;
+  });
+  _dbReady = ready;
   return _dbReady;
 }
 


### PR DESCRIPTION
## Summary

- `initDB()`'s `Worker` had no `onerror` handler. When the worker's script fails to load (e.g. a CDN hiccup fetching `duckdb-browser-eh.worker.js` from jsdelivr), the `NetworkError` is thrown inside the worker's own global scope — uncaught there, invisible to `initDB()`'s try/catch, and left as a permanently-pending `db.instantiate()` with nothing to turn it into a rejection.
- Since `_dbReady` is a shared, memoized promise, that one failed load wedges every scorecard chart on the page behind a promise that never resolves or rejects — worse than a single chart erroring out.
- `initDB()` now races `instantiate()` against a `worker.onerror` listener, and un-memoizes a rejection the same way `windowIsPublished()`'s `_windowDaysInFile` probe already does, so the failure becomes a normal caught error (reported via the existing `captureError` → Sentry path, with chart context) and a later retry isn't stuck behind the earlier one.

Addresses Sentry issue DYNAMICAL-ORG-SITE-H (`Uncaught NetworkError ... importScripts ... duckdb-browser-eh.worker.js`), reported from `/scorecard/station/LOT/`.

This mirrors the pattern from #191 (uncaught `ReferenceError` for missing `WebAssembly` in the same function) — turning an escaping worker/CDN failure mode into a caught, reported one, rather than adding retry/fallback-CDN logic for what looks like an ordinary jsdelivr blip.

## Test plan

- [x] `npm test` — passes (pre-existing, unrelated `test/og-card.test.mjs` failure present on `main` too, confirmed via `git stash`)
- [ ] `npm run test:e2e` scorecard specs (not run here — hits real CDNs/parquet; existing coverage should still pass since happy-path behavior is unchanged)
- Not covered by a new unit test: exercising the `worker.onerror` path requires the real CDN `import()` and a browser `Worker` global, neither available in the offline Node test suite (the existing `WebAssembly`-check test is unit-testable only because it returns before reaching either).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NRpBXeTP4KNWrpSQsDF5F2


---
_Generated by [Claude Code](https://claude.ai/code/session_01NRpBXeTP4KNWrpSQsDF5F2)_