### PR TITLE
Note the report URL contract dynamical-stac tests against

### DIFF
--- a/_data/validationReports.js
+++ b/_data/validationReports.js
@@ -8,6 +8,9 @@ const STAC_BASE_URL =
   (process.env.CF_PAGES_BRANCH && process.env.CF_PAGES_BRANCH !== "main"
     ? "https://stac-staging.dynamical.org"
     : "https://stac.dynamical.org");
+// dynamical-stac asserts every published dataset has a report at this host under
+// `{id}/latest/validation_summary.md` (tests/test_validation_reports.py). Change
+// either and that check still passes while this build 404s — update it there too.
 const VALIDATION_BASE_URL =
   process.env.VALIDATION_REPORTS_BASE_URL ||
   "https://dataset-validation-reports.dynamical.org";


### PR DESCRIPTION
`dynamical-stac` has an integration test asserting that every dataset in the production catalog has a published validation report. It fetches that report from this host at `{id}/latest/validation_summary.md` — the same URL `_data/validationReports.js` builds here.

Nothing links the two. Change the URL here and the dynamical-stac check keeps passing against the old location while this build 404s and dataset pages render an empty shell — the exact failure that check exists to catch.

Adds a three-line comment above `VALIDATION_BASE_URL` naming the test, so whoever changes it knows to update it there too.

Comment-only; `node --check` passes.

Companion to dynamical-org/dynamical-stac#90, which points that test at `validation_summary.md` (it had been asserting on `validation_report.html`, which this file never fetches).

🤖 Generated with [Claude Code](https://claude.com/claude-code)