### PR TITLE
Fit pipeline views to content and add navigation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,8 +23,8 @@ the published parquet files and take about a minute; they are the only check tha
 catches the data those charts read drifting out from under them. `pipeline.spec.mjs`
 instead stubs every request from `test/fixtures/pipeline-dashboard.json`, so it is
 offline and finishes in seconds — it exists because `/status/pipeline/` is laid out by
-measurement (lead rows sized by group, init columns sized by their label, views sharing
-one reserved height), and `npm test` has no layout engine to catch that class of bug.
+measurement (lead rows sized by group and init columns sized by their label), and `npm
+test` has no layout engine to catch that class of bug.
 Keep both out of `npm test`, which stays offline and instant.
 
 ## Architecture

--- a/content/status-pipeline.njk
+++ b/content/status-pipeline.njk
@@ -9,7 +9,7 @@ statusSection: pipeline
 pageStylesheet: /pipeline.css
 ---
 
-<main class="content pipeline-page" id="pipeline-app"
+<main class="content pipeline-page md-toc-content" id="pipeline-app"
   data-assets-base="{{ pipelineAssetsBase }}" style="margin-top: 4rem;">
   {% from "status-subnav.njk" import statusSubnav %}
   {% call statusSubnav(statusSection, statusFeed, pipelineAssetsBase) %}
@@ -24,6 +24,12 @@ pageStylesheet: /pipeline.css
       </label>
     </p>
   {% endcall %}
+
+  <div class="md-toc-rail" data-slot="pipeline-toc-rail" hidden>
+    <nav class="md-toc" data-slot="pipeline-toc" aria-label="Pipeline groups">
+      <ul class="toc-tree" data-slot="pipeline-toc-tree"></ul>
+    </nav>
+  </div>
 
   {# Remove once wxopticon's granular cutover and history backfill are done:
      dynamical-org/wxopticon#163 (cutover), #161 and #162 (backfill). #}
@@ -73,4 +79,6 @@ pageStylesheet: /pipeline.css
   <noscript><p>Pipeline status requires JavaScript.</p></noscript>
 </main>
 
+<style>{{ tocCSS | safe }}</style>
+<script>{{ tocJS | safe }}</script>
 <script type="module" src="/pipeline.mjs"></script>

--- a/lib/markdown-toc.js
+++ b/lib/markdown-toc.js
@@ -221,6 +221,16 @@ const JS = String.raw`
         break;
       }
     }
+    // The document may bottom out before its final heading reaches the active
+    // line. Once the reader has actually scrolled to the bottom, the final
+    // section is the useful active state.
+    if (
+      window.scrollY > 0 &&
+      window.innerHeight + window.scrollY >=
+        document.documentElement.scrollHeight - 1
+    ) {
+      activeId = headings[headings.length - 1].id;
+    }
 
     for (var id in entriesById) {
       entriesById[id].link.classList.remove('active');

--- a/lib/markdown-toc.js
+++ b/lib/markdown-toc.js
@@ -199,28 +199,19 @@ const CSS = `
 // back/forward) can move headings from above the viewport straight to
 // below the active line without ever crossing into the intersection
 // area, which IO doesn't report — so transition tracking would leave
-// stale "passed" flags and pick the wrong heading.
+// stale "passed" flags and pick the wrong heading. Pages that render their
+// headings at runtime dispatch `md-toc:refresh` after replacing the content.
 const JS = String.raw`
 (function () {
   var content = document.querySelector('.md-toc-content');
   var toc = document.querySelector('.md-toc');
   if (!content || !toc) return;
 
-  var headings = [].slice.call(content.querySelectorAll('h2[id], h3[id]'));
-  if (!headings.length) return;
-
+  var headings = [];
   var entriesById = {};
-  toc.querySelectorAll('a[href^="#"]').forEach(function (a) {
-    var id = a.getAttribute('href').slice(1);
-    var li = a.closest('li');
-    entriesById[id] = {
-      link: a,
-      li: li,
-      parentH2Li: li.closest('.toc-h2'),
-    };
-  });
 
   function update() {
+    if (!headings.length) return;
     var line = window.innerHeight * 0.3;
     var activeId = headings[0].id;
     for (var i = 0; i < headings.length; i++) {
@@ -244,6 +235,21 @@ const JS = String.raw`
     if (active.parentH2Li) active.parentH2Li.classList.add('expanded');
   }
 
