### PR TITLE
Render ECCC HRDPS on the pipeline page

### DIFF
--- a/public/pipeline.mjs
+++ b/public/pipeline.mjs
@@ -1010,9 +1010,9 @@ export function etaLineText(target, now, local) {
 // The percentile columns summarise every init in the historical baseline, not
 // just the runs the grid draws, so the header names the sample they came from.
 function statsHeader(sampleInitCount) {
-  return sampleInitCount
-    ? `time after init · ${sampleInitCount.toLocaleString("en-US")} inits`
-    : "time after init";
+  if (!sampleInitCount) return "time after init";
+  const inits = sampleInitCount === 1 ? "init" : "inits";
+  return `time after init · ${sampleInitCount.toLocaleString("en-US")} ${inits}`;
 }
 
 export function detailRows(product, now, local) {

--- a/public/pipeline.mjs
+++ b/public/pipeline.mjs
@@ -598,9 +598,11 @@ export function cellTitle(band, init, cell, local) {
   if (cell.state === "unobserved") {
     return `${band.label} · ${when} · no probe visibility; not a publication failure`;
   }
+  // the unit agrees with the total, so a band of one lead reads "1 / 1 file"
+  const files = cell.expected === 1 ? "file" : "files";
   const volume =
     cell.expected != null
-      ? `${cell.available.toLocaleString("en-US")} / ${cell.expected.toLocaleString("en-US")} files`
+      ? `${cell.available.toLocaleString("en-US")} / ${cell.expected.toLocaleString("en-US")} ${files}`
       : `${Math.round((cell.completion ?? 0) * 100)}%`;
   return [
     band.kind === "facet" ? `${band.label} (${band.dimension})` : `lead ${band.label}`,

--- a/test/e2e/pipeline.spec.mjs
+++ b/test/e2e/pipeline.spec.mjs
@@ -135,6 +135,37 @@ test("the default view is lead groups by init, sized by group and labelled per c
   expect(geometry.overflowsColumn).toBe(false);
 });
 
+test("a source with no mirror and no facets draws one row that does not cycle", async ({
+  page,
+}) => {
+  // HRDPS arrives as a group of one, with no facets and a baseline as short as
+  // its monitoring: three lead bands, five runs, and nothing to cycle to
+  await openPipeline(page);
+  const group = page
+    .locator(".pipeline-group")
+    .filter({ hasText: "ECCC HRDPS continental 2.5 km" });
+  const row = group.locator(".pipeline-row");
+  await expect(row).toHaveCount(1);
+  await expect(row.locator("strong").first()).toHaveText("MSC Datamart");
+  await expect(row.locator(".pipeline-source-meta")).toContainText("00/06/12/18z");
+  await expect(row.locator(".pipeline-run-label")).toHaveCount(5);
+
+  const geometry = await bandGeometry(row);
+  expect(geometry.labels).toEqual(["2d", "1d", "0h"]);
+  // the two 24-hour groups cover the same span; only 0h's single lead is thinner,
+  // and even it stays tall enough to carry its own label
+  const [longest, middle, shortest] = geometry.cellHeights;
+  expect(longest).toBe(middle);
+  expect(shortest).toBeLessThan(middle);
+  expect(shortest).toBeGreaterThanOrEqual(12);
+  expect(geometry.overflowsColumn).toBe(false);
+
+  // one view means a click is inert: no facet lanes, and the field keeps its shape
+  await row.locator(".pipeline-viz").click();
+  await expect(row.locator(".pipeline-facet-lane")).toHaveCount(0);
+  expect(await bandGeometry(row)).toEqual(geometry);
+});
+
 test("clicking cycles the rows through each facet dimension without moving the page", async ({
   page,
 }) => {

--- a/test/fixtures/pipeline-dashboard.json
+++ b/test/fixtures/pipeline-dashboard.json
@@ -1928,6 +1928,262 @@
           "next_expected_completion_at": "2026-07-25T19:30:00Z"
         }
       ]
+    },
+    {
+      "id": "eccc-hrdps",
+      "label": "ECCC HRDPS continental 2.5 km",
+      "products": [
+        {
+          "id": "external-eccc-hrdps-datamart",
+          "label": "ECCC HRDPS continental 2.5 km",
+          "source": "https://dd.weather.gc.ca",
+          "source_label": "MSC Datamart",
+          "row_label": "MSC Datamart",
+          "cadence_hours": 6,
+          "init_hours": [
+            "00",
+            "06",
+            "12",
+            "18"
+          ],
+          "lead_groups": [
+            {
+              "name": "f000",
+              "label": "0h",
+              "leads_in_group": 1,
+              "center_pct": 1.02
+            },
+            {
+              "name": "f024",
+              "label": "1d",
+              "leads_in_group": 25,
+              "center_pct": 26.53
+            },
+            {
+              "name": "f048",
+              "label": "2d",
+              "leads_in_group": 49,
+              "center_pct": 75.51
+            }
+          ],
+          "latency_stats": {
+            "p50_s": 13440,
+            "p95_s": 13440,
+            "p99_s": 13440,
+            "sample_init_count": 1
+          },
+          "lead_group_stats": [
+            {
+              "name": "f000",
+              "label": "0h",
+              "leads_in_group": 1,
+              "p50_s": 13200,
+              "p95_s": 13200,
+              "p99_s": 13200
+            },
+            {
+              "name": "f024",
+              "label": "1d",
+              "leads_in_group": 25,
+              "p50_s": 13200,
+              "p95_s": 13200,
+              "p99_s": 13200
+            },
+            {
+              "name": "f048",
+              "label": "2d",
+              "leads_in_group": 49,
+              "p50_s": 13440,
+              "p95_s": 13440,
+              "p99_s": 13440
+            }
+          ],
+          "recent_inits": [
+            {
+              "init_time": "2026-07-24T12:00:00Z",
+              "status": "complete",
+              "timing": "on_time",
+              "completion_pct": 1.0,
+              "latency_s": 13440,
+              "lead_groups": [
+                {
+                  "name": "f000",
+                  "status": "complete",
+                  "timing": "on_time",
+                  "completion_pct": 1.0,
+                  "latency_s": 13200,
+                  "leads_available": 1,
+                  "leads_expected": 1
+                },
+                {
+                  "name": "f024",
+                  "status": "complete",
+                  "timing": "on_time",
+                  "completion_pct": 1.0,
+                  "latency_s": 13200,
+                  "leads_available": 25,
+                  "leads_expected": 25
+                },
+                {
+                  "name": "f048",
+                  "status": "complete",
+                  "timing": "on_time",
+                  "completion_pct": 1.0,
+                  "latency_s": 13440,
+                  "leads_available": 49,
+                  "leads_expected": 49
+                }
+              ]
+            },
+            {
+              "init_time": "2026-07-24T18:00:00Z",
+              "status": "complete",
+              "timing": "on_time",
+              "completion_pct": 1.0,
+              "latency_s": 13440,
+              "lead_groups": [
+                {
+                  "name": "f000",
+                  "status": "complete",
+                  "timing": "on_time",
+                  "completion_pct": 1.0,
+                  "latency_s": 13200,
+                  "leads_available": 1,
+                  "leads_expected": 1
+                },
+                {
+                  "name": "f024",
+                  "status": "complete",
+                  "timing": "on_time",
+                  "completion_pct": 1.0,
+                  "latency_s": 13200,
+                  "leads_available": 25,
+                  "leads_expected": 25
+                },
+                {
+                  "name": "f048",
+                  "status": "complete",
+                  "timing": "on_time",
+                  "completion_pct": 1.0,
+                  "latency_s": 13440,
+                  "leads_available": 49,
+                  "leads_expected": 49
+                }
+              ]
+            },
+            {
+              "init_time": "2026-07-25T00:00:00Z",
+              "status": "complete",
+              "timing": "on_time",
+              "completion_pct": 1.0,
+              "latency_s": 13440,
+              "lead_groups": [
+                {
+                  "name": "f000",
+                  "status": "complete",
+                  "timing": "on_time",
+                  "completion_pct": 1.0,
+                  "latency_s": 13200,
+                  "leads_available": 1,
+                  "leads_expected": 1
+                },
+                {
+                  "name": "f024",
+                  "status": "complete",
+                  "timing": "on_time",
+                  "completion_pct": 1.0,
+                  "latency_s": 13200,
+                  "leads_available": 25,
+                  "leads_expected": 25
+                },
+                {
+                  "name": "f048",
+                  "status": "complete",
+                  "timing": "on_time",
+                  "completion_pct": 1.0,
+                  "latency_s": 13440,
+                  "leads_available": 49,
+                  "leads_expected": 49
+                }
+              ]
+            },
+            {
+              "init_time": "2026-07-25T06:00:00Z",
+              "status": "complete",
+              "timing": "on_time",
+              "completion_pct": 1.0,
+              "latency_s": 13440,
+              "lead_groups": [
+                {
+                  "name": "f000",
+                  "status": "complete",
+                  "timing": "on_time",
+                  "completion_pct": 1.0,
+                  "latency_s": 13200,
+                  "leads_available": 1,
+                  "leads_expected": 1
+                },
+                {
+                  "name": "f024",
+                  "status": "complete",
+                  "timing": "on_time",
+                  "completion_pct": 1.0,
+                  "latency_s": 13200,
+                  "leads_available": 25,
+                  "leads_expected": 25
+                },
+                {
+                  "name": "f048",
+                  "status": "complete",
+                  "timing": "on_time",
+                  "completion_pct": 1.0,
+                  "latency_s": 13440,
+                  "leads_available": 49,
+                  "leads_expected": 49
+                }
+              ]
+            },
+            {
+              "init_time": "2026-07-25T12:00:00Z",
+              "status": "complete",
+              "timing": "on_time",
+              "completion_pct": 1.0,
+              "latency_s": 13440,
+              "lead_groups": [
+                {
+                  "name": "f000",
+                  "status": "complete",
+                  "timing": "on_time",
+                  "completion_pct": 1.0,
+                  "latency_s": 13200,
+                  "leads_available": 1,
+                  "leads_expected": 1
+                },
+                {
+                  "name": "f024",
+                  "status": "complete",
+                  "timing": "on_time",
+                  "completion_pct": 1.0,
+                  "latency_s": 13200,
+                  "leads_available": 25,
+                  "leads_expected": 25
+                },
+                {
+                  "name": "f048",
+                  "status": "complete",
+                  "timing": "on_time",
+                  "completion_pct": 1.0,
+                  "latency_s": 13440,
+                  "leads_available": 49,
+                  "leads_expected": 49
+                }
+              ]
+            }
+          ],
+          "next_expected_init": "2026-07-25T18:00:00Z",
+          "next_expected_completion_at": "2026-07-25T21:44:00Z"
+        }
+      ]
     }
   ]
 }

