### PR TITLE
Describe monitoring gaps without claiming downtime

### DIFF
--- a/content/status.njk
+++ b/content/status.njk
@@ -151,6 +151,7 @@ statusSection: uptime
     color: var(--pill-degraded-fg);
     background: var(--pill-degraded-bg);
   }
+  .status-incident[data-kind="observation"] header strong,
   .status-incident[data-kind="delay"] header strong {
     color: var(--pill-degraded-fg);
     background: var(--pill-degraded-bg);

--- a/public/status.mjs
+++ b/public/status.mjs
@@ -39,8 +39,10 @@ function isIncidentGroup(group) {
   return (
     group &&
     typeof group.id === "string" &&
-    ["outage", "planned"].includes(group.kind) &&
+    ["observation", "outage", "planned"].includes(group.kind) &&
     typeof group.summary === "string" &&
+    (group.description == null || typeof group.description === "string") &&
+    (group.kind !== "observation" || typeof group.description === "string") &&
     hasUtcOffset(group.started_at) &&
     hasUtcOffset(group.ended_at) &&
     Date.parse(group.ended_at) > Date.parse(group.started_at) &&
@@ -262,6 +264,7 @@ export function applyIncidentGroups(history, incidentGroups = []) {
       id,
       kind: configured.kind,
       summary: configured.summary,
+      ...(configured.description ? { description: configured.description } : {}),
       components: configured.components.filter((component) =>
         matches.some((incident) => incident.component === component),
       ),
@@ -563,7 +566,8 @@ function incidentName(incident, names) {
   return incident.summary ?? names.get(incident.component);
 }
 
-function groupedIncidentDescription(incident, names, end) {
+export function groupedIncidentDescription(incident, names, end) {
+  if (incident.description) return incident.description;
   const affected = sentenceList([
     ...new Set(
       incident.components
@@ -612,7 +616,12 @@ function renderIncidentLog(root, history, data, local) {
     const summary = document.createElement("p");
     const timing = document.createElement("p");
     const kind = incident.kind ?? "outage";
-    const label = kind === "planned" ? "planned outage" : kind;
+    const label =
+      kind === "planned"
+        ? "planned outage"
+        : kind === "observation"
+          ? "observation gap"
+          : kind;
     const end = incident.end ?? history.asOf.getTime();
 
     item.id = incident.id;

--- a/test/status.test.mjs
+++ b/test/status.test.mjs
@@ -7,6 +7,7 @@ import {
   barDescription,
   buildHistory,
   incidentDescription,
+  groupedIncidentDescription,
   isHistoryCurrent,
   isStatusDataStale,
   overlappingEntries,
@@ -298,6 +299,49 @@ test("groups explicitly related outages and remaps day links", () => {
       incidentIds: ["incident-group-hrrr-history-migration"],
     });
   }
+});
+
+test("accepts and preserves an observation-gap explanation", () => {
+  const description =
+    "Our monitoring telemetry of data product reads was unavailable for 18 minutes. " +
+    "We have no indication that data product reads themselves were impacted.";
+  const group = {
+    id: "data-product-read-telemetry-gap",
+    kind: "observation",
+    summary: "Data product read monitoring telemetry",
+    description,
+    started_at: "2026-08-19T23:45:15Z",
+    ended_at: "2026-08-20T00:03:24Z",
+    components: ["data-product-reads"],
+  };
+  const data = validateStatusData({
+    ...operationalData,
+    incident_groups: [group],
+  });
+  const incident = {
+    id: "incident-data-product-reads-1",
+    component: "data-product-reads",
+    kind: "outage",
+    start: Date.parse(group.started_at),
+    end: Date.parse(group.ended_at),
+    ending: "resolved",
+  };
+
+  const grouped = applyIncidentGroups(
+    { incidents: [incident], cells: new Map() },
+    data.incident_groups,
+  );
+
+  assert.equal(grouped.incidents[0].kind, "observation");
+  assert.equal(grouped.incidents[0].description, description);
+  assert.equal(
+    groupedIncidentDescription(
+      grouped.incidents[0],
+      new Map([["data-product-reads", "Data product reads"]]),
+      incident.end,
+    ),
+    description,
+  );
 });
 
 test("explicit unplanned incident groups retain outage severity", () => {


### PR DESCRIPTION
## Summary

- accept observation-gap incident metadata from the status publisher
- render the supplied explanation and label it as an observation gap
- style observation gaps consistently with other non-outage incident states

## Verification

- `npm test` (149 tests passed)

## Deployment

Deploy this renderer before the companion publisher change begins emitting `kind: observation`; the existing renderer accepts only `outage` and `planned`.