### PR TITLE
Add August 31 update description and extend deprecation date

### DIFF
--- a/content/catalog-pages.njk
+++ b/content/catalog-pages.njk
@@ -251,7 +251,7 @@ eleventyComputed:
   </div>
   {% if entry.id in ["noaa-gfs-forecast", "noaa-gfs-analysis", "noaa-gefs-forecast-35-day", "noaa-gefs-analysis", "noaa-hrrr-forecast-48-hour", "noaa-hrrr-analysis", "noaa-mrms-conus-analysis-hourly", "ecmwf-ifs-ens-forecast-15-day-0-25-degree", "ecmwf-aifs-single-forecast", "dwd-icon-eu-forecast-5-day"] %}
     <aside aria-label="data.dynamical.org migration">
-      <strong><code>data.dynamical.org</code> access ends August 31, 2026.</strong>
+      <strong><code>data.dynamical.org</code> access ends September 30, 2026.</strong>
       If you use a <code>data.dynamical.org</code> URL for this dataset,
       <a href="/migration-2026/">migrate to a supported access pattern</a>.
     </aside>

--- a/content/llms-full.njk
+++ b/content/llms-full.njk
@@ -8,7 +8,7 @@ eleventyExcludeFromCollections: true
 
 **The STAC catalog at https://stac.dynamical.org/catalog.json is the authoritative source of truth** for data product documentation, dataset metadata, and data asset (Zarr/Icechunk) locations. The entries below are generated from it - for the most complete and current metadata (all variables, dimensions, extents, and exact asset URIs), read each dataset's STAC Collection linked below. Two equally supported ways to open a dataset: the `dynamical-catalog` Python library (`pip install --upgrade dynamical-catalog`, latest version): `import dynamical_catalog; ds = dynamical_catalog.open("<dataset-id>")`, or resolve the `icechunk-https` asset from the dataset's STAC Collection and open it with Icechunk directly.
 
-**`data.dynamical.org/**/latest.zarr` access ends after 2026-08-31.** Do not generate new code using those URLs. Migration guide: https://dynamical.org/migration-2026/
+**`data.dynamical.org/**/latest.zarr` access ends after 2026-09-30.** Do not generate new code using those URLs. Migration guide: https://dynamical.org/migration-2026/
 
 For LLM agents, an MCP server is live at https://mcp.dynamical.org/mcp (server name `dynamical-catalog`, streamable HTTP transport) with tools `search_catalog`, `get_dataset_info`, `get_access_pattern`, and `list_recent_runs` - prefer these for programmatic discovery, access snippets, and forecast-run freshness.
 

--- a/content/llms.njk
+++ b/content/llms.njk
@@ -10,7 +10,7 @@ All content below is public and requires no authentication. Machine-readable dat
 
 **The STAC catalog at https://stac.dynamical.org/catalog.json is the authoritative source of truth** for data product documentation, dataset metadata, and data asset (Zarr/Icechunk) locations. This file and the catalog pages are generated from it - when in doubt, read STAC. Two equally supported ways to open a dataset: the `dynamical-catalog` Python library (`pip install --upgrade dynamical-catalog`, latest version): `import dynamical_catalog; ds = dynamical_catalog.open("noaa-gfs-forecast")`, or resolve the `icechunk-https` asset from the dataset's STAC Collection and open it with Icechunk directly. LLM agents can query the catalog directly via the MCP server (see Tools below).
 
-**`data.dynamical.org/**/latest.zarr` access ends after 2026-08-31.** Do not generate new code using those URLs. Migration guide: https://dynamical.org/migration-2026/
+**`data.dynamical.org/**/latest.zarr` access ends after 2026-09-30.** Do not generate new code using those URLs. Migration guide: https://dynamical.org/migration-2026/
 
 ## Tools (MCP server)
 An MCP server for LLM agents and assistants is live at https://mcp.dynamical.org/mcp (server name `dynamical-catalog`, streamable HTTP transport). Prefer these tools for programmatic discovery and access - they read the live STAC catalog. Tools:

--- a/content/migration-2026.njk
+++ b/content/migration-2026.njk
@@ -40,7 +40,7 @@ permalink: /migration-2026/
   <h1 style="margin-top: 4rem; margin-bottom: 1rem;">Migrate from data.dynamical.org</h1>
 
   <ul>
-    <li><strong><code>data.dynamical.org</code> is going away</strong> — plan on August 31, 2026. In practice we will turn URLs off dataset by dataset over the following months rather than all at once, so nothing breaks the morning of September 1.</li>
+    <li><strong><code>data.dynamical.org</code> is going away</strong> — plan on September 30, 2026. In practice we will turn URLs off dataset by dataset over the following months rather than all at once, so nothing breaks the morning of October 1.</li>
     <li><strong>The replacement datasets are stored as Icechunk Zarr repositories.</strong></li>
     <li><strong>Only how they are opened needs to change.</strong> The Icechunk versions are identical in structure, naming, attributes, chunking/sharding, and content — drop-in replacements for the deprecated Zarrs.</li>
   </ul>