--- a/test/pipeline.test.mjs
+++ b/test/pipeline.test.mjs
@@ -723,6 +723,17 @@ test("names what a square measured, facet first, in its hover label", () => {
     cellTitle(leadBand, init, cellOf(leadBand, init), false),
     "lead 1d · 07-26 00z · 100% · complete · on time",
   );
+
+  // the unit agrees with the total: a band holding one file is not "1 files",
+  // and an empty one is still "0 / 1 file"
+  assert.match(
+    cellTitle(facetBand, init, { ...cellOf(facetBand, init), available: 1, expected: 1 }, false),
+    /1 \/ 1 file ·/,
+  );
+  assert.match(
+    cellTitle(facetBand, init, { ...cellOf(facetBand, init), available: 0, expected: 1 }, false),
+    /0 \/ 1 file ·/,
+  );
 });
 
 test("reads an unreported band as unobserved rather than a failure", () => {

--- a/test/pipeline.test.mjs
+++ b/test/pipeline.test.mjs
@@ -940,6 +940,33 @@ test("local preview fixture exercises dashboard v2 facet rendering", () => {
   assert.equal(facetRows(product).length, 5);
 });
 
+// A source with no mirror and no facets is the other shape the payload carries:
+// one row under its group, one view, and a baseline as short as its monitoring.
+test("local preview fixture carries a source-only group", () => {
+  const fixture = JSON.parse(
+    readFileSync(
+      new URL("./fixtures/pipeline-dashboard.json", import.meta.url),
+      "utf8",
+    ),
+  );
+  const group = fixture.groups.find(({ id }) => id === "eccc-hrdps");
+  assert.equal(group.products.length, 1);
+
+  const [product] = group.products;
+  assert.equal(product.row_label, "MSC Datamart");
+  assert.equal(displaySource(product.source), "dd.weather.gc.ca");
+  assert.equal(product.facet_groups, undefined);
+  assert.equal(viewsOf(product).length, 1);
+  assert.deepEqual(
+    (product.lead_group_stats ?? []).map(({ label }) => label),
+    ["0h", "1d", "2d"],
+  );
+  assert.equal(
+    detailRows(product, Date.parse("2026-07-25T18:00:00Z"), false).statsHeader,
+    "time after init \u00b7 1 init",
+  );
+});
+
 test("preview pipeline route exposes only allowlisted staging JSON", async () => {
   const requested = [];
   const bucket = {

--- a/test/pipeline.test.mjs
+++ b/test/pipeline.test.mjs
@@ -828,6 +828,13 @@ test("names the init sample the percentile columns summarise", () => {
     "time after init · 1,394 inits",
   );
 
+  // a product monitored since its first init has a sample of exactly one
+  product.latency_stats.sample_init_count = 1;
+  assert.equal(
+    detailRows(product, Date.parse("2026-07-26T07:00:00Z"), false).statsHeader,
+    "time after init \u00b7 1 init",
+  );
+
   product.latency_stats.sample_init_count = 0;
   assert.equal(
     detailRows(product, Date.parse("2026-07-26T07:00:00Z"), false).statsHeader,


### PR DESCRIPTION
wxopticon now publishes `external-eccc-hrdps-datamart` (dynamical-org/wxopticon#204) — a
source-only product, group `eccc-hrdps`, "ECCC HRDPS continental 2.5 km", badge "MSC
Datamart", 49 hourly leads over `f000`/`f024`/`f048`, inits 00/06/12/18z. This makes
`/status/pipeline/` render it correctly.

## What it turned out to need

Nothing in the site enumerates products: `/status/pipeline/` builds every group, row, badge
and lead label from `dashboard.json` alone (`renderStructure`, `public/pipeline.mjs`), and
`validateDashboard` is shape-only. There is no ordering table, label map, or allowlist to
add HRDPS to, and `test/fixtures/status.json` covers the `/status/` dataset list, which
HRDPS is absent from because it has no catalog dataset and no mirror yet
(dynamical-org/wxopticon#205). `dashboard.json` carries only the `external-*` sources under
each group, so the Source Coop mirror needs nothing here either — it will simply arrive as
a second row.

So HRDPS already appeared, with one thing wrong and one shape the tests had never seen.

## Plan

- [x] Verify the live payload renders: group heading, badge, source meta, lead labels,
      init tiers, ETA, details table
- [x] Fix the one defect HRDPS surfaces: a baseline of one init reads "1 inits"
- [x] Give the fixture the shape HRDPS introduced — a single-product, facet-less group —
      so `npm test`, the browser spec, and `npm run start:pipeline` all carry it
- [x] Browser spec for that group: heading, badge, three lead labels, no view cycling,
      no overflow
- [x] `npm test` (156 pass), `npm run test:e2e` (15 pass), `npm run build`

## Changes

**`Count a one-init baseline as one init`** — HRDPS has been monitored since its first
init, so `latency_stats.sample_init_count` is 1 and the details header read
"time after init · 1 inits". `statsHeader` now agrees in number. Red/green on the existing
`names the init sample the percentile columns summarise` test.

**`Give the pipeline fixture a source-only group`** — the fixture had exactly one group,
with two facet dimensions and a ten-init baseline; every product-shaped test therefore ran
against a faceted product. It now also carries `eccc-hrdps` in HRDPS's real shape — one
product, no `facet_groups`, three lead groups, five runs, `sample_init_count: 1` — which
`npm run start:pipeline` serves as well. Two tests read it: a unit test on the row label,
source, single view and lead labels, and a browser spec asserting the group draws one row,
the two 24-hour bands measure equal while `0h` stays above its 12px label floor, and a
click on a one-view product is inert.

## Verified against live data

`npm start` points the page at `assets.dynamical.org/wxopticon`, so this was checked
against the published payload, not a fixture: heading "ECCC HRDPS continental 2.5 km", one
row "MSC Datamart", `dd.weather.gc.ca` · 6h init cadence · 00/06/12/18z, bands 2d/1d/0h,
five init columns with their tiers, ETA, and the details table now reading
"time after init · 1 init". No console errors.

## Not in this PR

`/status/pipeline/`'s history scrubber leaves a stale row for any product missing from the
snapshot being shown: `renderSnapshot` hydrates the rows it finds and skips the rest, so
the row keeps whatever was last drawn into it. History snapshots are the pre-v2 flat shape
and stop before HRDPS existed, so scrubbing to, say, Aug 5 keeps HRDPS's live Aug 25–26
arrivals on screen under an Aug 5 timestamp. It predates this change —
`external-dwd-icon-eu-source-coop` does the same — and fixing it means deciding what a row
with no snapshot should say, so it is its own change.

## Review

A codex pass (review-only, findings posted as PR comments) turned up one real defect,
fixed in `Agree the hover file count with its total`: `cellTitle` hard-coded `files`, so
HRDPS's 0h cell — a band of one lead — hovered as "1 / 1 files". The unit now agrees with
the total, giving "1 / 1 file" and "0 / 1 file" while "12 / 49 files" is unchanged; the
existing `cellTitle` unit test covers it. `statsHeader` and `cellTitle` are now the only
two counted nouns in `public/pipeline.mjs`, and both agree in number.

Three further points were raised and answered without changes: the fixture keeps
`leads_in_group` and `center_pct` even though the renderer reads neither, because it is a
transcription of the published contract; the spec's post-click geometry equality is backed
by the `.pipeline-facet-lane` count for the visible failure and by the unit test on
`viewsOf` for the early return; and the second fixture group weakens no existing test.
