### PR TITLE
Coalesce nearby identical incident groups

### DIFF
--- a/public/status.mjs
+++ b/public/status.mjs
@@ -242,6 +242,58 @@ const IMPACT = {
   },
 };
 
+// A publisher emits one group per window it detects, so a single upstream
+// episode — a cron-monitoring outage flickering for an hour — reaches the page
+// as a run of identical groups minutes apart.
+const NEARBY_GROUP_GAP_MS = 2 * 60 * 60 * 1000;
+
+function sameEpisode(a, b) {
+  return (
+    a.kind === b.kind &&
+    a.summary === b.summary &&
+    a.description === b.description &&
+    a.components.length === b.components.length &&
+    a.components.every((component) => b.components.includes(component))
+  );
+}
+
+// Fold such a run into one entry that keeps every window, so the log reads as
+// one episode while its duration still counts only the windows themselves.
+export function coalesceIncidentGroups(incidentGroups) {
+  const coalesced = [];
+  const sorted = [...incidentGroups].sort(
+    (a, b) => Date.parse(a.started_at) - Date.parse(b.started_at),
+  );
+  for (const group of sorted) {
+    const window = {
+      start: Date.parse(group.started_at),
+      end: Date.parse(group.ended_at),
+    };
+    const previous = coalesced.at(-1);
+    if (
+      previous &&
+      sameEpisode(previous, group) &&
+      window.start - previous.windows.at(-1).end <= NEARBY_GROUP_GAP_MS
+    ) {
+      previous.windows.push(window);
+    } else {
+      coalesced.push({ ...group, windows: [window] });
+    }
+  }
+  return coalesced;
+}
+
+// A coalesced entry spans more than it lost: the minutes between its windows
+// were observed. Duration claims count the windows, never the span.
+function measuredDuration(entry, end) {
+  return entry.windows
+    ? entry.windows.reduce(
+        (total, window) => total + window.end - window.start,
+        0,
+      )
+    : (entry.end ?? end) - entry.start;
+}
+
 // Explicit publisher metadata, not time overlap alone, determines which events
 // share an incident.
 export function applyIncidentGroups(history, incidentGroups = []) {
@@ -275,27 +327,31 @@ export function applyIncidentGroups(history, incidentGroups = []) {
     return observed < end - start;
   };
 
-  for (const configured of incidentGroups) {
-    const windowStart = Date.parse(configured.started_at);
-    const windowEnd = Date.parse(configured.ended_at);
+  for (const configured of coalesceIncidentGroups(incidentGroups)) {
+    const windows = configured.windows;
+    const windowStart = windows[0].start;
+    const windowEnd = windows.at(-1).end;
+    const spread = windows.length > 1 ? { windows } : {};
     const components = new Set(configured.components);
+    // Each window matches on its own: an outage in the observed minutes
+    // between two windows is not part of the episode.
     const matches = ungrouped.filter(
       (incident) =>
         components.has(incident.component) &&
-        windowStart <= incident.start &&
-        incident.start < windowEnd,
+        windows.some(
+          ({ start, end }) => start <= incident.start && incident.start < end,
+        ),
     );
     if (matches.length === 0) {
       if (configured.kind !== "observation") continue;
       const id = `incident-group-${configured.id}`;
       const componentsWithGaps = configured.components.filter((component) =>
-        hasCoverageGap(component, windowStart, windowEnd),
+        windows.some(({ start, end }) => hasCoverageGap(component, start, end)),
       );
       if (componentsWithGaps.length === 0) continue;
       observationWindows.push({
         id,
-        start: windowStart,
-        end: windowEnd,
+        windows,
         components: new Set(componentsWithGaps),
       });
       grouped.push({
@@ -309,6 +365,7 @@ export function applyIncidentGroups(history, incidentGroups = []) {
         memberIds: [],
         start: windowStart,
         end: windowEnd,
+        ...spread,
         ending: "resolved",
       });
       continue;
@@ -337,6 +394,7 @@ export function applyIncidentGroups(history, incidentGroups = []) {
       end: allEnded
         ? Math.max(...matches.map((incident) => incident.end))
         : null,
+      ...spread,
       ending:
         allEnded && matches.every((incident) => incident.ending === "resolved")
           ? "resolved"
@@ -351,10 +409,10 @@ export function applyIncidentGroups(history, incidentGroups = []) {
       component,
       componentCells.map((cell) => {
         const standalone = observationWindows.filter(
-          (window) =>
+          (gap) =>
             ["operational", "nodata"].includes(cell.state) &&
-            window.components.has(component) &&
-            dayOverlaps(cell, window.start, window.end),
+            gap.components.has(component) &&
+            gap.windows.some(({ start, end }) => dayOverlaps(cell, start, end)),
         );
         if (standalone.length > 0) {
           return {
@@ -363,7 +421,7 @@ export function applyIncidentGroups(history, incidentGroups = []) {
             incidentIds: [
               ...new Set([
                 ...(cell.incidentIds ?? []),
-                ...standalone.map((window) => window.id),
+                ...standalone.map((gap) => gap.id),
               ]),
             ],
           };
@@ -671,9 +729,10 @@ export function groupedIncidentDescription(incident, names, end) {
     incident.kind === "planned"
       ? `Planned work affected ${affected}`
       : `Related outages affected ${affected}`;
+  const measured = formatDuration(0, measuredDuration(incident, end));
   return incident.end
-    ? `${impact} for ${formatDuration(incident.start, incident.end)}.`
-    : `${impact} — ongoing for ${formatDuration(incident.start, end)}.`;
+    ? `${impact} for ${measured}.`
+    : `${impact} — ongoing for ${measured}.`;
 }
 
 function renderIncidentLog(root, history, data, local) {
@@ -708,13 +767,17 @@ function renderIncidentLog(root, history, data, local) {
     const summary = document.createElement("p");
     const timing = document.createElement("p");
     const kind = incident.kind ?? "outage";
-    const label =
+    const kindLabel =
       kind === "planned"
         ? "planned outage"
         : kind === "observation"
           ? "observation gap"
           : kind;
+    // A coalesced entry stands for several windows, so it says so twice over:
+    // a plural state line, and a timing line that counts them.
+    const label = incident.windows ? `${kindLabel}s` : kindLabel;
     const end = incident.end ?? history.asOf.getTime();
+    const measured = formatDuration(0, measuredDuration(incident, end));
 
     item.id = incident.id;
     item.className = "status-incident";
@@ -753,12 +816,15 @@ function renderIncidentLog(root, history, data, local) {
       });
       summary.append(".");
     }
+    const spent = incident.windows
+      ? `${incident.windows.length} ${label} totaling ${measured}`
+      : measured;
     timing.textContent =
       incident.ending === "observation-ended"
-        ? `${formatTimestamp(incident.start, local)} – ${formatTimestamp(incident.end, local)} · ${formatDuration(incident.start, end)}. Recovery was not witnessed.`
+        ? `${formatTimestamp(incident.start, local)} – ${formatTimestamp(incident.end, local)} · ${spent}. Recovery was not witnessed.`
         : `${formatTimestamp(incident.start, local)} – ${
             incident.end ? formatTimestamp(incident.end, local) : "ongoing"
-          } · ${formatDuration(incident.start, end)}.`;
+          } · ${spent}.`;
     header.append(name, state);
     item.append(header, summary, timing);
     list.append(item);

--- a/test/status.test.mjs
+++ b/test/status.test.mjs
@@ -947,3 +947,226 @@ test("the hatch tile the status bars mark gaps with is a shared token", () => {
   assert.match(declaration(light), /fill='white'/);
   assert.match(declaration(dark), /fill='black'/);
 });
+
+test("a run of identical nearby gaps coalesces into one entry", () => {
+  const component = "data-product-reads";
+  const windows = [
+    ["2026-08-27T09:55:11Z", "2026-08-27T10:10:12Z"],
+    ["2026-08-27T10:35:10Z", "2026-08-27T10:40:12Z"],
+    ["2026-08-27T10:55:11Z", "2026-08-27T11:20:12Z"],
+  ];
+  const groups = windows.map(([started_at, ended_at]) => ({
+    id: `sentry-cron-gap-${started_at}`,
+    kind: "observation",
+    summary: "Data product read monitoring telemetry",
+    description:
+      "Sentry's US Cron Monitoring outage interrupted read-canary telemetry; " +
+      "data product reads were not confirmed down.",
+    started_at,
+    ended_at,
+    components: [component],
+  }));
+  const history = {
+    incidents: [],
+    cells: new Map([[component, [{ date: "2026-08-27", state: "nodata" }]]]),
+  };
+
+  const grouped = applyIncidentGroups(history, groups);
+
+  assert.deepEqual(grouped.incidents, [
+    {
+      id: `incident-group-${groups[0].id}`,
+      kind: "observation",
+      summary: groups[0].summary,
+      description: groups[0].description,
+      components: [component],
+      memberIds: [],
+      start: Date.parse(windows[0][0]),
+      end: Date.parse(windows.at(-1)[1]),
+      windows: windows.map(([start, end]) => ({
+        start: Date.parse(start),
+        end: Date.parse(end),
+      })),
+      ending: "resolved",
+    },
+  ]);
+  assert.deepEqual(grouped.cells.get(component)[0].incidentIds, [
+    `incident-group-${groups[0].id}`,
+  ]);
+});
+
+test("gaps further apart than the coalescing window stay separate", () => {
+  const component = "data-product-reads";
+  const group = (started_at, ended_at) => ({
+    id: `sentry-cron-gap-${started_at}`,
+    kind: "observation",
+    summary: "Data product read monitoring telemetry",
+    description: "Telemetry was unavailable; reads were not confirmed down.",
+    started_at,
+    ended_at,
+    components: [component],
+  });
+  const history = {
+    incidents: [],
+    cells: new Map([
+      [
+        component,
+        [
+          { date: "2026-08-26", state: "nodata" },
+          { date: "2026-08-27", state: "nodata" },
+        ],
+      ],
+    ]),
+  };
+
+  const sameDay = applyIncidentGroups(history, [
+    group("2026-08-27T04:00:00Z", "2026-08-27T04:10:00Z"),
+    group("2026-08-27T09:00:00Z", "2026-08-27T09:10:00Z"),
+  ]);
+  assert.equal(sameDay.incidents.length, 2);
+
+  // A different explanation is a different episode however close it lands.
+  const unlike = applyIncidentGroups(history, [
+    group("2026-08-27T09:55:11Z", "2026-08-27T10:10:12Z"),
+    {
+      ...group("2026-08-27T10:35:10Z", "2026-08-27T10:40:12Z"),
+      description: "A separate publisher outage interrupted telemetry.",
+    },
+  ]);
+  assert.equal(unlike.incidents.length, 2);
+});
+
+test("an outage between coalesced windows stays its own incident", () => {
+  const component = "data-product-reads";
+  const events = [
+    {
+      ts: "2026-08-27T00:00:00Z",
+      kind: "coverage",
+      component,
+      monitored: true,
+      state: "operational",
+    },
+    {
+      ts: "2026-08-27T09:55:11Z",
+      kind: "coverage",
+      component,
+      monitored: false,
+    },
+    {
+      ts: "2026-08-27T10:10:12Z",
+      kind: "coverage",
+      component,
+      monitored: true,
+      state: "operational",
+    },
+    { ts: "2026-08-27T10:30:00Z", kind: "transition", component, to: "down" },
+    {
+      ts: "2026-08-27T10:40:00Z",
+      kind: "transition",
+      component,
+      to: "operational",
+    },
+    {
+      ts: "2026-08-27T10:55:11Z",
+      kind: "coverage",
+      component,
+      monitored: false,
+    },
+    {
+      ts: "2026-08-27T11:20:12Z",
+      kind: "coverage",
+      component,
+      monitored: true,
+      state: "operational",
+    },
+  ]
+    .map(JSON.stringify)
+    .join("\n");
+  const history = buildHistory(
+    events,
+    JSON.stringify({
+      v: 2,
+      reconciled_at: "2026-08-27T12:00:00Z",
+      events_count: 7,
+    }),
+  );
+  const group = (started_at, ended_at) => ({
+    id: `sentry-cron-gap-${started_at}`,
+    kind: "observation",
+    summary: "Data product read monitoring telemetry",
+    description: "Telemetry was unavailable; reads were not confirmed down.",
+    started_at,
+    ended_at,
+    components: [component],
+  });
+
+  const grouped = applyIncidentGroups(history, [
+    group("2026-08-27T09:55:11Z", "2026-08-27T10:10:12Z"),
+    group("2026-08-27T10:55:11Z", "2026-08-27T11:20:12Z"),
+  ]);
+
+  const gap = grouped.incidents.find(({ kind }) => kind === "observation");
+  const outage = grouped.incidents.find(({ kind }) => kind === "outage");
+  assert.equal(grouped.incidents.length, 2);
+  assert.equal(gap.windows.length, 2);
+  assert.equal(outage.component, component);
+  assert.equal(outage.start, Date.parse("2026-08-27T10:30:00Z"));
+});
+
+test("a coalesced entry counts its windows, not the span between them", () => {
+  const component = "wxopticon-pipeline";
+  const incident = (start, end) => ({
+    id: `incident-${component}-${start}`,
+    component,
+    kind: "outage",
+    start: Date.parse(start),
+    end: Date.parse(end),
+    ending: "resolved",
+  });
+  const group = (started_at, ended_at) => ({
+    id: `hrrr-backfill-${started_at}`,
+    kind: "planned",
+    summary: "HRRR history migration",
+    started_at,
+    ended_at,
+    components: [component],
+  });
+  const incidents = [
+    incident("2026-08-05T20:00:00Z", "2026-08-05T20:10:00Z"),
+    incident("2026-08-05T20:40:00Z", "2026-08-05T20:50:00Z"),
+  ];
+
+  const grouped = applyIncidentGroups(
+    {
+      incidents,
+      cells: new Map([
+        [
+          component,
+          [
+            {
+              date: "2026-08-05",
+              state: "down",
+              incidentIds: incidents.map(({ id }) => id),
+            },
+          ],
+        ],
+      ]),
+    },
+    [
+      group("2026-08-05T19:59:00Z", "2026-08-05T20:10:00Z"),
+      group("2026-08-05T20:39:00Z", "2026-08-05T20:50:00Z"),
+    ],
+  );
+
+  const [entry] = grouped.incidents;
+  assert.deepEqual(
+    entry.memberIds,
+    incidents.map(({ id }) => id),
+  );
+  // 11 minutes per window — the 29 observed minutes between them are not
+  // planned downtime.
+  assert.equal(
+    groupedIncidentDescription(entry, new Map([[component, "Pipeline"]]), null),
+    "Planned work affected Pipeline for 22 minutes.",
+  );
+});


### PR DESCRIPTION
## Problem

The publisher emits one `incident_group` per window it detects, so the Aug 27
Sentry US Cron Monitoring outage reached `/status/` as three identical
observation-gap cards — same summary, same description, same component —
spread across Aug 27, 2026, 4:55 AM – 6:20 AM CDT.

## Approach

`coalesceIncidentGroups` folds a run of groups that agree on kind, summary,
description and components and land within two hours of each other into one
entry that keeps every window (`entry.windows`). The log now reads:

> **Data product read monitoring telemetry** — observation gaps · resolved
> Aug 27, 2026, 4:55 AM CDT – Aug 27, 2026, 6:20 AM CDT · 3 observation gaps totaling 45 minutes.

Two claims stay honest under merging:

- **Duration counts the windows, not the span.** The 40 observed minutes
  between the gaps were not lost, so the timing line (and the generated
  description for groups without one) sums the windows.
- **Matching stays per-window.** A real outage in the covered minutes between
  two windows is not part of the episode: it keeps its own entry and its red
  day on the strip.

The entry carries `windows` only when it actually spans more than one, so
single-window groups render exactly as before.

## Verification

- `npm test` — 167 pass, including four new cases: a run coalesces; groups too
  far apart or with a different explanation stay separate; an outage between
  windows stays its own incident; a coalesced entry's duration counts windows.
- Replayed the real published `status.json` / `events.jsonl` through
  `page.route` against a local build: three entries became one, the 90-day
  strip still hatches both Aug 19 and Aug 27.

### 2026-08-27 — Codex review

Six findings; five fixed in 392200459, one declined (replies in the threads):

- Overlapping published windows now merge instead of double-counting the overlap.
- A coalesced duration comes from the incidents recorded inside each window, not
  from the publisher's window bounds — the planned-group test now reads 20
  minutes, its two recorded ten-minute outages, rather than 22.
- A window still open advances with `asOf` instead of freezing.
- A window that matched no incident of its own still reframes its days: missing
  coverage is a gap's own evidence, so a sibling window matching an incident no
  longer costs it its hatch and its anchor.
- Coincidence is judged window by window, so an outage in the observed minutes
  between two windows no longer reads as coinciding with the gap.
- **Declined:** rewriting or refusing to coalesce publisher descriptions that
  carry their own duration. It needs a publisher that emitted the same duration
  sentence for two different windows, and both remedies (regex-sniffing prose,
  or generating an aggregate summary over the publisher's explanation) are worse
  than the disease.

## Out of scope

- The RSS feed (`assets.dynamical.org/status/incidents.xml`) is published
  separately and still carries one item per window.
- The publisher keeps emitting per-window groups; this is a page-side read of
  what it publishes.