### PR TITLE
Compact pipeline facet views

### DIFF
--- a/content/status-pipeline.njk
+++ b/content/status-pipeline.njk
@@ -54,7 +54,7 @@ pageStylesheet: /pipeline.css
         aria-hidden="true"></span>
       no monitoring data
     </span>
-    <span>one square per measurement · hover a square for what it measured</span>
+    <span>one cell per measurement · hover a cell for what it measured</span>
   </div>
 
   <div id="pipeline-history-panel" hidden>

--- a/public/pipeline.css
+++ b/public/pipeline.css
@@ -195,6 +195,15 @@
   height: auto;
 }
 
+.pipeline-field[data-compact] .pipeline-rows {
+  flex: none;
+}
+
+.pipeline-field[data-compact] .pipeline-rows > .pipeline-band {
+  flex: none;
+  height: var(--sq);
+}
+
 .pipeline-band {
   display: grid;
   grid-template-columns: var(--band-gutter) minmax(0, max-content);
@@ -307,11 +316,30 @@
 
 .pipeline-column-label {
   flex: none;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   width: var(--cell-w, var(--sq));
   height: var(--label-h);
   font-size: 0.9rem;
   line-height: var(--label-h);
   text-align: center;
+}
+
+.pipeline-lead-dots {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1px;
+  justify-content: center;
+  width: var(--dot-width);
+}
+
+.pipeline-lead-dot {
+  flex: none;
+  width: 2px;
+  height: 2px;
+  border-radius: 50%;
+  background: currentColor;
 }
 
 .pipeline-band--head {
@@ -332,6 +360,7 @@
   height: var(--label-h);
   font-size: 0.9rem;
   line-height: var(--label-h);
+  white-space: nowrap;
   text-align: center;
 }
 

--- a/public/pipeline.css
+++ b/public/pipeline.css
@@ -204,6 +204,16 @@
   height: var(--sq);
 }
 
+.pipeline-field[data-compact] {
+  gap: var(--lane-gap);
+}
+
+.pipeline-facet-lane {
+  display: flex;
+  flex-direction: column;
+  gap: var(--band-gap);
+}
+
 .pipeline-band {
   display: grid;
   grid-template-columns: var(--band-gutter) minmax(0, max-content);
@@ -324,22 +334,6 @@
   font-size: 0.9rem;
   line-height: var(--label-h);
   text-align: center;
-}
-
-.pipeline-lead-dots {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 1px;
-  justify-content: center;
-  width: var(--dot-width);
-}
-
-.pipeline-lead-dot {
-  flex: none;
-  width: 2px;
-  height: 2px;
-  border-radius: 50%;
-  background: currentColor;
 }
 
 .pipeline-band--head {

--- a/public/pipeline.mjs
+++ b/public/pipeline.mjs
@@ -15,10 +15,14 @@ const DASHBOARD_VERSION = 2; // the granular schema; the lead-only shape is gone
 const CELL_PX = 12; // one measurement, the same size in every view
 const CLUMP_GAP_PX = 2; // between the lead columns within one run
 const RUN_GAP_PX = 6; // between init columns, as main spaced its bars
-const CLUMPED_RUN_GAP_PX = 6; // between run blocks, which need daylight
+const FACET_CELL_PX = 8; // compact rows when a facet owns the vertical axis
+const FACET_CLUMP_GAP_PX = 1; // lead columns remain visibly separate
+const FACET_RUN_GAP_PX = 6; // separate runs after the lead columns compact
 // no lead group is thinner than its own label: "0h" is two characters, which is
 // exactly one cell, so every group can name itself
 const MIN_LEAD_PX = 12;
+const FACET_MIN_LEAD_PX = 3; // 0h needs status ink, not room for a text label
+const FACET_LEAD_ALLOWANCE_PX = 5;
 const BAND_GAP_PX = 2; // between bands, inside a field
 const LABEL_PX = 12; // one axis-label row
 const FOOT_GAP_PX = 3; // the breath above the init tiers
@@ -359,6 +363,62 @@ export function leadExtents(product) {
   );
 }
 
+/* Facet views name the lead scale with dots instead of text, so their columns
+   can preserve the same proportions without paying the 12px label floor. */
+
+export function compactLeadExtents(product) {
+  const leads = leadAxis(product);
+  const newest = product.recent_inits?.at(-1);
+  const slices = leadSlices(newest?.lead_groups ?? []);
+  const expected = leads.map(
+    (lead) => slices.find((slice) => slice.name === lead.key)?.expected ?? 0,
+  );
+  const total = expected.reduce((sum, count) => sum + count, 0);
+  const allowance = leads.length * FACET_LEAD_ALLOWANCE_PX;
+  return new Map(
+    leads.map((lead, index) => [
+      lead.key,
+      FACET_MIN_LEAD_PX +
+        (total ? expected[index] / total : 1 / leads.length) * allowance,
+    ]),
+  );
+}
+
+function leadDays(label) {
+  const match = /^(\d+)d$/.exec(label);
+  return match ? Number(match[1]) : 0;
+}
+
+function leadMarker(lead, width, visible) {
+  const days = visible ? leadDays(lead.label) : 0;
+  const columns = Math.ceil(Math.sqrt(days));
+  const dots = Array.from({ length: days }, () =>
+    element("span", { class: "pipeline-lead-dot" }),
+  );
+  return element(
+    "span",
+    {
+      class: "pipeline-column-label",
+      style: `--cell-w:${width.toFixed(2)}px`,
+      title: `lead ${lead.label}`,
+      role: visible ? "img" : null,
+      "aria-label": visible ? `lead ${lead.label}` : null,
+      "aria-hidden": visible ? null : "true",
+    },
+    days
+      ? element(
+          "span",
+          {
+            class: "pipeline-lead-dots",
+            "aria-hidden": "true",
+            style: `--dot-width:${columns * 3 - 1}px`,
+          },
+          dots,
+        )
+      : null,
+  );
+}
+
 /* How tall a view draws. The label rows have fixed heights, so this needs no
    measurement — which matters because the render pass writes without reading. */
 