--- a/content/updates/2026-08-31.md
+++ b/content/updates/2026-08-31.md
@@ -1,7 +1,7 @@
 ---
 title: "HRRR fam complete, the validation reports you crave"
 date: 2026-08-31
-description: ""
+description: "The complete HRRR family is now in the catalog, every dataset has a detailed validation report, and data.dynamical.org access now ends September 30, 2026."
 ---
 
 I bring you good tidings, friends. Alden said our last newsletter was too long; that information can ONLY be delivered in groups of three. So just close your eyes for a moment (breathe in, breathe out) and imagine all the stuff we've done that he's NOT letting me tell you about. Pretty sick, right? Yeah, I'm proud of that one too. Mmhm, yes, per-file arrival. Anyway --
@@ -41,4 +41,3 @@ Was that short enough, Alden? _Editors note: yes :)_
 
 Enjoy the [weather](https://malcolmmoutenot.bandcamp.com/album/week-off-unpaid)
 MM
-


### PR DESCRIPTION
Adds the missing August 31 update description and moves the active data.dynamical.org deprecation notices to September 30, 2026.\n\nTests: TAP version 13
# Subtest: sentry loader is not injected off production
ok 1 - sentry loader is not injected off production
  ---
  duration_ms: 5.742252
  type: 'test'
  ...
# Subtest: sentry loader is injected on production and initializes itself
ok 2 - sentry loader is injected on production and initializes itself
  ---
  duration_ms: 1.026045
  type: 'test'
  ...
# Subtest: sentry init keeps tracing and session replay off
ok 3 - sentry init keeps tracing and session replay off
  ---
  duration_ms: 0.927798
  type: 'test'
  ...
# Subtest: posthog is not loaded off production
ok 4 - posthog is not loaded off production
  ---
  duration_ms: 2.841227
  type: 'test'
  ...
# Subtest: posthog is loaded on production
ok 5 - posthog is loaded on production
  ---
  duration_ms: 1.548152
  type: 'test'
  ...
# Subtest: every example the page renders is defined
ok 6 - every example the page renders is defined
  ---
  duration_ms: 0.838777
  type: 'test'
  ...
# Subtest: every defined example is rendered
ok 7 - every defined example is rendered
  ---
  duration_ms: 0.33434
  type: 'test'
  ...
# Subtest: requests are relative paths, so the base stays configurable
ok 8 - requests are relative paths, so the base stays configurable
  ---
  duration_ms: 0.452437
  type: 'test'
  ...
# Subtest: the quickstart request is the minimal one
ok 9 - the quickstart request is the minimal one
  ---
  duration_ms: 0.555118
  type: 'test'
  ...
# Subtest: curl renders GET and POST in copy-pasteable form
ok 10 - curl renders GET and POST in copy-pasteable form
  ---
  duration_ms: 0.234911
  type: 'test'
  ...
# Subtest: long axes are elided with the count and the real last value
ok 11 - long axes are elided with the count and the real last value
  ---
  duration_ms: 0.263978
  type: 'test'
  ...
# Subtest: arrays of objects and oversized maps announce what was dropped
ok 12 - arrays of objects and oversized maps announce what was dropped
  ---
  duration_ms: 0.259058
  type: 'test'
  ...
# Subtest: elision never rewrites a value it keeps
ok 13 - elision never rewrites a value it keeps
  ---
  duration_ms: 0.227085
  type: 'test'
  ...
# Subtest: the analysis window is hour-aligned and lags the present
ok 14 - the analysis window is hour-aligned and lags the present
  ---
  duration_ms: 0.256347
  type: 'test'
  ...
# Subtest: abbreviates catalog durations
ok 15 - abbreviates catalog durations
  ---
  duration_ms: 1.43938
  type: 'test'
  ...
# Subtest: summarizes a forecast dataset as domain, variables, resolution, horizon, cadence
ok 16 - summarizes a forecast dataset as domain, variables, resolution, horizon, cadence
  ---
  duration_ms: 1.107361
  type: 'test'
  ...
# Subtest: summarizes an analysis dataset with its record extent instead of a horizon
ok 17 - summarizes an analysis dataset with its record extent instead of a horizon
  ---
  duration_ms: 0.404724
  type: 'test'
  ...
# Subtest: counts a model's live forecasts and analyses, skipping deprecated ones
ok 18 - counts a model's live forecasts and analyses, skipping deprecated ones
  ---
  duration_ms: 0.417517
  type: 'test'
  ...
# Subtest: maps public routes to a durable section label
ok 19 - maps public routes to a durable section label
  ---
  duration_ms: 1.64889
  type: 'test'
  ...
# Subtest: status labels name the live pages without embedding telemetry
ok 20 - status labels name the live pages without embedding telemetry
  ---
  duration_ms: 0.249117
  type: 'test'
  ...
# Subtest: link previews prefer a page's fact line while SEO keeps the prose
ok 21 - link previews prefer a page's fact line while SEO keeps the prose
  ---
  duration_ms: 0.260367
  type: 'test'
  ...
# Subtest: the card carries no copy of its own beyond the brand and the page
ok 22 - the card carries no copy of its own beyond the brand and the page
  ---
  duration_ms: 0.210669
  type: 'test'
  ...
# Subtest: status metadata describes the destination instead of a cached snapshot
ok 23 - status metadata describes the destination instead of a cached snapshot
  ---
  duration_ms: 0.278412
  type: 'test'
  ...
# Subtest: artwork is composed into generated cards and scorecard details share one image
ok 24 - artwork is composed into generated cards and scorecard details share one image
  ---
  duration_ms: 0.271853
  type: 'test'
  ...
# Subtest: a card leaves room for a full fact line on one line
ok 25 - a card leaves room for a full fact line on one line
  ---
  duration_ms: 0.189773
  type: 'test'
  ...
# Subtest: a fact line breaks between facts, never inside one
ok 26 - a fact line breaks between facts, never inside one
  ---
  duration_ms: 0.178248
  type: 'test'
  ...
# Subtest: the review contact sheet lists every card and flags the ones to look at
ok 27 - the review contact sheet lists every card and flags the ones to look at
  ---
  duration_ms: 5.816475
  type: 'test'
  ...
# Subtest: the review contact sheet is generated for previews but never for production
ok 28 - the review contact sheet is generated for previews but never for production
  ---
  duration_ms: 0.416069
  type: 'test'
  ...
# Subtest: renders plain, status, and artwork cards as 1200 by 630 PNGs
ok 29 - renders plain, status, and artwork cards as 1200 by 630 PNGs
  ---
  duration_ms: 10.286575
  type: 'test'
  ...
# Subtest: accepts the granular dashboard contract
ok 30 - accepts the granular dashboard contract
  ---
  duration_ms: 2.074447
  type: 'test'
  ...
# Subtest: rejects the lead-only schema it replaced
ok 31 - rejects the lead-only schema it replaced
  ---
  duration_ms: 0.724893
  type: 'test'
  ...
# Subtest: accepts a product's facets
ok 32 - accepts a product's facets
  ---
  duration_ms: 0.383163
  type: 'test'
  ...
# Subtest: rejects empty, unknown, and oversized dashboards
ok 33 - rejects empty, unknown, and oversized dashboards
  ---
  duration_ms: 0.611238
  type: 'test'
  ...
# Subtest: summarizes upstream agency advisories without changing pipeline state
ok 34 - summarizes upstream agency advisories without changing pipeline state
  ---
  duration_ms: 0.991503
  type: 'test'
  ...
# Subtest: summarizes shared system and agency health
ok 35 - summarizes shared system and agency health
  ---
  duration_ms: 0.46682
  type: 'test'
  ...
# Subtest: formats init labels in UTC and the selected local timezone
ok 36 - formats init labels in UTC and the selected local timezone
  ---
  duration_ms: 16.460305
  type: 'test'
  ...
# Subtest: falls back to UTC when the browser reports a non-IANA local timezone
ok 37 - falls back to UTC when the browser reports a non-IANA local timezone
  ---
  duration_ms: 0.333069
  type: 'test'
  ...
# Subtest: shortens displayed web sources without changing other schemes
ok 38 - shortens displayed web sources without changing other schemes
  ---
  duration_ms: 0.280793
  type: 'test'
  ...
# Subtest: bands the lead grid from the floor up, and only by lead group
ok 39 - bands the lead grid from the floor up, and only by lead group
  ---
  duration_ms: 0.412266
  type: 'test'
  ...
# Subtest: sizes the label gutter to the labels beside it
ok 40 - sizes the label gutter to the labels beside it
  ---
  duration_ms: 0.279104
  type: 'test'
  ...
# Subtest: orders the lead axis shortest horizon first, and the bands from the floor up
ok 41 - orders the lead axis shortest horizon first, and the bands from the floor up
  ---
  duration_ms: 0.110307
  type: 'test'
  ...
# Subtest: gives an init column room for its own label, in any zone
ok 42 - gives an init column room for its own label, in any zone
  ---
  duration_ms: 0.371762
  type: 'test'
  ...
# Subtest: fits the run count to the width the row actually has
ok 43 - fits the run count to the width the row actually has
  ---
  duration_ms: 0.142606
  type: 'test'
  ...
# Subtest: moves facets out of their own bands once the joint is published
ok 44 - moves facets out of their own bands once the joint is published
  ---
  duration_ms: 0.204258
  type: 'test'
  ...
# Subtest: sizes a lead group by its share of the run, never below its label
ok 45 - sizes a lead group by its share of the run, never below its label
  ---
  duration_ms: 0.243351
  type: 'test'
  ...
# Subtest: compacts lead columns when facets own the rows
ok 46 - compacts lead columns when facets own the rows
  ---
  duration_ms: 0.144096
  type: 'test'
  ...
# Subtest: offers one view per facet dimension, opening on the lead grid
ok 47 - offers one view per facet dimension, opening on the lead grid
  ---
  duration_ms: 0.662383
  type: 'test'
  ...
# Subtest: a facet view shows only its own dimension's rows
ok 48 - a facet view shows only its own dimension's rows
  ---
  duration_ms: 0.34136
  type: 'test'
  ...
# Subtest: abbreviates long facet axis labels without changing their data labels
ok 49 - abbreviates long facet axis labels without changing their data labels
  ---
  duration_ms: 0.132754
  type: 'test'
  ...
# Subtest: gives every facet in the joint its own labelled row
ok 50 - gives every facet in the joint its own labelled row
  ---
  duration_ms: 0.114059
  type: 'test'
  ...
# Subtest: keeps the lead grid usable when a joint reports nothing
ok 51 - keeps the lead grid usable when a joint reports nothing
  ---
  duration_ms: 0.114159
  type: 'test'
  ...
# Subtest: draws a facet row for anything the joint reported in the window
ok 52 - draws a facet row for anything the joint reported in the window
  ---
  duration_ms: 0.195928
  type: 'test'
  ...
# Subtest: fits run blocks of lead columns to the width, once facets own the rows
ok 53 - fits run blocks of lead columns to the width, once facets own the rows
  ---
  duration_ms: 0.171419
  type: 'test'
  ...
# Subtest: orders a lead group's facets as the product declares them
ok 54 - orders a lead group's facets as the product declares them
  ---
  duration_ms: 0.096136
  type: 'test'
  ...
# Subtest: a nested square names its facet and the lead it arrived under
ok 55 - a nested square names its facet and the lead it arrived under
  ---
  duration_ms: 2.721581
  type: 'test'
  ...
# Subtest: rejects a malformed joint the same way as run-level facets
ok 56 - rejects a malformed joint the same way as run-level facets
  ---
  duration_ms: 0.279856
  type: 'test'
  ...
# Subtest: measures a lead band by its own share, not the cumulative count
ok 57 - measures a lead band by its own share, not the cumulative count
  ---
  duration_ms: 0.093723
  type: 'test'
  ...
# Subtest: preserves delayed timing on an empty pending lead band
ok 58 - preserves delayed timing on an empty pending lead band
  ---
  duration_ms: 0.075063
  type: 'test'
  ...
# Subtest: names what a square measured, facet first, in its hover label
ok 59 - names what a square measured, facet first, in its hover label
  ---
  duration_ms: 0.23878
  type: 'test'
  ...
# Subtest: reads an unreported band as unobserved rather than a failure
ok 60 - reads an unreported band as unobserved rather than a failure
  ---
  duration_ms: 0.073755
  type: 'test'
  ...
# Subtest: shows exact and relative ETA in the selected timezone
ok 61 - shows exact and relative ETA in the selected timezone
  ---
  duration_ms: 0.685097
  type: 'test'
  ...
# Subtest: retains live horizon status, time, and duration in details
ok 62 - retains live horizon status, time, and duration in details
  ---
  duration_ms: 0.760988
  type: 'test'
  ...
# Subtest: treats a delayed pending init as the current run in details
ok 63 - treats a delayed pending init as the current run in details
  ---
  duration_ms: 0.114445
  type: 'test'
  ...
# Subtest: names the init sample the percentile columns summarise
ok 64 - names the init sample the percentile columns summarise
  ---
  duration_ms: 0.409703
  type: 'test'
  ...
# Subtest: shows the last and upcoming runs while waiting for the next init
ok 65 - shows the last and upcoming runs while waiting for the next init
  ---
  duration_ms: 0.460234
  type: 'test'
  ...
# Subtest: groups component and member readiness for the displayed init
ok 66 - groups component and member readiness for the displayed init
  ---
  duration_ms: 0.171256
  type: 'test'
  ...
# Subtest: facet rows take the timing of the run they describe
ok 67 - facet rows take the timing of the run they describe
  ---
  duration_ms: 0.085992
  type: 'test'
  ...
# Subtest: local preview fixture exercises dashboard v2 facet rendering
ok 68 - local preview fixture exercises dashboard v2 facet rendering
  ---
  duration_ms: 0.745977
  type: 'test'
  ...
# Subtest: local preview fixture carries a source-only group
ok 69 - local preview fixture carries a source-only group
  ---
  duration_ms: 0.799575
  type: 'test'
  ...
# Subtest: preview pipeline route exposes only allowlisted staging JSON
ok 70 - preview pipeline route exposes only allowlisted staging JSON
  ---
  duration_ms: 15.427776
  type: 'test'
  ...
# Subtest: preview branches select the private staging route
ok 71 - preview branches select the private staging route
  ---
  duration_ms: 0.143823
  type: 'test'
  ...
# Subtest: a resize re-fits the live dashboard at the current time
ok 72 - a resize re-fits the live dashboard at the current time
  ---
  duration_ms: 0.2996
  type: 'test'
  ...
# Subtest: status pages share the uptime, pipeline, and pipeline webhooks subnav
ok 73 - status pages share the uptime, pipeline, and pipeline webhooks subnav
  ---
  duration_ms: 0.339109
  type: 'test'
  ...
# Subtest: pipeline exposes no time-travel history controls or requests
ok 74 - pipeline exposes no time-travel history controls or requests
  ---
  duration_ms: 0.410676
  type: 'test'
  ...
# Subtest: primary navigation styles the current section like the status subnav
ok 75 - primary navigation styles the current section like the status subnav
  ---
  duration_ms: 0.360487
  type: 'test'
  ...
# Subtest: the shared time control shows only the browser's local zone
ok 76 - the shared time control shows only the browser's local zone
  ---
  duration_ms: 0.402343
  type: 'test'
  ...
# Subtest: either local status preview serves both fixture feeds
ok 77 - either local status preview serves both fixture feeds
  ---
  duration_ms: 0.222403
  type: 'test'
  ...
# Subtest: pipeline page uses the shared subnav without a separate footer
ok 78 - pipeline page uses the shared subnav without a separate footer
  ---
  duration_ms: 0.758303
  type: 'test'
  ...
# Subtest: uptime uses light section headings without subtitles or rules
ok 79 - uptime uses light section headings without subtitles or rules
  ---
  duration_ms: 0.224836
  type: 'test'
  ...
# Subtest: every offered metric has display configuration
ok 80 - every offered metric has display configuration
  ---
  duration_ms: 0.647906
  type: 'test'
  ...
# Subtest: every variable's default metric is one it offers
ok 81 - every variable's default metric is one it offers
  ---
  duration_ms: 0.125352
  type: 'test'
  ...
# Subtest: rejects with a catchable error, without reaching the CDN, when WebAssembly is unavailable
ok 82 - rejects with a catchable error, without reaching the CDN, when WebAssembly is unavailable
  ---
  duration_ms: 0.397147
  type: 'test'
  ...
# Subtest: window filters accept both published duration encodings
ok 83 - window filters accept both published duration encodings
  ---
  duration_ms: 0.521283
  type: 'test'
  ...
# Subtest: every page offers the same lookback windows
ok 84 - every page offers the same lookback windows
  ---
  duration_ms: 0.49854
  type: 'test'
  ...
# Subtest: publishes commercial SLA terms with shared page metadata
ok 85 - publishes commercial SLA terms with shared page metadata
  ---
  duration_ms: 0.640525
  type: 'test'
  ...
# Subtest: cross-links the SLA and its terms
ok 86 - cross-links the SLA and its terms
  ---
  duration_ms: 0.111773
  type: 'test'
  ...
# Subtest: keeps commercial SLA services separate from catalog data licenses
ok 87 - keeps commercial SLA services separate from catalog data licenses
  ---
  duration_ms: 0.268724
  type: 'test'
  ...
# Subtest: keeps ordinary SLA target misses within the SLA remedies
ok 88 - keeps ordinary SLA target misses within the SLA remedies
  ---
  duration_ms: 0.774638
  type: 'test'
  ...
# Subtest: skips unknown event kinds instead of failing
ok 89 - skips unknown event kinds instead of failing
  ---
  duration_ms: 2.36344
  type: 'test'
  ...
# Subtest: survives a truncated final line
ok 90 - survives a truncated final line
  ---
  duration_ms: 0.289201
  type: 'test'
  ...
# Subtest: sorts by timestamp, then coverage before transition
ok 91 - sorts by timestamp, then coverage before transition
  ---
  duration_ms: 0.14987
  type: 'test'
  ...
# Subtest: effective as-of covers CDN skew between the two artifacts
ok 92 - effective as-of covers CDN skew between the two artifacts
  ---
  duration_ms: 0.171712
  type: 'test'
  ...
# Subtest: an open span ends at the as-of, never at now
ok 93 - an open span ends at the as-of, never at now
  ---
  duration_ms: 0.259715
  type: 'test'
  ...
# Subtest: a same-state coverage re-assertion does not split a span
ok 94 - a same-state coverage re-assertion does not split a span
  ---
  duration_ms: 0.145801
  type: 'test'
  ...
# Subtest: a coverage exit closes the span and leaves a gap, not a state
ok 95 - a coverage exit closes the span and leaves a gap, not a state
  ---
  duration_ms: 0.180727
  type: 'test'
  ...
# Subtest: an unrecognized state becomes unknown, never operational
ok 96 - an unrecognized state becomes unknown, never operational
  ---
  duration_ms: 0.093857
  type: 'test'
  ...
# Subtest: a transition while uncovered is ignored rather than inventing coverage
ok 97 - a transition while uncovered is ignored rather than inventing coverage
  ---
  duration_ms: 0.961328
  type: 'test'
  ...
# Subtest: events after the as-of are clamped rather than extending the window
ok 98 - events after the as-of are clamped rather than extending the window
  ---
  duration_ms: 0.327877
  type: 'test'
  ...
# Subtest: incidents distinguish resolution from observation ending
ok 99 - incidents distinguish resolution from observation ending
  ---
  duration_ms: 0.427513
  type: 'test'
  ...
# Subtest: bars always cover the full rolling window
ok 100 - bars always cover the full rolling window
  ---
  duration_ms: 0.618895
  type: 'test'
  ...
# Subtest: an entirely unobserved component gets 90 blank bars
ok 101 - an entirely unobserved component gets 90 blank bars
  ---
  duration_ms: 0.22025
  type: 'test'
  ...
# Subtest: a day with any down interval renders down
ok 102 - a day with any down interval renders down
  ---
  duration_ms: 0.404251
  type: 'test'
  ...
# Subtest: a partly observed day is filled while coverage records the gap
ok 103 - a partly observed day is filled while coverage records the gap
  ---
  duration_ms: 0.22386
  type: 'test'
  ...
# Subtest: an unknown state outranks no data rather than hiding behind it
ok 104 - an unknown state outranks no data rather than hiding behind it
  ---
  duration_ms: 0.263404
  type: 'test'
  ...
# Subtest: partial first coverage day is filled from observed status
ok 105 - partial first coverage day is filled from observed status
  ---
  duration_ms: 0.567826
  type: 'test'
  ...
# Subtest: today is judged against the as-of, not against midnight
ok 106 - today is judged against the as-of, not against midnight
  ---
  duration_ms: 0.187954
  type: 'test'
  ...
# Subtest: the window caps at the requested number of days
ok 107 - the window caps at the requested number of days
  ---
  duration_ms: 0.157285
  type: 'test'
  ...
# Subtest: a degraded day outranks operational but never down
ok 108 - a degraded day outranks operational but never down
  ---
  duration_ms: 0.33561
  type: 'test'
  ...
# Subtest: a degraded day outranks unknown: a state we could read beats one we could not
ok 109 - a degraded day outranks unknown: a state we could read beats one we could not
  ---
  duration_ms: 0.215742
  type: 'test'
  ...
# Subtest: a degraded cell links to no incident
ok 110 - a degraded cell links to no incident
  ---
  duration_ms: 0.203584
  type: 'test'
  ...
# Subtest: delays are first-class history entries beside outages
ok 111 - delays are first-class history entries beside outages
  ---
  duration_ms: 0.170763
  type: 'test'
  ...
# Subtest: a delay ends as observation-ended when coverage stops
ok 112 - a delay ends as observation-ended when coverage stops
  ---
  duration_ms: 0.158977
  type: 'test'
  ...
# Subtest: a same-kind reassertion does not split a delay entry
ok 113 - a same-kind reassertion does not split a delay entry
  ---
  duration_ms: 0.074282
  type: 'test'
  ...
# Subtest: degraded days link their delay entries the way down days link incidents
ok 114 - degraded days link their delay entries the way down days link incidents
  ---
  duration_ms: 0.223755
  type: 'test'
  ...
# Subtest: a down day links only its outages, not the day's delays
ok 115 - a down day links only its outages, not the day's delays
  ---
  duration_ms: 0.227102
  type: 'test'
  ...
# Subtest: a witnessed delay never rounds itself invisible
ok 116 - a witnessed delay never rounds itself invisible
  ---
  duration_ms: 0.27912
  type: 'test'
  ...
# Subtest: a component with no degraded time reports exactly zero delayed
ok 117 - a component with no degraded time reports exactly zero delayed
  ---
  duration_ms: 0.226536
  type: 'test'
  ...
# Subtest: degraded time is monitored, leaves uptime alone, and shows as delayed
ok 118 - degraded time is monitored, leaves uptime alone, and shows as delayed
  ---
  duration_ms: 0.250191
  type: 'test'
  ...
# Subtest: uptime is derived from the log, so it cannot contradict the bars
ok 119 - uptime is derived from the log, so it cannot contradict the bars
  ---
  duration_ms: 0.958589
  type: 'test'
  ...
# Subtest: uptime excludes time before the first displayed UTC day
ok 120 - uptime excludes time before the first displayed UTC day
  ---
  duration_ms: 0.561082
  type: 'test'
  ...
# Subtest: confirmed downtime never presents as a flat 100%
ok 121 - confirmed downtime never presents as a flat 100%
  ---
  duration_ms: 0.182061
  type: 'test'
  ...
# Subtest: a coverage gap lowers coverage rather than uptime
ok 122 - a coverage gap lowers coverage rather than uptime
  ---
  duration_ms: 0.1972
  type: 'test'
  ...
# Subtest: an unknown state is excluded from the denominator, not counted either way
ok 123 - an unknown state is excluded from the denominator, not counted either way
  ---
  duration_ms: 0.237308
  type: 'test'
  ...
# Subtest: an offset-less event timestamp is refused rather than shifted
ok 124 - an offset-less event timestamp is refused rather than shifted
  ---
  duration_ms: 0.197745
  type: 'test'
  ...
# Subtest: accepts the published feed shape
ok 125 - accepts the published feed shape
  ---
  duration_ms: 3.738837
  type: 'test'
  ...
# Subtest: keeps the experimental wxopticon components off the page
ok 126 - keeps the experimental wxopticon components off the page
  ---
  duration_ms: 0.394988
  type: 'test'
  ...
# Subtest: an experimental component's state does not move the rollup
ok 127 - an experimental component's state does not move the rollup
  ---
  duration_ms: 0.469889
  type: 'test'
  ...
# Subtest: summarizes an operational feed
ok 128 - summarizes an operational feed
  ---
  duration_ms: 0.208915
  type: 'test'
  ...
# Subtest: summarizes only the components this page renders
ok 129 - summarizes only the components this page renders
  ---
  duration_ms: 0.324189
  type: 'test'
  ...
# Subtest: marks status data stale after twenty minutes
ok 130 - marks status data stale after twenty minutes
  ---
  duration_ms: 0.217335
  type: 'test'
  ...
# Subtest: rejects a malformed envelope
ok 131 - rejects a malformed envelope
  ---
  duration_ms: 0.839213
  type: 'test'
  ...
# Subtest: refuses a contentless document instead of reporting all clear
ok 132 - refuses a contentless document instead of reporting all clear
  ---
  duration_ms: 0.325148
  type: 'test'
  ...
# Subtest: does not require the deferred dataset section
ok 133 - does not require the deferred dataset section
  ---
  duration_ms: 0.540111
  type: 'test'
  ...
# Subtest: keeps rendering when a visible component has an unrecognized state
ok 134 - keeps rendering when a visible component has an unrecognized state
  ---
  duration_ms: 0.56269
  type: 'test'
  ...
# Subtest: labels a planned down component without changing its health state
ok 135 - labels a planned down component without changing its health state
  ---
  duration_ms: 0.304582
  type: 'test'
  ...
# Subtest: labels a degraded component as a live monitoring gap
ok 136 - labels a degraded component as a live monitoring gap
  ---
  duration_ms: 0.2227
  type: 'test'
  ...
# Subtest: rejects malformed live observation metadata
ok 137 - rejects malformed live observation metadata
  ---
  duration_ms: 0.246632
  type: 'test'
  ...
# Subtest: groups explicitly related outages and remaps day links
ok 138 - groups explicitly related outages and remaps day links
  ---
  duration_ms: 1.175156
  type: 'test'
  ...
# Subtest: accepts and preserves an observation-gap explanation
ok 139 - accepts and preserves an observation-gap explanation
  ---
  duration_ms: 0.408588
  type: 'test'
  ...
# Subtest: explicit unplanned incident groups retain outage severity
ok 140 - explicit unplanned incident groups retain outage severity
  ---
  duration_ms: 0.224449
  type: 'test'
  ...
# Subtest: rejects a mismatched event-log revision
ok 141 - rejects a mismatched event-log revision
  ---
  duration_ms: 0.413113
  type: 'test'
  ...
# Subtest: revision count includes additive records old clients skip
ok 142 - revision count includes additive records old clients skip
  ---
  duration_ms: 1.601879
  type: 'test'
  ...
# Subtest: revision metadata rejects a truncated record
ok 143 - revision metadata rejects a truncated record
  ---
  duration_ms: 0.300717
  type: 'test'
  ...
# Subtest: accepts legacy history metadata during publisher rollout
ok 144 - accepts legacy history metadata during publisher rollout
  ---
  duration_ms: 0.562988
  type: 'test'
  ...
# Subtest: history must be close to the current snapshot
ok 145 - history must be close to the current snapshot
  ---
  duration_ms: 0.193874
  type: 'test'
  ...
# Subtest: incident descriptions say what the state did to the thing you use
ok 146 - incident descriptions say what the state did to the thing you use
  ---
  duration_ms: 0.251485
  type: 'test'
  ...
# Subtest: incident descriptions fall back to generic phrasing for unknown ids
ok 147 - incident descriptions fall back to generic phrasing for unknown ids
  ---
  duration_ms: 0.807141
  type: 'test'
  ...
# Subtest: overlap is claimed only for intervals that actually intersect
ok 148 - overlap is claimed only for intervals that actually intersect
  ---
  duration_ms: 0.170575
  type: 'test'
  ...
# Subtest: bar descriptions distinguish unknown state from missing coverage
ok 149 - bar descriptions distinguish unknown state from missing coverage
  ---
  duration_ms: 0.262161
  type: 'test'
  ...
# Subtest: uptime description states the fixed window without a coverage suffix
ok 150 - uptime description states the fixed window without a coverage suffix
  ---
  duration_ms: 0.07257
  type: 'test'
  ...
# Subtest: bar descriptions count degraded days apart from outages
ok 151 - bar descriptions count degraded days apart from outages
  ---
  duration_ms: 0.095635
  type: 'test'
  ...
# Subtest: bar descriptions separate planned work from outages
ok 152 - bar descriptions separate planned work from outages
  ---
  duration_ms: 0.100236
  type: 'test'
  ...
# Subtest: uptime description surfaces degraded time without calling it downtime
ok 153 - uptime description surfaces degraded time without calling it downtime
  ---
  duration_ms: 0.059104
  type: 'test'
  ...
# Subtest: status page passes its timestamp into the shared subnav row
ok 154 - status page passes its timestamp into the shared subnav row
  ---
  duration_ms: 0.426358
  type: 'test'
  ...
# Subtest: observation groups render their days as a gap, not an outage
ok 155 - observation groups render their days as a gap, not an outage
  ---
  duration_ms: 0.146891
  type: 'test'
  ...
# Subtest: corrected coverage gaps retain their explicit observation incident
ok 156 - corrected coverage gaps retain their explicit observation incident
  ---
  duration_ms: 0.391653
  type: 'test'
  ...
# Subtest: partial-day corrected gaps override an otherwise operational day
ok 157 - partial-day corrected gaps override an otherwise operational day
  ---
  duration_ms: 0.443515
  type: 'test'
  ...
# Subtest: partial-day gaps do not soften known trouble elsewhere that day
ok 158 - partial-day gaps do not soften known trouble elsewhere that day
  ---
  duration_ms: 0.883289
  type: 'test'
  ...
# Subtest: bar descriptions separate monitoring gaps from outages
ok 159 - bar descriptions separate monitoring gaps from outages
  ---
  duration_ms: 0.169233
  type: 'test'
  ...
# Subtest: monitoring-gap days render as dithered green, not red
ok 160 - monitoring-gap days render as dithered green, not red
  ---
  duration_ms: 0.175275
  type: 'test'
  ...
# Subtest: the hatch tile the status bars mark gaps with is a shared token
ok 161 - the hatch tile the status bars mark gaps with is a shared token
  ---
  duration_ms: 0.245941
  type: 'test'
  ...
# Subtest: a run of identical nearby gaps coalesces into one entry
ok 162 - a run of identical nearby gaps coalesces into one entry
  ---
  duration_ms: 0.265792
  type: 'test'
  ...
# Subtest: gaps further apart than the coalescing window stay separate
ok 163 - gaps further apart than the coalescing window stay separate
  ---
  duration_ms: 0.220723
  type: 'test'
  ...
# Subtest: an outage between coalesced windows stays its own incident
ok 164 - an outage between coalesced windows stays its own incident
  ---
  duration_ms: 0.534222
  type: 'test'
  ...
# Subtest: a coalesced entry counts its windows, not the span between them
ok 165 - a coalesced entry counts its windows, not the span between them
  ---
  duration_ms: 0.250186
  type: 'test'
  ...
# Subtest: track is defined outside the posthog key conditional
ok 166 - track is defined outside the posthog key conditional
  ---
  duration_ms: 0.652641
  type: 'test'
  ...
# Subtest: track forwards to posthog.capture when it is present
ok 167 - track forwards to posthog.capture when it is present
  ---
  duration_ms: 1.090338
  type: 'test'
  ...
# Subtest: track is a silent no-op when posthog is absent or broken
ok 168 - track is a silent no-op when posthog is absent or broken
  ---
  duration_ms: 1.06009
  type: 'test'
  ...
1..168
# tests 168
# suites 0
# pass 168
# fail 0
# cancelled 0
# skipped 0
# todo 0
# duration_ms 171.894828