+  function refresh() {
+    headings = [].slice.call(content.querySelectorAll('h2[id], h3[id]'));
+    entriesById = {};
+    toc.querySelectorAll('a[href^="#"]').forEach(function (a) {
+      var id = a.getAttribute('href').slice(1);
+      var li = a.closest('li');
+      entriesById[id] = {
+        link: a,
+        li: li,
+        parentH2Li: li.closest('.toc-h2'),
+      };
+    });
+    update();
+  }
+
   var queued = false;
   function onScroll() {
     if (queued) return;
@@ -255,7 +261,8 @@ const JS = String.raw`
   }
   window.addEventListener('scroll', onScroll, { passive: true });
   window.addEventListener('resize', onScroll, { passive: true });
-  update();
+  document.addEventListener('md-toc:refresh', refresh);
+  refresh();
 })();
 `;
 

--- a/public/pipeline.css
+++ b/public/pipeline.css
@@ -111,6 +111,7 @@
 .pipeline-group > h3 {
   margin: 1.6rem 0 0.4rem;
   font-size: 1.5rem;
+  scroll-margin-top: 2rem;
 }
 
 .pipeline-row {

--- a/public/pipeline.css
+++ b/public/pipeline.css
@@ -164,9 +164,6 @@
   min-width: 0;
 }
 
-/* Facet rows grow evenly within a lane, capped at three cells so a sparse
-   product does not draw absurdly tall rows. */
-
 .pipeline-rows {
   display: flex;
   flex: 1;

--- a/public/pipeline.css
+++ b/public/pipeline.css
@@ -160,16 +160,11 @@
   display: flex;
   flex-direction: column;
   gap: var(--band-gap);
-  /* every view reserves the tallest view's height, so cycling does not shift
-     the page under the reader; a view that cannot fill it sits centred */
-  justify-content: center;
-  min-height: var(--reserve, auto);
   min-width: 0;
 }
 
-/* The facet rows share out whatever height the reserved box leaves them, so a
-   view with two rows draws as much ink as one with six — capped at three cells
-   so a sparse product does not draw absurdly tall rows. */
+/* Facet rows grow evenly within a lane, capped at three cells so a sparse
+   product does not draw absurdly tall rows. */
 
 .pipeline-rows {
   display: flex;

--- a/public/pipeline.mjs
+++ b/public/pipeline.mjs
@@ -875,13 +875,22 @@ function renderField(product, local, runCount) {
 
 function renderStructure(app, dashboard, rows) {
   const groupsSlot = app.querySelector('[data-slot="groups"]');
+  const tocRail = app.querySelector('[data-slot="pipeline-toc-rail"]');
+  const tocTree = app.querySelector('[data-slot="pipeline-toc-tree"]');
   groupsSlot.replaceChildren();
+  tocTree.replaceChildren();
   rows.clear();
 
   for (const group of dashboard.groups) {
+    const groupId = `pipeline-group-${group.id}`;
     const section = element("section", { class: "pipeline-group" }, [
-      element("h3", null, group.label),
+      element("h3", { id: groupId }, group.label),
     ]);
+    tocTree.append(
+      element("li", { class: "toc-h2" }, [
+        element("a", { href: `#${groupId}` }, group.label),
+      ]),
+    );
     for (const product of group.products) {
       const advisory = element("div", {
         class: "pipeline-row-advisory",
@@ -932,6 +941,8 @@ function renderStructure(app, dashboard, rows) {
     }
     groupsSlot.append(section);
   }
+  tocRail.hidden = false;
+  document.dispatchEvent(new Event("md-toc:refresh"));
 }
 
 function etaTarget(product) {

--- a/public/pipeline.mjs
+++ b/public/pipeline.mjs
@@ -28,8 +28,6 @@ const FACET_MIN_LEAD_PX = 12; // every lead group keeps room for its text label
 const FACET_LEAD_ALLOWANCE_PX = 5;
 const BAND_GAP_PX = 2; // between bands, inside a field
 const LABEL_PX = 12; // one axis-label row
-const FOOT_GAP_PX = 3; // the breath above the init tiers
-const HEAD_GAP_PX = 2; // the head band's margin under the lead labels
 const CH_PX = 6; // one monospace character at the band-label size
 const GUTTER_MAX_CH = 24; // long facet labels get room, but not unbounded
 const RUNS_MAX = 10; // what the payload carries
@@ -396,40 +394,6 @@ function leadLabel(lead, width) {
       title: `lead ${lead.label}`,
     },
     lead.label,
-  );
-}
-
-/* How tall a view draws. The label rows have fixed heights, so this needs no
-   measurement — which matters because the render pass writes without reading. */
-
-function chromePx(view, rows) {
-  const gap = view.dimension ? FACET_BAND_GAP_PX : BAND_GAP_PX;
-  const head = view.dimension ? LABEL_PX + gap + HEAD_GAP_PX : 0;
-  const tiers = FOOT_GAP_PX + 2 * (LABEL_PX + gap);
-  return head + tiers + gap * Math.max(0, rows - 1);
-}
-
-function viewHeightPx(product, view) {
-  const bands = view.dimension
-    ? facetRowsOf(product, view.dimension).map(() => FACET_CELL_PX)
-    : [...leadExtents(product).values()];
-  const rows = bands.length || 1;
-  const laneHeight =
-    bands.reduce((sum, px) => sum + px, 0) + chromePx(view, rows);
-  if (!view.dimension) return laneHeight;
-  const laneCount = Math.min(
-    FACET_LANES,
-    Math.max(1, product.recent_inits?.length ?? 0),
-  );
-  return laneHeight * laneCount + FACET_LANE_GAP_PX * (laneCount - 1);
-}
-
-/* The box every view of a product sits in: the tallest one. Clicking through
-   the views then never moves the rest of the page. */
-
-export function reservedHeightPx(product) {
-  return Math.max(
-    ...viewsOf(product).map((view) => viewHeightPx(product, view)),
   );
 }
 
@@ -862,7 +826,7 @@ function renderFacetRows(product, local, runCount, dimension) {
     // lead time runs across here, so progress fills across too
     "data-fill": "side",
     "data-compact": "",
-    style: `--sq:${FACET_CELL_PX}px;--clump-gap:${FACET_CLUMP_GAP_PX}px;--clumped-run-gap:${FACET_RUN_GAP_PX}px;--lane-gap:${FACET_LANE_GAP_PX}px;--band-gutter:${facetGutterPx(facets)}px;--run-width:${runWidth}px;--band-gap:${FACET_BAND_GAP_PX}px;--label-h:${LABEL_PX}px;--reserve:${reservedHeightPx(product)}px`,
+    style: `--sq:${FACET_CELL_PX}px;--clump-gap:${FACET_CLUMP_GAP_PX}px;--clumped-run-gap:${FACET_RUN_GAP_PX}px;--lane-gap:${FACET_LANE_GAP_PX}px;--band-gutter:${facetGutterPx(facets)}px;--run-width:${runWidth}px;--band-gap:${FACET_BAND_GAP_PX}px;--label-h:${LABEL_PX}px`,
   });
   const laneCount = Math.min(FACET_LANES, Math.max(1, runs.length));
   const runsPerLane = Math.ceil(runs.length / laneCount);
@@ -889,7 +853,7 @@ function renderField(product, local, runCount) {
   const field = element("div", {
     class: "pipeline-field",
     // a cell is as wide as its init label; the lead axis keeps its own scale
-    style: `--sq:${column}px;--run-gap:${RUN_GAP_PX}px;--clumped-run-gap:${RUN_GAP_PX}px;--run-width:${column}px;--band-gutter:${gutterPx(bandsOf(product))}px;--band-gap:${BAND_GAP_PX}px;--label-h:${LABEL_PX}px;--reserve:${reservedHeightPx(product)}px`,
+    style: `--sq:${column}px;--run-gap:${RUN_GAP_PX}px;--clumped-run-gap:${RUN_GAP_PX}px;--run-width:${column}px;--band-gutter:${gutterPx(bandsOf(product))}px;--band-gap:${BAND_GAP_PX}px;--label-h:${LABEL_PX}px`,
   });
   for (const band of bandsOf(product)) {
     field.append(

--- a/test/e2e/pipeline.spec.mjs
+++ b/test/e2e/pipeline.spec.mjs
@@ -135,6 +135,27 @@ test("the default view is lead groups by init, sized by group and labelled per c
   expect(geometry.overflowsColumn).toBe(false);
 });
 
+test("the table of contents follows the rendered pipeline groups", async ({
+  page,
+}) => {
+  await openPipeline(page);
+  const links = page.locator('[data-slot="pipeline-toc"] a');
+
+  await expect(links).toHaveText([
+    "NOAA GFS forecast",
+    "ECCC HRDPS continental 2.5 km",
+  ]);
+  expect(
+    await links.evaluateAll((nodes) =>
+      nodes.map((node) => node.getAttribute("href")),
+    ),
+  ).toEqual(["#pipeline-group-noaa-gfs", "#pipeline-group-eccc-hrdps"]);
+
+  await links.nth(1).click();
+  await expect(page).toHaveURL(/#pipeline-group-eccc-hrdps$/);
+  await expect(links.nth(1)).toHaveClass(/active/);
+});
+
 test("a source with no mirror and no facets draws one row that does not cycle", async ({
   page,
 }) => {

--- a/test/e2e/pipeline.spec.mjs
+++ b/test/e2e/pipeline.spec.mjs
@@ -138,8 +138,15 @@ test("the default view is lead groups by init, sized by group and labelled per c
 test("the table of contents follows the rendered pipeline groups", async ({
   page,
 }) => {
+  await page.setViewportSize({ width: 1600, height: 900 });
   await openPipeline(page);
   const links = page.locator('[data-slot="pipeline-toc"] a');
+
+  expect(
+    await page
+      .locator('[data-slot="pipeline-toc-rail"]')
+      .evaluate((node) => getComputedStyle(node).position),
+  ).toBe("absolute");
 
   await expect(links).toHaveText([
     "NOAA GFS forecast",

--- a/test/e2e/pipeline.spec.mjs
+++ b/test/e2e/pipeline.spec.mjs
@@ -3,9 +3,8 @@ import { readFileSync } from "node:fs";
 import { expect, test } from "@playwright/test";
 
 // /status/pipeline/ is drawn entirely by measurement: lead rows are sized by each
-// group's share of a run, init columns by the width of the label beneath them,
-// and every view reserves the tallest view's height so clicking through them does
-// not move the page. None of that is visible to `npm test`, which has no layout
+// group's share of a run and init columns by the width of the label beneath them.
+// None of that is visible to `npm test`, which has no layout
 // engine — and three defects found in review were geometry: an init label that
 // overflowed its tier in any timezone rendered as a GMT offset, a snapshot whose
 // newest run reported nothing rendering an empty field, and a negative
@@ -93,6 +92,7 @@ function bandGeometry(row) {
         (band) => +band.querySelector(".pipeline-cell").getBoundingClientRect().width.toFixed(1),
       ),
       fieldHeight: Math.round(field.height),
+      reserve: getComputedStyle(fieldNode).getPropertyValue("--reserve").trim(),
       overflowsColumn: field.width > body.width + 0.5,
     };
   });
@@ -166,15 +166,13 @@ test("a source with no mirror and no facets draws one row that does not cycle", 
   expect(await bandGeometry(row)).toEqual(geometry);
 });
 
-test("clicking cycles the rows through each facet dimension without moving the page", async ({
+test("clicking cycles the rows through content-height facet dimensions", async ({
   page,
 }) => {
   const row = await openPipeline(page);
   const viz = row.locator(".pipeline-viz");
-  const pageHeight = () => page.evaluate(() => document.body.scrollHeight);
 
   const lead = await bandGeometry(row);
-  const heightBefore = await pageHeight();
 
   await viz.click();
   const component = await bandGeometry(row);
@@ -191,10 +189,12 @@ test("clicking cycles the rows through each facet dimension without moving the p
   ).filter(Boolean);
   expect(columnLabels).toEqual(REPEATED_LEAD_LABELS);
 
-  // the views share one box: a cycle must not shift what is below the row
-  expect(component.fieldHeight).toBe(lead.fieldHeight);
-  expect(member.fieldHeight).toBe(lead.fieldHeight);
-  expect(await pageHeight()).toBe(heightBefore);
+  // each view fits its content instead of reserving the tallest view's height
+  expect(lead.reserve).toBe("");
+  expect(component.reserve).toBe("");
+  expect(member.reserve).toBe("");
+  expect(component.fieldHeight).not.toBe(lead.fieldHeight);
+  expect(member.fieldHeight).not.toBe(lead.fieldHeight);
   expect(member.overflowsColumn).toBe(false);
 
   // and it wraps back to where it started


### PR DESCRIPTION
# PR #205 — Pipeline content height and table of contents

Pipeline views now fit their rendered content instead of reserving the tallest view's height. The pipeline status page also has the same responsive TOC rail and scroll-spy behavior as the catalog, populated directly from the runtime dashboard groups.

## Success criteria

- [x] Pipeline views size to their rendered content instead of reserving the tallest view's height.
- [x] The pipeline page has a catalog-style TOC containing every rendered pipeline group.
- [x] TOC links target stable group headings and the shared scroll spy tracks the active group.
- [x] The TOC works with live and fixture payloads without duplicating product metadata in the template.
- [x] Unit tests, the full browser suite, and the production build pass.

## Plan

- [x] Remove `--reserve` and its unused height calculations.
- [x] Update the browser geometry contract and repository guidance.
- [x] Add the shared TOC rail markup and assets to the pipeline template.
- [x] Populate TOC entries from the same dashboard groups rendered by `pipeline.mjs`.
- [x] Add browser coverage for link targets and dynamic scroll-spy setup.
- [x] Run verification and update the PR description.

### 2026-08-26 — Initial implementation

Created draft PR #205 after isolating the work from merged PR #204. The content-height change was committed and pushed before TOC implementation began.

### 2026-08-26 — Dynamic TOC

Added the shared catalog-style rail to the pipeline template. `renderStructure` assigns stable IDs to group headings, creates matching TOC entries from the dashboard payload, and refreshes the shared scroll spy after runtime content arrives.

### 2026-08-26 — Verification and retro

`npm test` passed all 10 test files, `npm run test:e2e` passed all 16 browser tests, and `npm run build` completed successfully. Deriving the TOC from `dashboard.json` kept the runtime group list as the single source of truth; the only shared-component extension needed was an explicit refresh event for dynamically inserted headings.

### 2026-08-26 — Claude review

Claude posted two low-severity inline findings. Both were actionable. The shared scroll spy now selects the final section at the document bottom when that heading cannot cross the 30% activation line; the browser test reproduces this at 1600×900 and also exercises the floating rail. The inaccurate facet-row growth comment was removed, while the pre-existing dormant declarations were left untouched to keep the change surgical. Both threads have resolution replies.

## Changes

- Remove the pipeline field's reserved minimum height and its unused height calculations.
- Render stable anchors and TOC links for every dashboard group.
- Reuse the shared responsive TOC styles and scroll spy, including runtime refresh and bottom-of-document handling.
- Cover content-height views, wide-viewport TOC layout, link targets, and active-link navigation in Chromium.

## Verification

- `npm test` — 10/10 test files passed
- `npm run test:e2e` — 16/16 tests passed
- `npm run build` — passed