@@ -370,7 +430,7 @@ function chromePx(view, rows) {
 
 function viewHeightPx(product, view) {
   const bands = view.dimension
-    ? facetRowsOf(product, view.dimension).map(() => CELL_PX)
+    ? facetRowsOf(product, view.dimension).map(() => FACET_CELL_PX)
     : [...leadExtents(product).values()];
   const rows = bands.length || 1;
   return bands.reduce((sum, px) => sum + px, 0) + chromePx(view, rows);
@@ -472,15 +532,18 @@ export function runsThatFit(product, availablePx, local) {
 
 export function runsThatFitFacetRows(product, availablePx, dimension) {
   const leads = leadAxis(product);
-  const extents = leadExtents(product);
+  const extents = compactLeadExtents(product);
   const runWidth =
-    leads.reduce((sum, lead) => sum + (extents.get(lead.key) ?? CELL_PX), 0) +
-    Math.max(0, leads.length - 1) * CLUMP_GAP_PX;
+    leads.reduce(
+      (sum, lead) => sum + (extents.get(lead.key) ?? FACET_CELL_PX),
+      0,
+    ) +
+    Math.max(0, leads.length - 1) * FACET_CLUMP_GAP_PX;
   return runsFitting(
     availablePx,
     gutterPx(facetRowsOf(product, dimension)),
     runWidth,
-    CLUMPED_RUN_GAP_PX,
+    FACET_RUN_GAP_PX,
   );
 }
 
@@ -637,7 +700,7 @@ export function viewAt(product, index) {
 /* The init axis: the time under every column, then the date only where it turns
    over, so a date lines up with the first timestamp it covers. */
 
-function initTiers(runs, local) {
+function initTiers(runs, local, sparse = false) {
   const zone = selectedTimeZone(local);
   let previousDate = null;
   return [
@@ -645,7 +708,11 @@ function initTiers(runs, local) {
       bandClass: "pipeline-band pipeline-band--foot",
       spanClass: "pipeline-run-label",
       runs,
-      textOf: (init) => initParts(init.init_time, zone).time,
+      textOf: (init, index) =>
+        sparse && (runs.length - 1 - index) % 2
+          ? ""
+          : initParts(init.init_time, zone).time,
+      titleOf: (init) => initShort(init.init_time, local),
     }),
     labelTier({
       spanClass: "pipeline-run-date",
@@ -688,12 +755,22 @@ function jointIndex(product, runs, leads) {
 /* One label tier under the blocks: a span per run, exactly one block wide, so
    every tier centres on the same axis as the squares above it. */
 
-function labelTier({ bandClass = "pipeline-band", spanClass, runs, textOf }) {
+function labelTier({
+  bandClass = "pipeline-band",
+  spanClass,
+  runs,
+  textOf,
+  titleOf,
+}) {
   return bandNode({
     className: bandClass,
     clumped: true,
-    children: runs.map((init) =>
-      element("span", { class: spanClass }, textOf(init)),
+    children: runs.map((init, index) =>
+      element(
+        "span",
+        { class: spanClass, title: titleOf?.(init) },
+        textOf(init, index),
+      ),
     ),
   });
 }
@@ -707,16 +784,17 @@ function renderFacetRows(product, local, runCount, dimension) {
   const leads = leadAxis(product); // shortest horizon first
   const facets = facetRowsOf(product, dimension);
   const joint = jointIndex(product, runs, leads);
-  const extents = leadExtents(product);
-  const leadWidth = (lead) => extents.get(lead.key) ?? CELL_PX;
+  const extents = compactLeadExtents(product);
+  const leadWidth = (lead) => extents.get(lead.key) ?? FACET_CELL_PX;
   const runWidth =
     leads.reduce((sum, lead) => sum + leadWidth(lead), 0) +
-    Math.max(0, leads.length - 1) * CLUMP_GAP_PX;
+    Math.max(0, leads.length - 1) * FACET_CLUMP_GAP_PX;
   const field = element("div", {
     class: "pipeline-field",
     // lead time runs across here, so progress fills across too
     "data-fill": "side",
-    style: `--sq:${CELL_PX}px;--clump-gap:${CLUMP_GAP_PX}px;--clumped-run-gap:${CLUMPED_RUN_GAP_PX}px;--band-gutter:${gutterPx(facets)}px;--run-width:${runWidth}px;--band-gap:${BAND_GAP_PX}px;--label-h:${LABEL_PX}px;--reserve:${reservedHeightPx(product)}px`,
+    "data-compact": "",
+    style: `--sq:${FACET_CELL_PX}px;--clump-gap:${FACET_CLUMP_GAP_PX}px;--clumped-run-gap:${FACET_RUN_GAP_PX}px;--band-gutter:${gutterPx(facets)}px;--run-width:${runWidth}px;--band-gap:${BAND_GAP_PX}px;--label-h:${LABEL_PX}px;--reserve:${reservedHeightPx(product)}px`,
   });
 
   // the lead order repeats in every run, so name it once over the first block
@@ -728,27 +806,15 @@ function renderFacetRows(product, local, runCount, dimension) {
         element(
           "div",
           { class: "pipeline-clump" },
-          leads.map((lead) => {
-            // a proportional column can be narrower than its own name; the
-            // ones that cannot hold their label keep it on hover only
-            const width = leadWidth(lead);
-            const fits = width >= lead.label.length * CH_PX;
-            return element(
-              "span",
-              {
-                class: "pipeline-column-label",
-                style: `--cell-w:${width.toFixed(2)}px`,
-                title: `lead ${lead.label}`,
-              },
-              index === 0 && fits ? lead.label : "",
-            );
-          }),
+          leads.map((lead) =>
+            leadMarker(lead, leadWidth(lead), index === 0),
+          ),
         ),
       ),
     }),
   );
 
-  // one container so the rows share out whatever height the box leaves them
+  // facet rows stay short; the reserved field still prevents view-switch jumps
   const rowsNode = element("div", { class: "pipeline-rows" });
   for (const facet of facets) {
     rowsNode.append(
@@ -787,9 +853,7 @@ function renderFacetRows(product, local, runCount, dimension) {
     );
   }
   field.append(rowsNode);
-
-
-  field.append(...initTiers(runs, local));
+  field.append(...initTiers(runs, local, true));
   return field;
 }
 

--- a/public/pipeline.mjs
+++ b/public/pipeline.mjs
@@ -18,8 +18,9 @@ const RUN_GAP_PX = 6; // between init columns, as main spaced its bars
 const FACET_CELL_PX = 8; // compact rows when a facet owns the vertical axis
 const FACET_CLUMP_GAP_PX = 1; // lead columns remain visibly separate
 const FACET_RUN_GAP_PX = 6; // separate runs after the lead columns compact
+const FACET_BAND_GAP_PX = 4; // use the reserved height between compact rows
 const FACET_LANES = 2; // two chronological rows show more runs without crowding
-const FACET_LANE_GAP_PX = 6;
+const FACET_LANE_GAP_PX = 10;
 // no lead group is thinner than its own label: "0h" is two characters, which is
 // exactly one cell, so every group can name itself
 const MIN_LEAD_PX = 12;
@@ -403,9 +404,10 @@ function leadLabel(lead, width, visible) {
    measurement — which matters because the render pass writes without reading. */
 
 function chromePx(view, rows) {
-  const head = view.dimension ? LABEL_PX + BAND_GAP_PX + HEAD_GAP_PX : 0;
-  const tiers = FOOT_GAP_PX + 2 * (LABEL_PX + BAND_GAP_PX);
-  return head + tiers + BAND_GAP_PX * Math.max(0, rows - 1);
+  const gap = view.dimension ? FACET_BAND_GAP_PX : BAND_GAP_PX;
+  const head = view.dimension ? LABEL_PX + gap + HEAD_GAP_PX : 0;
+  const tiers = FOOT_GAP_PX + 2 * (LABEL_PX + gap);
+  return head + tiers + gap * Math.max(0, rows - 1);
 }
 
 function viewHeightPx(product, view) {
@@ -526,7 +528,7 @@ export function runsThatFitFacetRows(product, availablePx, dimension) {
     Math.max(0, leads.length - 1) * FACET_CLUMP_GAP_PX;
   const perLane = runsFitting(
     availablePx,
-    gutterPx(facetRowsOf(product, dimension)),
+    facetGutterPx(facetRowsOf(product, dimension)),
     runWidth,
     FACET_RUN_GAP_PX,
   );
@@ -659,6 +661,19 @@ export function facetRowsOf(product, dimension) {
   return dimension ? rows.filter((facet) => facet.dimension === dimension) : rows;
 }
 
+function facetAxisLabel(facet) {
+  if (facet.dimension !== "member") return facet.label;
+  if (facet.label === "control") return "ctl";
+  if (facet.label === "perturbed") return "pert";
+  return facet.label;
+}
+
+function facetGutterPx(facets) {
+  return gutterPx(
+    facets.map((facet) => ({ ...facet, label: facetAxisLabel(facet) })),
+  );
+}
+
 /* The views a product offers, in click order: the lead grid it opens on, then
    one grid per facet dimension the joint reports. A product without a joint
    offers the lead grid alone, so clicking it does nothing. */
@@ -785,7 +800,7 @@ function renderFacetLane(product, local, runs, leads, facets, leadWidth) {
     rowsNode.append(
       bandNode({
         kind: "facet",
-        label: facet.label,
+        label: facetAxisLabel(facet),
         labelTitle: `${facet.label} (${facet.dimension})`,
         clumped: true,
         children: runs.map((init) =>
@@ -836,7 +851,7 @@ function renderFacetRows(product, local, runCount, dimension) {
     // lead time runs across here, so progress fills across too
     "data-fill": "side",
     "data-compact": "",
-    style: `--sq:${FACET_CELL_PX}px;--clump-gap:${FACET_CLUMP_GAP_PX}px;--clumped-run-gap:${FACET_RUN_GAP_PX}px;--lane-gap:${FACET_LANE_GAP_PX}px;--band-gutter:${gutterPx(facets)}px;--run-width:${runWidth}px;--band-gap:${BAND_GAP_PX}px;--label-h:${LABEL_PX}px;--reserve:${reservedHeightPx(product)}px`,
+    style: `--sq:${FACET_CELL_PX}px;--clump-gap:${FACET_CLUMP_GAP_PX}px;--clumped-run-gap:${FACET_RUN_GAP_PX}px;--lane-gap:${FACET_LANE_GAP_PX}px;--band-gutter:${facetGutterPx(facets)}px;--run-width:${runWidth}px;--band-gap:${FACET_BAND_GAP_PX}px;--label-h:${LABEL_PX}px;--reserve:${reservedHeightPx(product)}px`,
   });
   const laneCount = Math.min(FACET_LANES, Math.max(1, runs.length));
   const runsPerLane = Math.ceil(runs.length / laneCount);

--- a/public/pipeline.mjs
+++ b/public/pipeline.mjs
@@ -387,16 +387,15 @@ export function compactLeadExtents(product) {
   );
 }
 
-function leadLabel(lead, width, visible) {
+function leadLabel(lead, width) {
   return element(
     "span",
     {
       class: "pipeline-column-label",
       style: `--cell-w:${width.toFixed(2)}px`,
       title: `lead ${lead.label}`,
-      "aria-hidden": visible ? null : "true",
     },
-    visible ? lead.label : "",
+    lead.label,
   );
 }
 
@@ -661,11 +660,23 @@ export function facetRowsOf(product, dimension) {
   return dimension ? rows.filter((facet) => facet.dimension === dimension) : rows;
 }
 
-function facetAxisLabel(facet) {
-  if (facet.dimension !== "member") return facet.label;
-  if (facet.label === "control") return "ctl";
-  if (facet.label === "perturbed") return "pert";
-  return facet.label;
+const FACET_AXIS_ABBREVIATIONS = new Map([
+  ["cloud and convection", "cloud/conv"],
+  ["natural levels", "nat lvls"],
+  ["precipitation and snow", "precip/snow"],
+  ["pressure levels", "prs lvls"],
+  ["solar radiation", "solar"],
+  ["surface state", "sfc state"],
+  ["control", "ctl"],
+  ["perturbed", "pert"],
+  ["perturbed members", "pert"],
+]);
+
+export function facetAxisLabel(facet) {
+  return (
+    FACET_AXIS_ABBREVIATIONS.get(facet.label) ??
+    facet.label.replace(/^(pgrb2[abs])\.\d+p\d+$/, "$1")
+  );
 }
 
 function facetGutterPx(facets) {
@@ -784,13 +795,11 @@ function renderFacetLane(product, local, runs, leads, facets, leadWidth) {
     bandNode({
       className: "pipeline-band pipeline-band--head",
       clumped: true,
-      children: runs.map((init, index) =>
+      children: runs.map(() =>
         element(
           "div",
           { class: "pipeline-clump" },
-          leads.map((lead) =>
-            leadLabel(lead, leadWidth(lead), index === 0),
-          ),
+          leads.map((lead) => leadLabel(lead, leadWidth(lead))),
         ),
       ),
     }),

--- a/public/pipeline.mjs
+++ b/public/pipeline.mjs
@@ -18,10 +18,12 @@ const RUN_GAP_PX = 6; // between init columns, as main spaced its bars
 const FACET_CELL_PX = 8; // compact rows when a facet owns the vertical axis
 const FACET_CLUMP_GAP_PX = 1; // lead columns remain visibly separate
 const FACET_RUN_GAP_PX = 6; // separate runs after the lead columns compact
+const FACET_LANES = 2; // two chronological rows show more runs without crowding
+const FACET_LANE_GAP_PX = 6;
 // no lead group is thinner than its own label: "0h" is two characters, which is
 // exactly one cell, so every group can name itself
 const MIN_LEAD_PX = 12;
-const FACET_MIN_LEAD_PX = 3; // 0h needs status ink, not room for a text label
+const FACET_MIN_LEAD_PX = 12; // every lead group keeps room for its text label
 const FACET_LEAD_ALLOWANCE_PX = 5;
 const BAND_GAP_PX = 2; // between bands, inside a field
 const LABEL_PX = 12; // one axis-label row
@@ -363,8 +365,8 @@ export function leadExtents(product) {
   );
 }
 
-/* Facet views name the lead scale with dots instead of text, so their columns
-   can preserve the same proportions without paying the 12px label floor. */
+/* Facet views keep the text scale while spending less proportional allowance
+   than the lead view, so each run stays compact without ambiguous labels. */
 
 export function compactLeadExtents(product) {
   const leads = leadAxis(product);
@@ -384,38 +386,16 @@ export function compactLeadExtents(product) {
   );
 }
 
-function leadDays(label) {
-  const match = /^(\d+)d$/.exec(label);
-  return match ? Number(match[1]) : 0;
-}
-
-function leadMarker(lead, width, visible) {
-  const days = visible ? leadDays(lead.label) : 0;
-  const columns = Math.ceil(Math.sqrt(days));
-  const dots = Array.from({ length: days }, () =>
-    element("span", { class: "pipeline-lead-dot" }),
-  );
+function leadLabel(lead, width, visible) {
   return element(
     "span",
     {
       class: "pipeline-column-label",
       style: `--cell-w:${width.toFixed(2)}px`,
       title: `lead ${lead.label}`,
-      role: visible ? "img" : null,
-      "aria-label": visible ? `lead ${lead.label}` : null,
       "aria-hidden": visible ? null : "true",
     },
-    days
-      ? element(
-          "span",
-          {
-            class: "pipeline-lead-dots",
-            "aria-hidden": "true",
-            style: `--dot-width:${columns * 3 - 1}px`,
-          },
-          dots,
-        )
-      : null,
+    visible ? lead.label : "",
   );
 }
 
@@ -433,10 +413,15 @@ function viewHeightPx(product, view) {
     ? facetRowsOf(product, view.dimension).map(() => FACET_CELL_PX)
     : [...leadExtents(product).values()];
   const rows = bands.length || 1;
-  return bands.reduce((sum, px) => sum + px, 0) + chromePx(view, rows);
+  const laneHeight =
+    bands.reduce((sum, px) => sum + px, 0) + chromePx(view, rows);
+  if (!view.dimension) return laneHeight;
+  const laneCount = Math.min(
+    FACET_LANES,
+    Math.max(1, product.recent_inits?.length ?? 0),
+  );
+  return laneHeight * laneCount + FACET_LANE_GAP_PX * (laneCount - 1);
 }
-
-
 
 /* The box every view of a product sits in: the tallest one. Clicking through
    the views then never moves the rest of the page. */
@@ -539,12 +524,13 @@ export function runsThatFitFacetRows(product, availablePx, dimension) {
       0,
     ) +
     Math.max(0, leads.length - 1) * FACET_CLUMP_GAP_PX;
-  return runsFitting(
+  const perLane = runsFitting(
     availablePx,
     gutterPx(facetRowsOf(product, dimension)),
     runWidth,
     FACET_RUN_GAP_PX,
   );
+  return Math.min(RUNS_MAX, perLane * FACET_LANES);
 }
 
 /* Every band is the same skeleton: a gutter label, then its row of cells. */
@@ -700,7 +686,7 @@ export function viewAt(product, index) {
 /* The init axis: the time under every column, then the date only where it turns
    over, so a date lines up with the first timestamp it covers. */
 
-function initTiers(runs, local, sparse = false) {
+function initTiers(runs, local) {
   const zone = selectedTimeZone(local);
   let previousDate = null;
   return [
@@ -708,10 +694,7 @@ function initTiers(runs, local, sparse = false) {
       bandClass: "pipeline-band pipeline-band--foot",
       spanClass: "pipeline-run-label",
       runs,
-      textOf: (init, index) =>
-        sparse && (runs.length - 1 - index) % 2
-          ? ""
-          : initParts(init.init_time, zone).time,
+      textOf: (init) => initParts(init.init_time, zone).time,
       titleOf: (init) => initShort(init.init_time, local),
     }),
     labelTier({
@@ -779,26 +762,10 @@ function labelTier({
    lead group inside a block. Same squares and same hover labels as the banded
    field — only which dimension owns which axis changes. */
 
-function renderFacetRows(product, local, runCount, dimension) {
-  const runs = product.recent_inits.slice(-Math.max(1, runCount || RUNS_MAX));
-  const leads = leadAxis(product); // shortest horizon first
-  const facets = facetRowsOf(product, dimension);
+function renderFacetLane(product, local, runs, leads, facets, leadWidth) {
   const joint = jointIndex(product, runs, leads);
-  const extents = compactLeadExtents(product);
-  const leadWidth = (lead) => extents.get(lead.key) ?? FACET_CELL_PX;
-  const runWidth =
-    leads.reduce((sum, lead) => sum + leadWidth(lead), 0) +
-    Math.max(0, leads.length - 1) * FACET_CLUMP_GAP_PX;
-  const field = element("div", {
-    class: "pipeline-field",
-    // lead time runs across here, so progress fills across too
-    "data-fill": "side",
-    "data-compact": "",
-    style: `--sq:${FACET_CELL_PX}px;--clump-gap:${FACET_CLUMP_GAP_PX}px;--clumped-run-gap:${FACET_RUN_GAP_PX}px;--band-gutter:${gutterPx(facets)}px;--run-width:${runWidth}px;--band-gap:${BAND_GAP_PX}px;--label-h:${LABEL_PX}px;--reserve:${reservedHeightPx(product)}px`,
-  });
-
-  // the lead order repeats in every run, so name it once over the first block
-  field.append(
+  const lane = element("div", { class: "pipeline-facet-lane" });
+  lane.append(
     bandNode({
       className: "pipeline-band pipeline-band--head",
       clumped: true,
@@ -807,14 +774,12 @@ function renderFacetRows(product, local, runCount, dimension) {
           "div",
           { class: "pipeline-clump" },
           leads.map((lead) =>
-            leadMarker(lead, leadWidth(lead), index === 0),
+            leadLabel(lead, leadWidth(lead), index === 0),
           ),
         ),
       ),
     }),
   );
-
-  // facet rows stay short; the reserved field still prevents view-switch jumps
   const rowsNode = element("div", { class: "pipeline-rows" });
   for (const facet of facets) {
     rowsNode.append(
@@ -852,8 +817,42 @@ function renderFacetRows(product, local, runCount, dimension) {
       }),
     );
   }
-  field.append(rowsNode);
-  field.append(...initTiers(runs, local, true));
+  lane.append(rowsNode);
+  lane.append(...initTiers(runs, local));
+  return lane;
+}
+
+function renderFacetRows(product, local, runCount, dimension) {
+  const runs = product.recent_inits.slice(-Math.max(1, runCount || RUNS_MAX));
+  const leads = leadAxis(product); // shortest horizon first
+  const facets = facetRowsOf(product, dimension);
+  const extents = compactLeadExtents(product);
+  const leadWidth = (lead) => extents.get(lead.key) ?? FACET_CELL_PX;
+  const runWidth =
+    leads.reduce((sum, lead) => sum + leadWidth(lead), 0) +
+    Math.max(0, leads.length - 1) * FACET_CLUMP_GAP_PX;
+  const field = element("div", {
+    class: "pipeline-field",
+    // lead time runs across here, so progress fills across too
+    "data-fill": "side",
+    "data-compact": "",
+    style: `--sq:${FACET_CELL_PX}px;--clump-gap:${FACET_CLUMP_GAP_PX}px;--clumped-run-gap:${FACET_RUN_GAP_PX}px;--lane-gap:${FACET_LANE_GAP_PX}px;--band-gutter:${gutterPx(facets)}px;--run-width:${runWidth}px;--band-gap:${BAND_GAP_PX}px;--label-h:${LABEL_PX}px;--reserve:${reservedHeightPx(product)}px`,
+  });
+  const laneCount = Math.min(FACET_LANES, Math.max(1, runs.length));
+  const runsPerLane = Math.ceil(runs.length / laneCount);
+  // older runs occupy the first lane; newer runs continue in the second
+  for (let start = 0; start < runs.length; start += runsPerLane) {
+    field.append(
+      renderFacetLane(
+        product,
+        local,
+        runs.slice(start, start + runsPerLane),
+        leads,
+        facets,
+        leadWidth,
+      ),
+    );
+  }
   return field;
 }
 

--- a/test/e2e/pipeline.spec.mjs
+++ b/test/e2e/pipeline.spec.mjs
@@ -147,7 +147,7 @@ test("clicking cycles the rows through each facet dimension without moving the p
 
   await viz.click();
   const member = await bandGeometry(row);
-  expect(member.labels).toEqual(["control", "perturbed"]);
+  expect(member.labels).toEqual(["ctl", "pert"]);
 
   // lead time owns the columns in a facet view, so each lane names it there
   const firstLane = row.locator(".pipeline-facet-lane").first();
@@ -179,12 +179,27 @@ test("facet views use two compact lanes and show every available init", async ({
   const lanes = row.locator(".pipeline-facet-lane");
   await expect(lanes).toHaveCount(2);
   for (const lane of await lanes.all()) {
+    expect(
+      await lane
+        .locator(".pipeline-band[data-kind='facet'] .pipeline-band-label")
+        .allTextContents(),
+    ).toEqual(["pgrb2a", "pgrb2b", "pgrb2s"]);
     const leadLabels = (
       await lane.locator(".pipeline-column-label").allTextContents()
     ).filter(Boolean);
     expect(leadLabels).toEqual(["0h", "1d", "3d"]);
     await expect(lane.locator(".pipeline-run-label")).toHaveCount(5);
   }
+  const rowGaps = await lanes.first().evaluate((lane) => {
+    const cells = [
+      ...lane.querySelectorAll(".pipeline-band[data-kind='facet']"),
+    ].map((band) =>
+      band.querySelector(".pipeline-cell").getBoundingClientRect(),
+    );
+    return cells.slice(1).map((cell, index) => cell.top - cells[index].bottom);
+  });
+  expect(rowGaps.length).toBeGreaterThan(0);
+  for (const gap of rowGaps) expect(gap).toBeGreaterThanOrEqual(4);
 
   const times = await row.locator(".pipeline-run-label").allTextContents();
   expect(times).toHaveLength(10);

--- a/test/e2e/pipeline.spec.mjs
+++ b/test/e2e/pipeline.spec.mjs
@@ -144,12 +144,13 @@ test("clicking cycles the rows through each facet dimension without moving the p
   const member = await bandGeometry(row);
   expect(member.labels).toEqual(["control", "perturbed"]);
 
-  // lead time owns the columns in a facet view, so it is named there instead
-  expect(await row.locator(".pipeline-column-label").first()).toBeTruthy();
-  const columnLabels = (await row.locator(".pipeline-column-label").allTextContents()).filter(
-    Boolean,
-  );
-  expect(columnLabels).toEqual(["0h", "1d", "3d"]);
+  // lead time owns the columns in a facet view, so the first dot cluster names it
+  const columnLabels = await row
+    .locator(".pipeline-column-label")
+    .evaluateAll((nodes) =>
+      nodes.slice(0, 3).map((node) => node.getAttribute("aria-label")),
+    );
+  expect(columnLabels).toEqual(["lead 0h", "lead 1d", "lead 3d"]);
 
   // the views share one box: a cycle must not shift what is below the row
   expect(component.fieldHeight).toBe(lead.fieldHeight);
@@ -174,11 +175,14 @@ test("facet views use compact lead dots and show every available init", async ({
   const leadMarkers = row.locator(".pipeline-column-label");
   await expect(leadMarkers).toHaveCount(30);
   await expect(leadMarkers.nth(0)).toHaveAttribute("aria-label", "lead 0h");
+  await expect(leadMarkers.nth(0)).toHaveAttribute("role", "img");
   await expect(leadMarkers.nth(1).locator(".pipeline-lead-dot")).toHaveCount(1);
   await expect(leadMarkers.nth(2).locator(".pipeline-lead-dot")).toHaveCount(3);
 
   await expect(row.locator(".pipeline-run-label")).toHaveCount(10);
-  const labelled = (await row.locator(".pipeline-run-label").allTextContents()).filter(Boolean);
+  const labelled = (
+    await row.locator(".pipeline-run-label").allTextContents()
+  ).filter(Boolean);
   expect(labelled.length).toBeLessThan(10);
   expect((await bandGeometry(row)).overflowsColumn).toBe(false);
 });

--- a/test/e2e/pipeline.spec.mjs
+++ b/test/e2e/pipeline.spec.mjs
@@ -72,11 +72,16 @@ async function openPipeline(page, mutate) {
 /** What one band's cells actually measure, in the row's first band. */
 function bandGeometry(row) {
   return row.evaluate((node) => {
-    const bands = [...node.querySelectorAll(".pipeline-band[data-kind]")];
-    const field = node.querySelector(".pipeline-field").getBoundingClientRect();
+    const fieldNode = node.querySelector(".pipeline-field");
+    const geometryRoot =
+      fieldNode.querySelector(".pipeline-facet-lane") ?? fieldNode;
+    const bands = [...geometryRoot.querySelectorAll(".pipeline-band[data-kind]")];
+    const field = fieldNode.getBoundingClientRect();
     const body = node.querySelector(".pipeline-row-body").getBoundingClientRect();
     return {
-      labels: bands.map((band) => band.querySelector(".pipeline-band-label").textContent),
+      labels: bands.map(
+        (band) => band.querySelector(".pipeline-band-label").textContent,
+      ),
       cellHeights: bands.map(
         (band) => +band.querySelector(".pipeline-cell").getBoundingClientRect().height.toFixed(1),
       ),
@@ -144,13 +149,12 @@ test("clicking cycles the rows through each facet dimension without moving the p
   const member = await bandGeometry(row);
   expect(member.labels).toEqual(["control", "perturbed"]);
 
-  // lead time owns the columns in a facet view, so the first dot cluster names it
-  const columnLabels = await row
-    .locator(".pipeline-column-label")
-    .evaluateAll((nodes) =>
-      nodes.slice(0, 3).map((node) => node.getAttribute("aria-label")),
-    );
-  expect(columnLabels).toEqual(["lead 0h", "lead 1d", "lead 3d"]);
+  // lead time owns the columns in a facet view, so each lane names it there
+  const firstLane = row.locator(".pipeline-facet-lane").first();
+  const columnLabels = (
+    await firstLane.locator(".pipeline-column-label").allTextContents()
+  ).filter(Boolean);
+  expect(columnLabels).toEqual(["0h", "1d", "3d"]);
 
   // the views share one box: a cycle must not shift what is below the row
   expect(component.fieldHeight).toBe(lead.fieldHeight);
@@ -168,22 +172,30 @@ test("clicking cycles the rows through each facet dimension without moving the p
   expect((await bandGeometry(row)).labels).toEqual(component.labels);
 });
 
-test("facet views use compact lead dots and show every available init", async ({ page }) => {
+test("facet views use two compact lanes and show every available init", async ({ page }) => {
   const row = await openPipeline(page);
   await row.locator(".pipeline-viz").click();
 
-  const leadMarkers = row.locator(".pipeline-column-label");
-  await expect(leadMarkers).toHaveCount(30);
-  await expect(leadMarkers.nth(0)).toHaveAttribute("aria-label", "lead 0h");
-  await expect(leadMarkers.nth(0)).toHaveAttribute("role", "img");
-  await expect(leadMarkers.nth(1).locator(".pipeline-lead-dot")).toHaveCount(1);
-  await expect(leadMarkers.nth(2).locator(".pipeline-lead-dot")).toHaveCount(3);
+  const lanes = row.locator(".pipeline-facet-lane");
+  await expect(lanes).toHaveCount(2);
+  for (const lane of await lanes.all()) {
+    const leadLabels = (
+      await lane.locator(".pipeline-column-label").allTextContents()
+    ).filter(Boolean);
+    expect(leadLabels).toEqual(["0h", "1d", "3d"]);
+    await expect(lane.locator(".pipeline-run-label")).toHaveCount(5);
+  }
 
-  await expect(row.locator(".pipeline-run-label")).toHaveCount(10);
-  const labelled = (
-    await row.locator(".pipeline-run-label").allTextContents()
-  ).filter(Boolean);
-  expect(labelled.length).toBeLessThan(10);
+  const times = await row.locator(".pipeline-run-label").allTextContents();
+  expect(times).toHaveLength(10);
+  expect(times.every(Boolean)).toBe(true);
+  expect(await row.locator(".pipeline-lead-dot").count()).toBe(0);
+  expect(
+    await row
+      .locator(".pipeline-cell")
+      .first()
+      .evaluate((cell) => cell.offsetHeight),
+  ).toBe(8);
   expect((await bandGeometry(row)).overflowsColumn).toBe(false);
 });
 

--- a/test/e2e/pipeline.spec.mjs
+++ b/test/e2e/pipeline.spec.mjs
@@ -21,6 +21,10 @@ const FIXTURE = JSON.parse(
 );
 
 const JSON_HEADERS = { "access-control-allow-origin": "*" };
+const REPEATED_LEAD_LABELS = Array.from(
+  { length: 5 },
+  () => ["0h", "1d", "3d"],
+).flat();
 
 /* Match by filename, not by base: the dev server points the page at the published
    assets under `npm start` but at `/pipeline-preview/` under `npm run
@@ -154,7 +158,7 @@ test("clicking cycles the rows through each facet dimension without moving the p
   const columnLabels = (
     await firstLane.locator(".pipeline-column-label").allTextContents()
   ).filter(Boolean);
-  expect(columnLabels).toEqual(["0h", "1d", "3d"]);
+  expect(columnLabels).toEqual(REPEATED_LEAD_LABELS);
 
   // the views share one box: a cycle must not shift what is below the row
   expect(component.fieldHeight).toBe(lead.fieldHeight);
@@ -187,7 +191,7 @@ test("facet views use two compact lanes and show every available init", async ({
     const leadLabels = (
       await lane.locator(".pipeline-column-label").allTextContents()
     ).filter(Boolean);
-    expect(leadLabels).toEqual(["0h", "1d", "3d"]);
+    expect(leadLabels).toEqual(REPEATED_LEAD_LABELS);
     await expect(lane.locator(".pipeline-run-label")).toHaveCount(5);
   }
   const rowGaps = await lanes.first().evaluate((lane) => {

--- a/test/e2e/pipeline.spec.mjs
+++ b/test/e2e/pipeline.spec.mjs
@@ -167,6 +167,22 @@ test("clicking cycles the rows through each facet dimension without moving the p
   expect((await bandGeometry(row)).labels).toEqual(component.labels);
 });
 
+test("facet views use compact lead dots and show every available init", async ({ page }) => {
+  const row = await openPipeline(page);
+  await row.locator(".pipeline-viz").click();
+
+  const leadMarkers = row.locator(".pipeline-column-label");
+  await expect(leadMarkers).toHaveCount(30);
+  await expect(leadMarkers.nth(0)).toHaveAttribute("aria-label", "lead 0h");
+  await expect(leadMarkers.nth(1).locator(".pipeline-lead-dot")).toHaveCount(1);
+  await expect(leadMarkers.nth(2).locator(".pipeline-lead-dot")).toHaveCount(3);
+
+  await expect(row.locator(".pipeline-run-label")).toHaveCount(10);
+  const labelled = (await row.locator(".pipeline-run-label").allTextContents()).filter(Boolean);
+  expect(labelled.length).toBeLessThan(10);
+  expect((await bandGeometry(row)).overflowsColumn).toBe(false);
+});
+
 test("progress fills along whichever axis lead time owns", async ({ page }) => {
   const row = await openPipeline(page);
 

--- a/test/pipeline.test.mjs
+++ b/test/pipeline.test.mjs
@@ -488,10 +488,9 @@ test("a facet view shows only its own dimension's rows", () => {
     facetRowsOf(joint, "member").map((facet) => facet.label),
     ["control"],
   );
-  // and the fit follows the rows it will actually draw: "pgrb2a.0p50" needs a
-  // 66px gutter where "control" needs 42px, so the member view fits one more run
-  assert.equal(runsThatFitFacetRows(joint, 390, "component"), 5);
-  assert.equal(runsThatFitFacetRows(joint, 390, "member"), 6);
+  // both gutters leave enough room for all ten compact run blocks
+  assert.equal(runsThatFitFacetRows(joint, 390, "component"), 10);
+  assert.equal(runsThatFitFacetRows(joint, 390, "member"), 10);
 });
 
 test("gives every facet in the joint its own labelled row", () => {
@@ -568,11 +567,10 @@ test("draws a facet row for anything the joint reported in the window", () => {
 
 test("fits run blocks of lead columns to the width, once facets own the rows", () => {
   const joint = jointProduct();
-  // a block is its lead columns at proportional widths (18px + 30px) plus the
-  // 2px between them, so 50px of block and 56px of pitch
-  assert.equal(runsThatFitFacetRows(joint, 390), 5);
-  assert.equal(runsThatFitFacetRows(joint, 240), 3);
-  assert.equal(runsThatFitFacetRows(joint, 200), 2);
+  // compact columns make a two-lead block 17px wide with a 23px pitch
+  assert.equal(runsThatFitFacetRows(joint, 390), 10);
+  assert.equal(runsThatFitFacetRows(joint, 240), 7);
+  assert.equal(runsThatFitFacetRows(joint, 200), 5);
   assert.equal(runsThatFitFacetRows(joint, 1200), 10);
   // never zero, and an unmeasured row shows everything rather than nothing
   assert.equal(runsThatFitFacetRows(joint, 80), 1);
@@ -1090,7 +1088,7 @@ test("pipeline page uses the shared subnav without a separate footer", () => {
   assert.match(template, /part arrived/);
   assert.match(template, /still expected/);
   assert.match(template, /no monitoring data/);
-  assert.match(template, /hover a square for what it measured/);
+  assert.match(template, /hover a cell for what it measured/);
   assert.match(template, /no monitoring data/);
   assert.doesNotMatch(template, /pipeline-footer|window-days/);
   assert.doesNotMatch(pipelineScript, /window-days/);

--- a/test/pipeline.test.mjs
+++ b/test/pipeline.test.mjs
@@ -8,6 +8,7 @@ import {
   cellOf,
   cellTitle,
   compactLeadExtents,
+  facetAxisLabel,
   facetRowsOf,
   leadAxis,
   leadExtents,
@@ -492,6 +493,24 @@ test("a facet view shows only its own dimension's rows", () => {
   // both gutters leave enough room for all ten compact run blocks
   assert.equal(runsThatFitFacetRows(joint, 390, "component"), 10);
   assert.equal(runsThatFitFacetRows(joint, 390, "member"), 10);
+});
+
+test("abbreviates long facet axis labels without changing their data labels", () => {
+  const abbreviations = new Map([
+    ["cloud and convection", "cloud/conv"],
+    ["natural levels", "nat lvls"],
+    ["pgrb2a.0p50", "pgrb2a"],
+    ["precipitation and snow", "precip/snow"],
+    ["pressure levels", "prs lvls"],
+    ["solar radiation", "solar"],
+    ["surface state", "sfc state"],
+    ["control", "ctl"],
+    ["perturbed members", "pert"],
+  ]);
+  for (const [label, abbreviation] of abbreviations) {
+    assert.equal(facetAxisLabel({ label }), abbreviation);
+  }
+  assert.equal(facetAxisLabel({ label: "wind" }), "wind");
 });
 
 test("gives every facet in the joint its own labelled row", () => {

--- a/test/pipeline.test.mjs
+++ b/test/pipeline.test.mjs
@@ -454,6 +454,7 @@ test("compacts lead columns when facets own the rows", () => {
   const compact = compactLeadExtents(product);
 
   assert.ok(compact.get("f000") < regular.get("f000"));
+  assert.ok(compact.get("f000") >= 12);
   assert.ok(compact.get("f240") < regular.get("f240"));
   assert.ok(compact.get("f240") > compact.get("f000"));
 });
@@ -567,13 +568,13 @@ test("draws a facet row for anything the joint reported in the window", () => {
 
 test("fits run blocks of lead columns to the width, once facets own the rows", () => {
   const joint = jointProduct();
-  // compact columns make a two-lead block 17px wide with a 23px pitch
+  // each lane keeps the text floor; two lanes double the fitted run count
   assert.equal(runsThatFitFacetRows(joint, 390), 10);
-  assert.equal(runsThatFitFacetRows(joint, 240), 7);
-  assert.equal(runsThatFitFacetRows(joint, 200), 5);
+  assert.equal(runsThatFitFacetRows(joint, 240), 8);
+  assert.equal(runsThatFitFacetRows(joint, 200), 6);
   assert.equal(runsThatFitFacetRows(joint, 1200), 10);
   // never zero, and an unmeasured row shows everything rather than nothing
-  assert.equal(runsThatFitFacetRows(joint, 80), 1);
+  assert.equal(runsThatFitFacetRows(joint, 80), 2);
   assert.equal(runsThatFitFacetRows(joint, 0), 10);
 });
 

--- a/test/pipeline.test.mjs
+++ b/test/pipeline.test.mjs
@@ -7,6 +7,7 @@ import {
   bandsOf,
   cellOf,
   cellTitle,
+  compactLeadExtents,
   facetRowsOf,
   leadAxis,
   leadExtents,
@@ -445,6 +446,16 @@ test("sizes a lead group by its share of the run, never below its label", () => 
     delete group.leads_available;
   }
   assert.deepEqual([...leadExtents(uncounted).values()], [24, 24]);
+});
+
+test("compacts lead columns when facets own the rows", () => {
+  const product = facetedProduct();
+  const regular = leadExtents(product);
+  const compact = compactLeadExtents(product);
+
+  assert.ok(compact.get("f000") < regular.get("f000"));
+  assert.ok(compact.get("f240") < regular.get("f240"));
+  assert.ok(compact.get("f240") > compact.get("f000"));
 });
 
 test("offers one view per facet dimension, opening on the lead grid", () => {


### PR DESCRIPTION
# Compact pipeline facet views

PR: #201

## Assumptions

- Only facet-dimension views change; the default lead-group-by-init view keeps its geometry.
- The current payload cap remains 10 inits.
- Text lead labels require a 12px minimum width, so density comes from two chronological lanes rather than making every lead column a sliver.
- Facet cells stay 8px high.
- Each init returns to a visible exact time label because a text-width run block can hold it.

## Success criteria

- [x] Initial compact-dot implementation shipped to the draft PR and passed verification.
- [x] Replace lead-time dots with the original text labels.
- [x] Render recent inits in two chronological lanes with consistent lead and facet axes.
- [x] Show all 10 fixture inits without overflow at desktop width.
- [x] Keep facet cells at 8px high and leave the default lead-group view unchanged.
- [x] Show the exact time under every init and dates at lane-local transitions.
- [x] Update unit and browser tests before implementation, then pass the full suites.
- [x] Visually review desktop and narrow layouts.

## Work log

### 2026-08-21 — Started

- Created draft PR #201 from a red-test checkpoint.
- Confirmed the 12px lead-label floor and 6px init gap were the primary horizontal constraints.
- The repository patch helper cannot enter its sandbox because loopback setup fails; edits use the system patch applicator as the closest safe fallback.

### 2026-08-21 — Initial visual review

- Desktop and 800px-wide fixture views both showed all 10 inits without horizontal overflow.
- Increased dots from 1px to 2px after the first render made them look too faint.
- Kept 6px between init blocks after compaction; this preserved grouping and gave sparse labels enough room.
- Prevented local-zone labels such as `04 CDT` from wrapping into the date tier.

### 2026-08-21 — Initial retro

- The label floor, rather than proportional scaling itself, was the main density cost.
- Compact facet blocks fit all 10 payload inits at the fixture's desktop width while preserving the default view.
- Full verification: 149 unit tests and 14 browser tests passed.

### 2026-08-21 — User feedback: two-lane grid

- Long-lead dot clusters are visually too busy.
- Restore text lead labels while retaining the useful shorter facet cells.
- Try two rows of inits to gain history without over-compressing each run.

### 2026-08-21 — Two-lane retro

- Split the selected chronological window evenly: older inits occupy the first lane and newer inits continue in the second.
- Restored visible text lead labels at the start of each lane and exact time labels beneath every init.
- Kept facet cells at 8px and reserved both lanes in the shared view height, so cycling dimensions does not shift the page.
- Desktop and 720px visual checks showed all 10 fixture inits without horizontal overflow.
- Full verification: 149 unit tests and 14 browser tests passed.


### 2026-08-21 — Spacing and axis-label feedback

- Increase the space between compact facet rows while keeping their 8px bars.
- Repeat facet-axis labels in both chronological lanes.
- Abbreviate member labels to `ctl` and `pert` without changing underlying facet data or hover detail.

### 2026-08-21 — Spacing retro

- Increased compact facet-row gaps from 2px to 4px and the lane gap from 6px to 10px.
- Both lanes render their own facet labels; browser coverage verifies the repetition.
- Member-axis labels now use `ctl` and `pert`, while full labels remain in hover details.
- Desktop component and member views remain balanced, with all 10 inits visible.
- Full verification: 149 unit tests and 14 browser tests passed.


### 2026-08-21 — Repeat every init's lead labels

- Clarified that `0h`, `1d`, and later lead labels must repeat above every init block, not only once per lane.
- Expand display-only abbreviations to the long component labels present in the public live dashboard.

### 2026-08-21 — Repeated-label retro

- Every init block now renders its complete lead-time header; browser coverage expects all five repetitions in each lane.
- Added concise axis forms for the long labels in the live feed, including `nat lvls`, `prs lvls`, `cloud/conv`, `precip/snow`, `sfc state`, and pgrb labels without resolution suffixes.
- Full data labels remain unchanged for cell hover details.
- Visually verified live GEFS and HRRR rows at desktop width, including six lead groups per init.
- Full verification: 150 unit tests and 14 browser tests passed.
