### PR TITLE
Highlight late pending runs and pin history

### DIFF
--- a/public/pipeline.css
+++ b/public/pipeline.css
@@ -420,7 +420,7 @@
 
 .pipeline-row-details table {
   width: 100%;
-  min-width: 64rem;
+  min-width: 90rem;
   border-collapse: collapse;
   font-size: 1.2rem;
 }

--- a/public/pipeline.css
+++ b/public/pipeline.css
@@ -70,9 +70,21 @@
 }
 
 #pipeline-history-panel {
-  position: relative;
-  margin: 2rem 0;
-  padding-top: 2.4rem;
+  position: fixed;
+  z-index: 10;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  width: min(78rem, calc(100vw - 2rem));
+  margin: 0 auto;
+  padding: 2.4rem 1rem 1rem;
+  border-top: 1px solid var(--border-muted-color);
+  background: var(--bg-color);
+  box-shadow: 0 -0.4rem 1rem var(--shadow-color);
+}
+
+.pipeline-page:has(#pipeline-history-panel:not([hidden])) {
+  padding-bottom: 8rem;
 }
 
 #pipeline-history-panel > span {
@@ -306,6 +318,10 @@
    other is the absence of one */
 .pipeline-cell.g-pending {
   border: 1px solid var(--pipeline-unobserved);
+}
+
+.pipeline-cell.g-pending[data-timing="delayed"] {
+  border-color: var(--pipeline-progress);
 }
 
 .pipeline-cell.g-unobserved {

--- a/public/pipeline.mjs
+++ b/public/pipeline.mjs
@@ -972,7 +972,7 @@ function renderStructure(app, dashboard, rows) {
 
 function etaTarget(product) {
   const running = product.recent_inits.findLast(
-    (init) => init.status === "in_flight",
+    (init) => init.status === "pending" || init.status === "in_flight",
   );
   if (running) {
     const p95 = product.latency_stats?.p95_s;
@@ -1019,7 +1019,7 @@ function statsHeader(sampleInitCount) {
 
 export function detailRows(product, now, local) {
   const running = product.recent_inits.findLast(
-    (init) => init.status === "in_flight",
+    (init) => init.status === "pending" || init.status === "in_flight",
   );
   const displayed = running ?? product.recent_inits.at(-1);
   const groups = displayed?.lead_groups ?? [];

--- a/public/pipeline.mjs
+++ b/public/pipeline.mjs
@@ -1013,49 +1013,91 @@ export function etaLineText(target, now, local) {
 // just the runs the grid draws, so the header names the sample they came from.
 function statsHeader(sampleInitCount) {
   if (!sampleInitCount) return "time after init";
-  const inits = sampleInitCount === 1 ? "init" : "inits";
-  return `time after init · ${sampleInitCount.toLocaleString("en-US")} ${inits}`;
+  const samples = sampleInitCount === 1 ? "sample" : "samples";
+  return `time after init · ${sampleInitCount.toLocaleString("en-US")} ${samples}`;
+}
+
+function observedRunDetail(init, live, stats, now, local, active) {
+  if (!init) return { status: "—", time: "—", duration: "—" };
+  const initMs = Date.parse(init.init_time);
+  let time = "—";
+  let duration = "—";
+  if (live?.status === "complete" && live.latency_s != null) {
+    time = clockTime(
+      initMs + live.latency_s * 1000,
+      selectedTimeZone(local),
+    );
+    duration = formatLatency(live.latency_s);
+  } else if (live?.status === "complete") {
+    time = "done";
+  } else if (active && stats.p95_s != null) {
+    const target = initMs + stats.p95_s * 1000;
+    if (target > now) {
+      time = `ETA ${clockTime(target, selectedTimeZone(local))}`;
+    }
+    const elapsed = Math.floor((now - initMs) / 1000);
+    if (elapsed > 0) duration = formatDuration(elapsed);
+  }
+  return {
+    status: statusLabel(live?.status ?? "pending"),
+    time,
+    duration,
+  };
+}
+
+function upcomingRunDetail(initTime, stats, local) {
+  if (!initTime) return { status: "—", time: "—", duration: "—" };
+  const target =
+    stats.p95_s == null ? null : Date.parse(initTime) + stats.p95_s * 1000;
+  return {
+    status: "upcoming",
+    time:
+      target == null
+        ? "—"
+        : `ETA ${clockTime(target, selectedTimeZone(local))}`,
+    duration: "—",
+  };
+}
+
+function labelledRun(label, initTime, local) {
+  return initTime ? `${label} · ${initShort(initTime, local)}` : label;
 }
 
 export function detailRows(product, now, local) {
-  const running = product.recent_inits.findLast(
+  const recent = product.recent_inits ?? [];
+  const activeIndex = recent.findLastIndex(
     (init) => init.status === "pending" || init.status === "in_flight",
   );
-  const displayed = running ?? product.recent_inits.at(-1);
-  const groups = displayed?.lead_groups ?? [];
-  const initMs = displayed ? Date.parse(displayed.init_time) : 0;
+  const active = activeIndex >= 0 ? recent[activeIndex] : null;
+  const last = activeIndex >= 0 ? recent[activeIndex - 1] : recent.at(-1);
+  const upcoming = active ? null : product.next_expected_init;
   return {
-    header: running
-      ? initShort(running.init_time, local)
-      : displayed
-        ? `${initShort(displayed.init_time, local)} · previous init`
-        : "waiting for next init",
+    lastHeader: labelledRun("last run", last?.init_time, local),
+    runHeader: active
+      ? labelledRun("current run", active.init_time, local)
+      : labelledRun("upcoming run", upcoming, local),
     statsHeader: statsHeader(product.latency_stats?.sample_init_count),
     rows: (product.lead_group_stats ?? []).map((stats, index) => {
-      const live = groups[index];
-      let time = "—";
-      let duration = "—";
-      if (live?.status === "complete" && live.latency_s != null) {
-        time = clockTime(
-          initMs + live.latency_s * 1000,
-          selectedTimeZone(local),
-        );
-        duration = formatLatency(live.latency_s);
-      } else if (live?.status === "complete") {
-        time = "done";
-      } else if (running && stats.p95_s != null) {
-        const target = initMs + stats.p95_s * 1000;
-        if (target > now) {
-          time = `ETA ${clockTime(target, selectedTimeZone(local))}`;
-        }
-        const elapsed = Math.floor((now - initMs) / 1000);
-        if (elapsed > 0) duration = formatDuration(elapsed);
-      }
       return {
         label: stats.label,
-        status: statusLabel(live?.status ?? "pending"),
-        time,
-        duration,
+        last: observedRunDetail(
+          last,
+          last?.lead_groups?.[index],
+          stats,
+          now,
+          local,
+          false,
+        ),
+        run: active
+          ? observedRunDetail(
+              active,
+              active.lead_groups?.[index],
+              stats,
+              now,
+              local,
+              true,
+            )
+          : upcomingRunDetail(upcoming, stats, local),
         p50: formatLatency(stats.p50_s),
         p95: formatLatency(stats.p95_s),
         p99: formatLatency(stats.p99_s),
@@ -1081,12 +1123,15 @@ export function facetRows(product) {
 function buildDetails(product, now, local) {
   const details = detailRows(product, now, local);
   const groupHead = element("tr", null, [
-    element("th"),
-    element("th", { colspan: "3" }, details.header),
+    element("th", { rowspan: "2" }, "horizon"),
+    element("th", { colspan: "3" }, details.lastHeader),
+    element("th", { colspan: "3" }, details.runHeader),
     element("th", { colspan: "3" }, details.statsHeader),
   ]);
   const head = element("tr", null, [
-    element("th", null, "horizon"),
+    element("th", null, "status"),
+    element("th", null, "time"),
+    element("th", null, "duration"),
     element("th", null, "status"),
     element("th", null, "time"),
     element("th", null, "duration"),
@@ -1099,9 +1144,12 @@ function buildDetails(product, now, local) {
     body.append(
       element("tr", null, [
         element("td", null, row.label),
-        element("td", null, row.status),
-        element("td", null, row.time),
-        element("td", null, row.duration),
+        element("td", null, row.last.status),
+        element("td", null, row.last.time),
+        element("td", null, row.last.duration),
+        element("td", null, row.run.status),
+        element("td", null, row.run.time),
+        element("td", null, row.run.duration),
         element("td", null, row.p50),
         element("td", null, row.p95),
         element("td", null, row.p99),

--- a/test/e2e/pipeline.spec.mjs
+++ b/test/e2e/pipeline.spec.mjs
@@ -331,6 +331,49 @@ test("expected-but-absent and never-observed do not look the same", async ({ pag
   expect(pending.background).not.toContain("gradient");
 });
 
+test("scan-confirmed late pending work is visibly delayed", async ({ page }) => {
+  const row = await openPipeline(page, (payload) => {
+    const product = payload.groups[0].products[0];
+    const newest = product.recent_inits.at(-1);
+    newest.status = "pending";
+    newest.timing = "delayed";
+    newest.completion_pct = 0;
+    for (const group of newest.lead_groups ?? []) {
+      group.status = "pending";
+      group.timing = "delayed";
+      group.completion_pct = 0;
+      group.leads_available = 0;
+    }
+    return payload;
+  });
+
+  const cell = row.locator('.pipeline-cell.g-pending[data-timing="delayed"]').first();
+  await expect(cell).toBeVisible();
+  await expect(cell).toHaveCSS("border-color", "rgb(244, 185, 66)");
+  await expect(row.locator('[data-slot="eta-state"]')).toHaveText("pending · delayed");
+  await expect(row.locator('[data-slot="eta-state"]')).toHaveCSS(
+    "color",
+    "rgb(244, 185, 66)",
+  );
+});
+
+test("history scrubber stays fixed to the viewport bottom", async ({ page }) => {
+  await openPipeline(page);
+  await page.locator("#pipeline-history-toggle").click();
+  const panel = page.locator("#pipeline-history-panel");
+  await expect(panel).toBeVisible();
+  await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
+
+  const placement = await panel.evaluate((node) => {
+    const rect = node.getBoundingClientRect();
+    return {
+      position: getComputedStyle(node).position,
+      bottomGap: Math.round(window.innerHeight - rect.bottom),
+    };
+  });
+  expect(placement).toEqual({ position: "fixed", bottomGap: 0 });
+});
+
 test("a run that reported nothing does not empty the field", async ({ page }) => {
   // history snapshots declare no lead groups of their own, so a newest run with
   // none used to leave the axis empty — no bands, and a negative --run-width

--- a/test/e2e/pipeline.spec.mjs
+++ b/test/e2e/pipeline.spec.mjs
@@ -357,6 +357,21 @@ test("scan-confirmed late pending work is visibly delayed", async ({ page }) => 
   );
 });
 
+test("details distinguish last, current or upcoming, and historical timings", async ({
+  page,
+}) => {
+  const row = await openPipeline(page);
+  await row.locator('[data-slot="details-button"]').click();
+  const headings = await row
+    .locator(".pipeline-row-details table:first-child thead tr:first-child th")
+    .allTextContents();
+
+  expect(headings[0]).toBe("horizon");
+  expect(headings[1]).toMatch(/^last run(?: · |$)/);
+  expect(headings[2]).toMatch(/^(?:current|upcoming) run(?: · |$)/);
+  expect(headings[3]).toMatch(/^time after init · [\d,]+ samples$/);
+});
+
 test("history scrubber stays fixed to the viewport bottom", async ({ page }) => {
   await openPipeline(page);
   await page.locator("#pipeline-history-toggle").click();

--- a/test/pipeline.test.mjs
+++ b/test/pipeline.test.mjs
@@ -704,6 +704,25 @@ test("measures a lead band by its own share, not the cumulative count", () => {
   assert.equal(cell.completion, 0.25);
 });
 
+test("preserves delayed timing on an empty pending lead band", () => {
+  const product = facetedProduct();
+  const init = product.recent_inits[0];
+  init.status = "pending";
+  init.timing = "delayed";
+  init.completion_pct = 0;
+  for (const group of init.lead_groups) {
+    group.status = "pending";
+    group.timing = "delayed";
+    group.completion_pct = 0;
+    group.leads_available = 0;
+  }
+
+  const cell = cellOf(bandsOf(product)[0], init);
+  assert.equal(cell.state, "pending");
+  assert.equal(cell.timing, "delayed");
+  assert.equal(cell.completion, 0);
+});
+
 test("names what a square measured, facet first, in its hover label", () => {
   const product = facetedProduct();
   const init = product.recent_inits[0];
@@ -814,6 +833,25 @@ test("retains live horizon status, time, and duration in details", () => {
       ],
     },
   );
+});
+
+test("treats a delayed pending init as the current run in details", () => {
+  const product = {
+    recent_inits: [
+      {
+        init_time: "2026-07-26T12:00:00Z",
+        status: "pending",
+        timing: "delayed",
+        lead_groups: [{ status: "pending", timing: "delayed" }],
+      },
+    ],
+    lead_group_stats: [{ label: "1d", p50_s: 1200, p95_s: 1800, p99_s: 2400 }],
+  };
+
+  const details = detailRows(product, Date.parse("2026-07-26T12:45:00Z"), false);
+  assert.equal(details.header, "07-26 12z");
+  assert.equal(details.rows[0].status, "pending");
+  assert.equal(details.rows[0].duration, "45m 0s");
 });
 
 test("names the init sample the percentile columns summarise", () => {
@@ -1165,6 +1203,10 @@ test("pipeline page uses the shared subnav without a separate footer", () => {
   assert.match(
     pipelineCss,
     /\.pipeline-cell\.g-pending\s*{\s*border: 1px solid var\(--pipeline-unobserved\);\s*}/,
+  );
+  assert.match(
+    pipelineCss,
+    /\.pipeline-cell\.g-pending\[data-timing="delayed"\]\s*{\s*border-color: var\(--pipeline-progress\);\s*}/,
   );
   assert.match(
     pipelineCss,

--- a/test/pipeline.test.mjs
+++ b/test/pipeline.test.mjs
@@ -793,6 +793,14 @@ test("retains live horizon status, time, and duration in details", () => {
   const product = {
     recent_inits: [
       {
+        init_time: "2026-07-26T06:00:00Z",
+        status: "complete",
+        lead_groups: [
+          { status: "complete", latency_s: 1200 },
+          { status: "complete", latency_s: 2700 },
+        ],
+      },
+      {
         init_time: "2026-07-26T12:00:00Z",
         status: "in_flight",
         lead_groups: [
@@ -809,23 +817,22 @@ test("retains live horizon status, time, and duration in details", () => {
   assert.deepEqual(
     detailRows(product, Date.parse("2026-07-26T12:30:00Z"), false),
     {
-      header: "07-26 12z",
+      lastHeader: "last run · 07-26 06z",
+      runHeader: "current run · 07-26 12z",
       statsHeader: "time after init",
       rows: [
         {
           label: "1d",
-          status: "complete",
-          time: "12:30",
-          duration: "30m",
+          last: { status: "complete", time: "06:20", duration: "20m" },
+          run: { status: "complete", time: "12:30", duration: "30m" },
           p50: "20m",
           p95: "30m",
           p99: "40m",
         },
         {
           label: "3d",
-          status: "processing",
-          time: "ETA 13:00",
-          duration: "30m 0s",
+          last: { status: "complete", time: "06:45", duration: "45m" },
+          run: { status: "processing", time: "ETA 13:00", duration: "30m 0s" },
           p50: "40m",
           p95: "1h",
           p99: "1h 20m",
@@ -849,9 +856,9 @@ test("treats a delayed pending init as the current run in details", () => {
   };
 
   const details = detailRows(product, Date.parse("2026-07-26T12:45:00Z"), false);
-  assert.equal(details.header, "07-26 12z");
-  assert.equal(details.rows[0].status, "pending");
-  assert.equal(details.rows[0].duration, "45m 0s");
+  assert.equal(details.runHeader, "current run · 07-26 12z");
+  assert.equal(details.rows[0].run.status, "pending");
+  assert.equal(details.rows[0].run.duration, "45m 0s");
 });
 
 test("names the init sample the percentile columns summarise", () => {
@@ -874,14 +881,14 @@ test("names the init sample the percentile columns summarise", () => {
 
   assert.equal(
     detailRows(product, Date.parse("2026-07-26T07:00:00Z"), false).statsHeader,
-    "time after init · 1,394 inits",
+    "time after init · 1,394 samples",
   );
 
   // a product monitored since its first init has a sample of exactly one
   product.latency_stats.sample_init_count = 1;
   assert.equal(
     detailRows(product, Date.parse("2026-07-26T07:00:00Z"), false).statsHeader,
-    "time after init \u00b7 1 init",
+    "time after init \u00b7 1 sample",
   );
 
   product.latency_stats.sample_init_count = 0;
@@ -891,7 +898,7 @@ test("names the init sample the percentile columns summarise", () => {
   );
 });
 
-test("shows the previous init details while waiting for the next init", () => {
+test("shows the last and upcoming runs while waiting for the next init", () => {
   const product = {
     recent_inits: [
       {
@@ -907,6 +914,7 @@ test("shows the previous init details while waiting for the next init", () => {
       { label: "1d", p50_s: 1200, p95_s: 1800, p99_s: 2400 },
       { label: "3d", p50_s: 2400, p95_s: 3600, p99_s: 4800 },
     ],
+    next_expected_init: "2026-07-26T12:00:00Z",
   };
 
   const details = detailRows(
@@ -915,16 +923,19 @@ test("shows the previous init details while waiting for the next init", () => {
     false,
   );
 
-  assert.equal(details.header, "07-26 06z · previous init");
+  assert.equal(details.lastHeader, "last run · 07-26 06z");
+  assert.equal(details.runHeader, "upcoming run · 07-26 12z");
   assert.deepEqual(
-    details.rows.map(({ status, time, duration }) => ({
-      status,
-      time,
-      duration,
-    })),
+    details.rows.map(({ last, run }) => ({ last, run })),
     [
-      { status: "complete", time: "06:20", duration: "20m" },
-      { status: "complete", time: "06:45", duration: "45m" },
+      {
+        last: { status: "complete", time: "06:20", duration: "20m" },
+        run: { status: "upcoming", time: "ETA 12:30", duration: "—" },
+      },
+      {
+        last: { status: "complete", time: "06:45", duration: "45m" },
+        run: { status: "upcoming", time: "ETA 13:00", duration: "—" },
+      },
     ],
   );
 });
@@ -1012,7 +1023,7 @@ test("local preview fixture carries a source-only group", () => {
   );
   assert.equal(
     detailRows(product, Date.parse("2026-07-25T18:00:00Z"), false).statsHeader,
-    "time after init \u00b7 1 init",
+    "time after init \u00b7 1 sample",
   );
 });
 


### PR DESCRIPTION
## Outcome

The pipeline page gives scan-confirmed late pending work a yellow outline and yellow pending · delayed status, treats that pending init as the current run in details, and fixes the History scrubber to the viewport bottom.

The details table separately presents the last run, the current or upcoming run, and the historical time-after-init sample, retaining each run timestamp and per-horizon status, time, and duration.

Depends on dynamical-org/wxopticon#207 for the new pending + delayed payload state.

## Plan

- [x] Trace timing from the dashboard payload through cell state and DOM attributes.
- [x] Give delayed pending cells and status text an explicit yellow treatment.
- [x] Keep pending current-run details attached to the active init.
- [x] Fix the History scrubber to the viewport bottom without covering final content.
- [x] Add browser regressions for color and viewport placement.
- [x] Separate last-run, current/upcoming-run, and historical timing columns.
- [x] Run unit and pipeline browser suites.

## Verification

- npm test — 10 suites passed
- npx playwright test test/e2e/pipeline.spec.mjs — 11 passed

### 2026-08-26 — Details table feedback

Expanded the timing table into three explicit groups: last run, current or upcoming run, and time after init · n samples. The first two retain their init timestamps and independent status/time/duration columns.

### 2026-08-26 — Retro

The missing warning was not a dropped field: timing already reached the DOM. The gap was the pending-specific CSS treatment plus the display selectors that only considered in-flight runs active. Separating observed run values from the historical baseline also removed the prior ambiguity between a previous run and an upcoming one.