### PR TITLE
Render partial-day monitoring gaps

### DIFF
--- a/public/status.mjs
+++ b/public/status.mjs
@@ -260,6 +260,20 @@ export function applyIncidentGroups(history, incidentGroups = []) {
       start < dayStart + 86_400_000
     );
   };
+  const hasCoverageGap = (component, start, end) => {
+    const spans = history.spans?.get(component);
+    if (!spans) {
+      return (history.cells?.get(component) ?? []).some(
+        (cell) => cell.state === "nodata" && dayOverlaps(cell, start, end),
+      );
+    }
+    const observed = spans.reduce(
+      (total, span) =>
+        total + Math.max(0, Math.min(span.end, end) - Math.max(span.start, start)),
+      0,
+    );
+    return observed < end - start;
+  };
 
   for (const configured of incidentGroups) {
     const windowStart = Date.parse(configured.started_at);
@@ -275,11 +289,7 @@ export function applyIncidentGroups(history, incidentGroups = []) {
       if (configured.kind !== "observation") continue;
       const id = `incident-group-${configured.id}`;
       const componentsWithGaps = configured.components.filter((component) =>
-        (history.cells?.get(component) ?? []).some(
-          (cell) =>
-            cell.state === "nodata" &&
-            dayOverlaps(cell, windowStart, windowEnd),
-        ),
+        hasCoverageGap(component, windowStart, windowEnd),
       );
       if (componentsWithGaps.length === 0) continue;
       observationWindows.push({
@@ -342,7 +352,7 @@ export function applyIncidentGroups(history, incidentGroups = []) {
       componentCells.map((cell) => {
         const standalone = observationWindows.filter(
           (window) =>
-            cell.state === "nodata" &&
+            ["operational", "nodata"].includes(cell.state) &&
             window.components.has(component) &&
             dayOverlaps(cell, window.start, window.end),
         );
@@ -522,6 +532,7 @@ export function buildHistory(eventsText, metaText) {
   const spans = componentSpans(events, { asOf });
   return {
     asOf,
+    spans,
     cells: dailyBars(spans, { asOf, days: BAR_DAYS }),
     incidents: incidentLog(events),
     uptime: uptimeSummary(spans, { asOf, days: BAR_DAYS }),

--- a/test/status.test.mjs
+++ b/test/status.test.mjs
@@ -838,6 +838,73 @@ test("partial-day corrected gaps override an otherwise operational day", () => {
   assert.equal(grouped.incidents[0].id, `incident-group-${configured.id}`);
 });
 
+test("partial-day gaps do not soften known trouble elsewhere that day", () => {
+  const component = "data-product-reads";
+  const configured = {
+    id: "sentry-cron-gap-20260827-0955",
+    kind: "observation",
+    summary: "Data product read monitoring telemetry",
+    description: "Telemetry was unavailable; reads were not confirmed down.",
+    started_at: "2026-08-27T09:55:11Z",
+    ended_at: "2026-08-27T10:10:12Z",
+    components: [component],
+  };
+
+  for (const state of ["degraded", "down"]) {
+    const events = [
+      {
+        ts: "2026-08-27T00:00:00Z",
+        kind: "coverage",
+        component,
+        monitored: true,
+        state: "operational",
+      },
+      {
+        ts: configured.started_at,
+        kind: "coverage",
+        component,
+        monitored: false,
+      },
+      {
+        ts: configured.ended_at,
+        kind: "coverage",
+        component,
+        monitored: true,
+        state: "operational",
+      },
+      {
+        ts: "2026-08-27T11:00:00Z",
+        kind: "transition",
+        component,
+        to: state,
+      },
+    ]
+      .map(JSON.stringify)
+      .join("\n");
+    const history = buildHistory(
+      events,
+      JSON.stringify({
+        v: 2,
+        reconciled_at: "2026-08-27T12:00:00Z",
+        events_count: 4,
+      }),
+    );
+
+    const grouped = applyIncidentGroups(history, [configured]);
+    const cell = grouped.cells
+      .get(component)
+      .find(({ date }) => date === "2026-08-27");
+
+    assert.equal(cell.state, state);
+    assert.equal(cell.displayState, undefined);
+    assert.ok(
+      grouped.incidents.some(
+        ({ id }) => id === `incident-group-${configured.id}`,
+      ),
+    );
+  }
+});
+
 test("bar descriptions separate monitoring gaps from outages", () => {
   const description = barDescription([
     { state: "down", displayState: "observation" },

--- a/test/status.test.mjs
+++ b/test/status.test.mjs
@@ -781,6 +781,63 @@ test("corrected coverage gaps retain their explicit observation incident", () =>
   });
 });
 
+test("partial-day corrected gaps override an otherwise operational day", () => {
+  const component = "data-product-reads";
+  const events = [
+    {
+      ts: "2026-08-27T00:00:00Z",
+      kind: "coverage",
+      component,
+      monitored: true,
+      state: "operational",
+    },
+    {
+      ts: "2026-08-27T09:55:11Z",
+      kind: "coverage",
+      component,
+      monitored: false,
+    },
+    {
+      ts: "2026-08-27T10:10:12Z",
+      kind: "coverage",
+      component,
+      monitored: true,
+      state: "operational",
+    },
+  ]
+    .map(JSON.stringify)
+    .join("\n");
+  const history = buildHistory(
+    events,
+    JSON.stringify({
+      v: 2,
+      reconciled_at: "2026-08-27T12:00:00Z",
+      events_count: 3,
+    }),
+  );
+  const configured = {
+    id: "sentry-cron-gap-20260827-0955",
+    kind: "observation",
+    summary: "Data product read monitoring telemetry",
+    description:
+      "Sentry's US Cron Monitoring outage interrupted read-canary telemetry; " +
+      "data product reads were not confirmed down.",
+    started_at: "2026-08-27T09:55:11Z",
+    ended_at: "2026-08-27T10:10:12Z",
+    components: [component],
+  };
+
+  const grouped = applyIncidentGroups(history, [configured]);
+  const cell = grouped.cells
+    .get(component)
+    .find(({ date }) => date === "2026-08-27");
+
+  assert.equal(cell.state, "operational");
+  assert.equal(cell.displayState, "observation");
+  assert.deepEqual(cell.incidentIds, [`incident-group-${configured.id}`]);
+  assert.equal(grouped.incidents[0].id, `incident-group-${configured.id}`);
+});
+
 test("bar descriptions separate monitoring gaps from outages", () => {
   const description = barDescription([
     { state: "down", displayState: "observation" },


### PR DESCRIPTION
# Partial-day observation gaps

## Goal

Render explicitly classified partial-day monitoring gaps in status history even
when the rest of the UTC day was operational.

## Assumptions

- Explicit publisher observation metadata remains the authority for reframing a
  coverage gap; an arbitrary hole in coverage should not create an incident.
- A confirmed outage or degradation elsewhere on the same day is stronger than
  gap styling and must remain visible.

## Success criteria

- [x] Reproduce the live partial-day event shape with a failing test.
- [x] Preserve component spans so observation metadata can verify the exact gap.
- [x] Render an operational day with a matching partial gap as an observation.
- [x] Do not soften a separate down or degraded interval on the same day.
- [x] Run the full Node test suite.

### 2026-08-27 — Diagnosis

Daily bars intentionally collapse any partially observed operational day to
`operational`. The standalone observation-group path looked only for a `nodata`
daily cell, so it could recognize full-day gaps but not the live 15-minute and
25-minute gaps.

### 2026-08-27 — Implementation

- `buildHistory` now retains the already-derived component spans for downstream
  observation matching.
- An explicit observation group is accepted only when those spans prove some of
  its exact window was uncovered.
- Matching gaps reframe operational or no-data daily cells; degraded and down
  cells remain unchanged.
- Replayed the downloaded production artifacts: August 19, August 20, and August
  27 now carry observation styling, and all four explanatory incidents appear.

### 2026-08-27 — Retro

The first renderer test modeled a full-day `nodata` cell rather than the actual
partial-day event stream. Exercising `buildHistory` end-to-end exposed the lossy
daily aggregation boundary and keeps the regression aligned with production.
All ten Node test files pass.
