### PR TITLE
Name the init sample behind the pipeline percentile columns

### DIFF
--- a/public/pipeline.mjs
+++ b/public/pipeline.mjs
@@ -920,6 +920,14 @@ export function etaLineText(target, now, local) {
     : `ETA ${time} (in ${formatDuration(seconds)})`;
 }
 
+// The percentile columns summarise every init in the historical baseline, not
+// just the runs the grid draws, so the header names the sample they came from.
+function statsHeader(sampleInitCount) {
+  return sampleInitCount
+    ? `time after init · ${sampleInitCount.toLocaleString("en-US")} inits`
+    : "time after init";
+}
+
 export function detailRows(product, now, local) {
   const running = product.recent_inits.findLast(
     (init) => init.status === "in_flight",
@@ -933,6 +941,7 @@ export function detailRows(product, now, local) {
       : displayed
         ? `${initShort(displayed.init_time, local)} · previous init`
         : "waiting for next init",
+    statsHeader: statsHeader(product.latency_stats?.sample_init_count),
     rows: (product.lead_group_stats ?? []).map((stats, index) => {
       const live = groups[index];
       let time = "—";
@@ -985,7 +994,7 @@ function buildDetails(product, now, local) {
   const groupHead = element("tr", null, [
     element("th"),
     element("th", { colspan: "3" }, details.header),
-    element("th", { colspan: "3" }, "time after init"),
+    element("th", { colspan: "3" }, details.statsHeader),
   ]);
   const head = element("tr", null, [
     element("th", null, "horizon"),

--- a/test/pipeline.test.mjs
+++ b/test/pipeline.test.mjs
@@ -751,6 +751,7 @@ test("retains live horizon status, time, and duration in details", () => {
     detailRows(product, Date.parse("2026-07-26T12:30:00Z"), false),
     {
       header: "07-26 12z",
+      statsHeader: "time after init",
       rows: [
         {
           label: "1d",
@@ -772,6 +773,36 @@ test("retains live horizon status, time, and duration in details", () => {
         },
       ],
     },
+  );
+});
+
+test("names the init sample the percentile columns summarise", () => {
+  const product = {
+    recent_inits: [
+      {
+        init_time: "2026-07-26T06:00:00Z",
+        status: "complete",
+        lead_groups: [{ status: "complete", latency_s: 1200 }],
+      },
+    ],
+    latency_stats: {
+      p50_s: 1200,
+      p95_s: 1800,
+      p99_s: 2400,
+      sample_init_count: 1394,
+    },
+    lead_group_stats: [{ label: "1d", p50_s: 1200, p95_s: 1800, p99_s: 2400 }],
+  };
+
+  assert.equal(
+    detailRows(product, Date.parse("2026-07-26T07:00:00Z"), false).statsHeader,
+    "time after init · 1,394 inits",
+  );
+
+  product.latency_stats.sample_init_count = 0;
+  assert.equal(
+    detailRows(product, Date.parse("2026-07-26T07:00:00Z"), false).statsHeader,
+    "time after init",
   );
 });
 


### PR DESCRIPTION
## Outcome

The `/status/pipeline/` detail table's `time after init` columns (p50/p95/p99) summarise every init in a product's historical baseline — not the runs the grid draws — and nothing on the page said how large that sample was.

That gap is actively misleading right now. `external-noaa-gefs-long-aws` draws **one** bar but its percentiles rest on **346** inits; `noaa-gfs-forecast` draws **eight** bars but its percentiles rest on **five**. A reader can't tell those apart.

## Change

`detailRows()` now returns a `statsHeader` string built from `latency_stats.sample_init_count`, and `buildDetails()` renders it in place of the fixed label:

```
horizon | status | time | duration |  time after init · 1,394 inits
                                   |  p50  |  p95  |  p99
```

Products with no completed run yet (`sample_init_count` 0 or absent) keep the bare `time after init`.

`sample_init_count` is already published in `dashboard.json` per product — no producer change needed.

## Tests

- New: `names the init sample the percentile columns summarise` covers both the populated and the zero/absent branch.
- Updated: the existing `detailRows` `deepEqual` assertion now pins the fallback header.
- `npm test` — 148/148 pass.

## Notes

- Based on `main` at e9052f4d1. Formatting is hand-matched to the surrounding style; `npx prettier --write` reformats ~15 unrelated spots in these two files on this base, so it was not run.