### PR TITLE
Give facet statuses the timing their squares use

### DIFF
--- a/public/pipeline.mjs
+++ b/public/pipeline.mjs
@@ -1093,6 +1093,9 @@ export function facetRows(product) {
     label: facet.label,
     status: statusLabel(facet.status),
     state: facet.status,
+    // a facet reports no timing of its own; its square takes the run's, so the
+    // row must too, or one word reads in two colors across the two tables
+    timing: displayed.timing ?? null,
     completion: facet.completion_pct,
     count: `${facet.dependencies_available.toLocaleString("en-US")} / ${facet.dependencies_expected.toLocaleString("en-US")} observed`,
   }));

--- a/test/e2e/pipeline.spec.mjs
+++ b/test/e2e/pipeline.spec.mjs
@@ -432,6 +432,35 @@ test("each details table scrolls itself, under a header that names its column", 
   expect(measured.failed).toBe("rgb(197, 34, 31)");
 });
 
+// The fixture's running init is delayed, which colors both tables amber and so
+// hides a disagreement. On an on-time run the lead table read green while the
+// facet table stayed amber, because a facet reports no timing of its own.
+test("the same status reads the same color in both details tables", async ({
+  page,
+}) => {
+  const row = await openPipeline(page, (payload) => {
+    const product = payload.groups[0].products[0];
+    const running = product.recent_inits.findLast(
+      (init) => init.status === "in_flight",
+    );
+    running.timing = "on_time";
+    for (const group of running.lead_groups) group.timing = "on_time";
+    return payload;
+  });
+  await row.locator('[data-slot="details-button"]').click();
+
+  const colors = await row
+    .locator(".pipeline-row-details")
+    .evaluate((node) =>
+      [...node.querySelectorAll('td[data-status="in_flight"]')].map(
+        (cell) => getComputedStyle(cell).color,
+      ),
+    );
+
+  expect(colors.length).toBeGreaterThan(1);
+  expect(new Set(colors)).toEqual(new Set(["rgb(91, 197, 74)"]));
+});
+
 test("pipeline exposes no history scrubber", async ({ page }) => {
   await openPipeline(page);
   await expect(page.locator("#pipeline-history-toggle")).toHaveCount(0);

--- a/test/pipeline.test.mjs
+++ b/test/pipeline.test.mjs
@@ -1004,6 +1004,7 @@ test("groups component and member readiness for the displayed init", () => {
       label: "pgrb2a",
       status: "processing",
       state: "in_flight",
+      timing: null,
       completion: 0.75,
       count: "3 / 4 observed",
     },
@@ -1012,10 +1013,41 @@ test("groups component and member readiness for the displayed init", () => {
       label: "control",
       status: "complete",
       state: "complete",
+      timing: null,
       completion: 1,
       count: "4 / 4 observed",
     },
   ]);
+});
+
+// A facet reports no timing of its own, so its row inherits the run's — the
+// grid's facet squares already do, and the two must not disagree about whether
+// the same in-flight work is on time.
+test("facet rows take the timing of the run they describe", () => {
+  const product = {
+    recent_inits: [
+      {
+        init_time: "2026-07-26T12:00:00Z",
+        status: "in_flight",
+        timing: "on_time",
+        facets: [
+          {
+            dimension: "component",
+            label: "pgrb2a",
+            status: "in_flight",
+            completion_pct: 0.5,
+            dependencies_available: 2,
+            dependencies_expected: 4,
+          },
+        ],
+      },
+    ],
+  };
+
+  assert.deepEqual(
+    facetRows(product).map(({ status, timing }) => ({ status, timing })),
+    [{ status: "processing", timing: "on_time" }],
+  );
 });
 
 test("local preview fixture exercises dashboard v2 facet rendering", () => {


### PR DESCRIPTION
Follow-up to #211. The same word read in two colors: on an on-time in-flight
run, "processing" was green in the lead table and amber in the arrival facets
table right below it.

A facet reports no `timing` of its own. The grid's facet squares handle that by
taking the run's — `facetCell(facet, init)` defaults `timing` to `init.timing` —
but `facetRows` dropped it, so every in-flight facet fell through to the plain
`[data-status="in_flight"]` rule and came out amber, regardless of whether the
run was on schedule. The lead groups, which do carry their own timing, went
green.

Live in production as I write this, for GEFS 35-day (`f840` in flight, on time)
and ICON-EU.

The fix carries the displayed run's timing into the facet rows, so the table
agrees with the square above it.

## Testing

`npm test` (168) and the pipeline browser spec (14) pass.

The fixture's running init is `delayed`, which colors both tables amber and so
hides this class of disagreement entirely. The new browser case flips that run
and its lead groups to `on_time` before asserting that every in-flight status in
the details block shares one color; it fails on `main` and passes here.
