### PR TITLE
Keep corrected observation gaps visible

### DIFF
--- a/public/status.mjs
+++ b/public/status.mjs
@@ -243,6 +243,15 @@ export function applyIncidentGroups(history, incidentGroups = []) {
   const grouped = [];
   const aliases = new Map();
   const dayStates = new Map();
+  const observationWindows = [];
+  const dayOverlaps = (cell, start, end) => {
+    const dayStart = Date.parse(`${cell.date}T00:00:00Z`);
+    return (
+      Number.isFinite(dayStart) &&
+      dayStart < end &&
+      start < dayStart + 86_400_000
+    );
+  };
 
   for (const configured of incidentGroups) {
     const windowStart = Date.parse(configured.started_at);
@@ -254,7 +263,38 @@ export function applyIncidentGroups(history, incidentGroups = []) {
         windowStart <= incident.start &&
         incident.start < windowEnd,
     );
-    if (matches.length === 0) continue;
+    if (matches.length === 0) {
+      if (configured.kind !== "observation") continue;
+      const id = `incident-group-${configured.id}`;
+      const componentsWithGaps = configured.components.filter((component) =>
+        (history.cells?.get(component) ?? []).some(
+          (cell) =>
+            cell.state === "nodata" &&
+            dayOverlaps(cell, windowStart, windowEnd),
+        ),
+      );
+      if (componentsWithGaps.length === 0) continue;
+      observationWindows.push({
+        id,
+        start: windowStart,
+        end: windowEnd,
+        components: new Set(componentsWithGaps),
+      });
+      grouped.push({
+        id,
+        kind: configured.kind,
+        summary: configured.summary,
+        ...(configured.description
+          ? { description: configured.description }
+          : {}),
+        components: componentsWithGaps,
+        memberIds: [],
+        start: windowStart,
+        end: windowEnd,
+        ending: "resolved",
+      });
+      continue;
+    }
 
     const matched = new Set(matches);
     ungrouped = ungrouped.filter((incident) => !matched.has(incident));
@@ -292,6 +332,24 @@ export function applyIncidentGroups(history, incidentGroups = []) {
     [...history.cells.entries()].map(([component, componentCells]) => [
       component,
       componentCells.map((cell) => {
+        const standalone = observationWindows.filter(
+          (window) =>
+            cell.state === "nodata" &&
+            window.components.has(component) &&
+            dayOverlaps(cell, window.start, window.end),
+        );
+        if (standalone.length > 0) {
+          return {
+            ...cell,
+            displayState: "observation",
+            incidentIds: [
+              ...new Set([
+                ...(cell.incidentIds ?? []),
+                ...standalone.map((window) => window.id),
+              ]),
+            ],
+          };
+        }
         if (!cell.incidentIds?.length) return { ...cell };
         const incidentIds = [
           ...new Set(cell.incidentIds.map((id) => aliases.get(id) ?? id)),

--- a/public/status.mjs
+++ b/public/status.mjs
@@ -28,7 +28,12 @@ export const STALE_MESSAGE = "Stale: status page experiencing delayed updates";
 
 function isStatusEntry(entry) {
   return (
-    entry && typeof entry.id === "string" && typeof entry.name === "string"
+    entry &&
+    typeof entry.id === "string" &&
+    typeof entry.name === "string" &&
+    (entry.observation == null ||
+      (entry.observation.kind === "observation" &&
+        typeof entry.observation.summary === "string"))
   );
 }
 
@@ -148,6 +153,9 @@ export function summarizeOverallStatus(data) {
 }
 
 export function statusLabel(entry) {
+  if (entry.status === "degraded" && entry.observation?.kind === "observation") {
+    return "Monitoring gap";
+  }
   if (
     entry.status === "down" &&
     entry.maintenance?.kind === "planned"
@@ -415,6 +423,7 @@ function renderGroup(list, entries, bars, uptime, emptyCells) {
 
     item.dataset.status = entry.status;
     if (entry.maintenance?.kind) item.dataset.kind = entry.maintenance.kind;
+    if (entry.observation?.kind) item.dataset.kind = entry.observation.kind;
     name.textContent = entry.name;
     state.className = "status-label";
     mark.setAttribute("aria-hidden", "true");

--- a/test/status.test.mjs
+++ b/test/status.test.mjs
@@ -696,6 +696,51 @@ test("observation groups render their days as a gap, not an outage", () => {
   });
 });
 
+test("corrected coverage gaps retain their explicit observation incident", () => {
+  const history = {
+    incidents: [],
+    cells: new Map([
+      [
+        "data-product-reads",
+        [{ date: "2026-08-27", state: "nodata" }],
+      ],
+    ]),
+  };
+  const configured = {
+    id: "sentry-cron-gap-20260827-0955",
+    kind: "observation",
+    summary: "Data product read monitoring telemetry",
+    description:
+      "Sentry's US Cron Monitoring outage interrupted read-canary telemetry; " +
+      "data product reads were not confirmed down.",
+    started_at: "2026-08-27T09:55:11Z",
+    ended_at: "2026-08-27T10:10:12Z",
+    components: ["data-product-reads"],
+  };
+
+  const grouped = applyIncidentGroups(history, [configured]);
+
+  assert.deepEqual(grouped.incidents, [
+    {
+      id: `incident-group-${configured.id}`,
+      kind: "observation",
+      summary: configured.summary,
+      description: configured.description,
+      components: configured.components,
+      memberIds: [],
+      start: Date.parse(configured.started_at),
+      end: Date.parse(configured.ended_at),
+      ending: "resolved",
+    },
+  ]);
+  assert.deepEqual(grouped.cells.get("data-product-reads")[0], {
+    date: "2026-08-27",
+    state: "nodata",
+    displayState: "observation",
+    incidentIds: [`incident-group-${configured.id}`],
+  });
+});
+
 test("bar descriptions separate monitoring gaps from outages", () => {
   const description = barDescription([
     { state: "down", displayState: "observation" },

--- a/test/status.test.mjs
+++ b/test/status.test.mjs
@@ -219,6 +219,46 @@ test("labels a planned down component without changing its health state", () => 
   );
 });
 
+test("labels a degraded component as a live monitoring gap", () => {
+  const entry = {
+    id: "data-product-reads",
+    name: "Data product reads",
+    group: "endpoint",
+    status: "degraded",
+    observation: {
+      kind: "observation",
+      summary: "Sentry Cron Monitoring unavailable",
+    },
+  };
+
+  assert.doesNotThrow(() =>
+    validateStatusData({ ...operationalData, endpoints: [entry] }),
+  );
+  assert.equal(statusLabel(entry), "Monitoring gap");
+  assert.deepEqual(
+    summarizeOverallStatus({ ...operationalData, endpoints: [entry] }),
+    {
+      status: "degraded",
+      incidents: [{ name: "Data product reads", status: "degraded" }],
+    },
+  );
+});
+
+test("rejects malformed live observation metadata", () => {
+  const entry = {
+    id: "data-product-reads",
+    name: "Data product reads",
+    group: "endpoint",
+    status: "degraded",
+    observation: { kind: "observation" },
+  };
+
+  assert.throws(
+    () => validateStatusData({ ...operationalData, endpoints: [entry] }),
+    /invalid status entry/i,
+  );
+});
+
 test("groups explicitly related outages and remaps day links", () => {
   const detection = {
     id: "incident-wxopticon-pipeline-1785960026",


### PR DESCRIPTION
# Corrected observation-gap rendering

## Goal

Keep explicit monitoring-gap incident copy and dithered day styling after the
publisher retroactively replaces false downtime with missing coverage.

## Success criteria

- [x] Reproduce the corrected-history shape with a failing test.
- [x] Match explicit observation windows against `nodata` cells when no outage
      incident remains.
- [x] Retain the configured incident explanation and day anchor.
- [x] Label live channel-qualified degradation as a monitoring gap.
- [x] Run the full Node test suite.

## Relationship

Companion to dynamical-org/dynamical.org-data#32. The publisher owns the uptime
correction; this repo only preserves the existing presentation of an explicitly
classified monitoring gap.

### 2026-08-27 — Implementation

Corrected coverage gaps no longer contain an outage incident for the existing
grouping path to match. Explicit observation windows now match overlapping
`nodata` cells, retain their configured incident entry and explanation, and mark
the affected day with the existing observation-gap style.

- Deploy this renderer before the publisher correction. It accepts both the
  existing outage-shaped history and the corrected coverage-gap history, so the
  status page keeps its explanation throughout rollout.

### 2026-08-27 — Publisher review follow-up

The publisher now emits explicit live observation metadata when Sentry channel
health makes a strict component ambiguous. The renderer validates that metadata
and labels the row “Monitoring gap” while retaining degraded overall health.

### 2026-08-27 — Retro

The renderer now supports all three rollout shapes: the original outage history,
the corrected coverage-gap history, and a live channel-qualified gap. All ten
Node test files pass. Deploy this PR before the publisher correction.
