### PR TITLE
Show ingestion lag for dynamical.org rows on the pipeline page

### DIFF
--- a/public/pipeline.mjs
+++ b/public/pipeline.mjs
@@ -134,6 +134,16 @@ function productsOf(dashboard) {
   return dashboard.groups.flatMap((group) => group.products);
 }
 
+// a dynamical row reads its lag off the sources beside it, so every row needs
+// its group's products; one pass builds the lookup for a whole render
+function groupProductsById(dashboard) {
+  const index = new Map();
+  for (const group of dashboard.groups) {
+    for (const product of group.products) index.set(product.id, group.products);
+  }
+  return index;
+}
+
 function element(tag, attrs, children) {
   const node = document.createElement(tag);
   for (const [name, value] of Object.entries(attrs ?? {})) {
@@ -159,6 +169,16 @@ function formatLatency(seconds) {
   const hours = Math.floor(seconds / 3600);
   const minutes = Math.round((seconds % 3600) / 60);
   return minutes ? `${hours}h ${minutes}m` : `${hours}h`;
+}
+
+// a lag can run either way: the source's completion is wxopticon's stricter
+// one — every component and lead of the run — so dynamical can finish first,
+// and the column has to carry a sign
+function formatSignedLatency(seconds) {
+  if (seconds == null || !Number.isFinite(seconds)) return "—";
+  return seconds < 0
+    ? `−${formatLatency(-seconds)}`
+    : formatLatency(seconds);
 }
 
 function formatDuration(seconds) {
@@ -982,6 +1002,14 @@ function statsHeader(sampleInitCount) {
   return `time after init · ${sampleInitCount.toLocaleString("en-US")} ${samples}`;
 }
 
+// A lag has no published baseline behind it, so its sample is the handful of
+// runs the payload carries — named apart from the upstream rows' own count.
+function lagStatsHeader(sampleCount) {
+  if (!sampleCount) return "lag after source";
+  const samples = sampleCount === 1 ? "recent sample" : "recent samples";
+  return `lag after source · ${sampleCount.toLocaleString("en-US")} ${samples}`;
+}
+
 const NO_RUN = Object.freeze({
   status: "—",
   state: null,
@@ -1040,7 +1068,67 @@ function labelledRun(label, initTime, local) {
   return initTime ? `${label} · ${initShort(initTime, local)}` : label;
 }
 
-export function detailRows(product, now, local) {
+/* Ingestion lag. dynamical.org's own rows sit in the same group as the upstream
+   sources they read, and their `source_label` is null; what matters for them is
+   not time after init but how long after the source published the dataset
+   landed. Both latencies are seconds after the same init, so the init cancels
+   out of the subtraction. */
+
+export function sourceRowsOf(products) {
+  return (products ?? []).filter(({ source_label }) => source_label != null);
+}
+
+export function isDynamicalRow(product) {
+  return product.source_label == null;
+}
+
+function completedLatency(measured) {
+  return measured?.status === "complete" && Number.isFinite(measured.latency_s)
+    ? measured.latency_s
+    : null;
+}
+
+function initAt(product, initTime) {
+  const at = Date.parse(initTime);
+  return (product.recent_inits ?? []).find(
+    (init) => Date.parse(init.init_time) === at,
+  );
+}
+
+// The earliest source completion is the one to measure from — a mirror that
+// lagged tells us nothing about when the data became available. Only whole
+// runs are subtracted: two rows carrying the same number of lead groups is no
+// evidence that they cut their horizons the same way, so there is no per-group
+// lag to report.
+export function lagAt(init, sources) {
+  if (!init) return null;
+  const mine = completedLatency(init);
+  if (mine == null) return null;
+  let earliest = null;
+  for (const source of sources) {
+    const theirs = completedLatency(initAt(source, init.init_time));
+    if (theirs == null) continue;
+    if (earliest == null || theirs < earliest) earliest = theirs;
+  }
+  return earliest == null ? null : mine - earliest;
+}
+
+export function lagSeries(product, sources) {
+  return (product.recent_inits ?? [])
+    .map((init) => lagAt(init, sources))
+    .filter((lag) => lag != null);
+}
+
+// Nearest rank over the runs the payload carries: no baseline is published for
+// a lag, so the columns summarise the sample on screen. Two runs is the least
+// that reads as a distribution rather than a single number three times.
+export function lagPercentile(lags, fraction) {
+  if (lags.length < 2) return null;
+  const sorted = [...lags].sort((a, b) => a - b);
+  return sorted[Math.max(1, Math.ceil(fraction * sorted.length)) - 1];
+}
+
+export function detailRows(product, now, local, groupProducts = []) {
   const recent = product.recent_inits ?? [];
   const activeIndex = recent.findLastIndex(
     (init) => init.status === "pending" || init.status === "in_flight",
@@ -1048,39 +1136,69 @@ export function detailRows(product, now, local) {
   const active = activeIndex >= 0 ? recent[activeIndex] : null;
   const last = activeIndex >= 0 ? recent[activeIndex - 1] : recent.at(-1);
   const upcoming = active ? null : product.next_expected_init;
+  const sources = isDynamicalRow(product) ? sourceRowsOf(groupProducts) : [];
+  const lagged = sources.length > 0;
+  // the lag is a property of the whole run, so every lead-group row of a
+  // lagged product reports the same series
+  const lags = lagged ? lagSeries(product, sources) : null;
+  const lastLag = lagAt(last, sources);
+  const runLag = lagAt(active, sources);
   return {
     lastHeader: labelledRun("last run", last?.init_time, local),
     runHeader: active
       ? labelledRun("current run", active.init_time, local)
       : labelledRun("upcoming run", upcoming, local),
-    statsHeader: statsHeader(product.latency_stats?.sample_init_count),
+    statsHeader: lagged
+      ? lagStatsHeader(lags.length)
+      : statsHeader(product.latency_stats?.sample_init_count),
     rows: (product.lead_group_stats ?? []).map((stats, index) => {
       return {
         label: stats.label,
-        last: observedRunDetail(
-          last,
-          last?.lead_groups?.[index],
-          stats,
-          now,
-          local,
-          false,
+        last: withLag(
+          observedRunDetail(
+            last,
+            last?.lead_groups?.[index],
+            stats,
+            now,
+            local,
+            false,
+          ),
+          lagged,
+          lastLag,
         ),
-        run: active
-          ? observedRunDetail(
-              active,
-              active.lead_groups?.[index],
-              stats,
-              now,
-              local,
-              true,
-            )
-          : upcomingRunDetail(upcoming, stats, local),
-        p50: formatLatency(stats.p50_s),
-        p95: formatLatency(stats.p95_s),
-        p99: formatLatency(stats.p99_s),
+        run: withLag(
+          active
+            ? observedRunDetail(
+                active,
+                active.lead_groups?.[index],
+                stats,
+                now,
+                local,
+                true,
+              )
+            : upcomingRunDetail(upcoming, stats, local),
+          lagged,
+          runLag,
+        ),
+        p50: lags
+          ? formatSignedLatency(lagPercentile(lags, 0.5))
+          : formatLatency(stats.p50_s),
+        p95: lags
+          ? formatSignedLatency(lagPercentile(lags, 0.95))
+          : formatLatency(stats.p95_s),
+        p99: lags
+          ? formatSignedLatency(lagPercentile(lags, 0.99))
+          : formatLatency(stats.p99_s),
       };
     }),
   };
+}
+
+// On a lagged row the lag replaces the duration column outright — the
+// wall-clock time beside it still says when the run finished, and a lag of
+// null (no completed pair for that init) reads as "—".
+function withLag(detail, lagged, lag) {
+  return lagged ? { ...detail, duration: formatSignedLatency(lag) } : detail;
 }
 
 export function facetRows(product) {
@@ -1115,8 +1233,8 @@ function scrollable(table) {
   return element("div", { class: "table-container" }, [table]);
 }
 
-function buildDetails(product, now, local) {
-  const details = detailRows(product, now, local);
+function buildDetails(product, now, local, groupProducts) {
+  const details = detailRows(product, now, local, groupProducts);
   const groupHead = element("tr", null, [
     element("th", { rowspan: "2" }, "horizon"),
     element("th", { colspan: "3" }, details.lastHeader),
@@ -1204,7 +1322,7 @@ function buildDetails(product, now, local) {
   return element("div", null, [scrollable(leadTable), scrollable(facetTable)]);
 }
 
-function hydrateRow(row, product, now, local, available) {
+function hydrateRow(row, product, now, local, available, groupProducts) {
   // the lead grid is the view a row opens on; the facet grids are a click away
   const views = viewsOf(product);
   const index = wrapIndex(Number(row.dataset.view ?? 0), views.length);
@@ -1245,7 +1363,7 @@ function hydrateRow(row, product, now, local, available) {
   const details = row.querySelector('[data-slot="details"]');
   if (product.lead_group_stats?.length || facetRows(product).length) {
     button.hidden = false;
-    details.replaceChildren(buildDetails(product, now, local));
+    details.replaceChildren(buildDetails(product, now, local, groupProducts));
   } else {
     button.hidden = true;
     details.hidden = true;
@@ -1337,6 +1455,7 @@ function renderDashboard(app, dashboard, rows, now) {
   // column, so its width does not depend on the field it holds, and reading all
   // the widths first costs one layout instead of one per product
   const pending = [];
+  const siblings = groupProductsById(dashboard);
   for (const product of productsOf(dashboard)) {
     const row = rows.get(product.id);
     if (!row) continue;
@@ -1344,7 +1463,7 @@ function renderDashboard(app, dashboard, rows, now) {
     pending.push([row, product, body?.getBoundingClientRect().width ?? 0]);
   }
   for (const [row, product, available] of pending) {
-    hydrateRow(row, product, now, local, available);
+    hydrateRow(row, product, now, local, available, siblings.get(product.id));
   }
   renderAdvisories(app, dashboard.advisories ?? [], rows);
 }
@@ -1387,6 +1506,7 @@ function start(app) {
       Date.now(),
       document.body.classList.contains("pipeline-time-local"),
       body?.getBoundingClientRect().width ?? 0,
+      groupProductsById(displayedDashboard).get(product.id),
     );
   }
 
@@ -1485,13 +1605,16 @@ function start(app) {
     if (!latest) return;
     const local = document.body.classList.contains("pipeline-time-local");
     const now = Date.now();
+    const siblings = groupProductsById(latest);
     for (const product of productsOf(latest)) {
       const row = rows.get(product.id);
       if (!row) continue;
       hydrateEta(row, product, now, local);
       const details = row.querySelector('[data-slot="details"]');
       if (!details.hidden) {
-        details.replaceChildren(buildDetails(product, now, local));
+        details.replaceChildren(
+          buildDetails(product, now, local, siblings.get(product.id)),
+        );
       }
     }
   }

--- a/test/e2e/pipeline.spec.mjs
+++ b/test/e2e/pipeline.spec.mjs
@@ -394,6 +394,26 @@ test("details distinguish last, current or upcoming, and historical timings", as
   expect(headings[3]).toMatch(/^time after init · [\d,]+ samples$/);
 });
 
+test("a dynamical row reports lag after its source, not time after init", async ({
+  page,
+}) => {
+  await openPipeline(page);
+  const row = page
+    .locator(".pipeline-row")
+    .filter({ hasText: "dynamical.org · virtual" });
+  await row.locator('[data-slot="details-button"]').click();
+  const table = row.locator(".pipeline-row-details .table-container").first();
+
+  await expect(table.locator("thead tr:first-child th").nth(3)).toHaveText(
+    "lag after source · 8 recent samples",
+  );
+  // the lag replaces the duration column; the time beside it stays wall-clock
+  const cells = table.locator("tbody tr:first-child td");
+  await expect(cells.nth(2)).toHaveText(/^\d{2}:\d{2}$/);
+  await expect(cells.nth(3)).toHaveText("5m");
+  await expect(cells.nth(7)).toHaveText("9m");
+});
+
 test("each details table scrolls itself, under a header that names its column", async ({
   page,
 }) => {

--- a/test/fixtures/pipeline-dashboard.json
+++ b/test/fixtures/pipeline-dashboard.json
@@ -1926,6 +1926,192 @@
           ],
           "next_expected_init": "2026-07-25T18:00:00Z",
           "next_expected_completion_at": "2026-07-25T19:30:00Z"
+        },
+        {
+          "id": "noaa-gfs-forecast-virtual",
+          "label": "NOAA GFS forecast, virtual",
+          "source": "s3://dynamical-noaa-gfs/noaa-gfs-forecast-virtual",
+          "source_label": null,
+          "row_label": "dynamical.org · virtual",
+          "cadence_hours": 6,
+          "init_hours": [
+            "00",
+            "06",
+            "12",
+            "18"
+          ],
+          "lead_groups": [
+            {
+              "name": "forecast",
+              "label": "fc",
+              "leads_in_group": 1,
+              "center_pct": 50
+            }
+          ],
+          "latency_stats": {
+            "p50_s": 4100,
+            "p95_s": 5000,
+            "p99_s": 6100,
+            "sample_init_count": 24
+          },
+          "lead_group_stats": [
+            {
+              "name": "forecast",
+              "label": "fc",
+              "leads_in_group": 1,
+              "p50_s": 4100,
+              "p95_s": 5000,
+              "p99_s": 6100
+            }
+          ],
+          "recent_inits": [
+            {
+              "init_time": "2026-07-23T06:00:00Z",
+              "status": "complete",
+              "timing": "on_time",
+              "completion_pct": 1.0,
+              "latency_s": 4020,
+              "lead_groups": [
+                {
+                  "name": "forecast",
+                  "status": "complete",
+                  "timing": "on_time",
+                  "completion_pct": 1.0,
+                  "latency_s": 4020,
+                  "leads_available": 1,
+                  "leads_expected": 1
+                }
+              ]
+            },
+            {
+              "init_time": "2026-07-23T12:00:00Z",
+              "status": "complete",
+              "timing": "on_time",
+              "completion_pct": 1.0,
+              "latency_s": 4050,
+              "lead_groups": [
+                {
+                  "name": "forecast",
+                  "status": "complete",
+                  "timing": "on_time",
+                  "completion_pct": 1.0,
+                  "latency_s": 4050,
+                  "leads_available": 1,
+                  "leads_expected": 1
+                }
+              ]
+            },
+            {
+              "init_time": "2026-07-23T18:00:00Z",
+              "status": "complete",
+              "timing": "on_time",
+              "completion_pct": 1.0,
+              "latency_s": 4140,
+              "lead_groups": [
+                {
+                  "name": "forecast",
+                  "status": "complete",
+                  "timing": "on_time",
+                  "completion_pct": 1.0,
+                  "latency_s": 4140,
+                  "leads_available": 1,
+                  "leads_expected": 1
+                }
+              ]
+            },
+            {
+              "init_time": "2026-07-24T00:00:00Z",
+              "status": "complete",
+              "timing": "on_time",
+              "completion_pct": 1.0,
+              "latency_s": 4030,
+              "lead_groups": [
+                {
+                  "name": "forecast",
+                  "status": "complete",
+                  "timing": "on_time",
+                  "completion_pct": 1.0,
+                  "latency_s": 4030,
+                  "leads_available": 1,
+                  "leads_expected": 1
+                }
+              ]
+            },
+            {
+              "init_time": "2026-07-24T06:00:00Z",
+              "status": "complete",
+              "timing": "on_time",
+              "completion_pct": 1.0,
+              "latency_s": 4330,
+              "lead_groups": [
+                {
+                  "name": "forecast",
+                  "status": "complete",
+                  "timing": "on_time",
+                  "completion_pct": 1.0,
+                  "latency_s": 4330,
+                  "leads_available": 1,
+                  "leads_expected": 1
+                }
+              ]
+            },
+            {
+              "init_time": "2026-07-24T12:00:00Z",
+              "status": "complete",
+              "timing": "on_time",
+              "completion_pct": 1.0,
+              "latency_s": 4100,
+              "lead_groups": [
+                {
+                  "name": "forecast",
+                  "status": "complete",
+                  "timing": "on_time",
+                  "completion_pct": 1.0,
+                  "latency_s": 4100,
+                  "leads_available": 1,
+                  "leads_expected": 1
+                }
+              ]
+            },
+            {
+              "init_time": "2026-07-24T18:00:00Z",
+              "status": "complete",
+              "timing": "on_time",
+              "completion_pct": 1.0,
+              "latency_s": 4230,
+              "lead_groups": [
+                {
+                  "name": "forecast",
+                  "status": "complete",
+                  "timing": "on_time",
+                  "completion_pct": 1.0,
+                  "latency_s": 4230,
+                  "leads_available": 1,
+                  "leads_expected": 1
+                }
+              ]
+            },
+            {
+              "init_time": "2026-07-25T00:00:00Z",
+              "status": "complete",
+              "timing": "on_time",
+              "completion_pct": 1.0,
+              "latency_s": 6000,
+              "lead_groups": [
+                {
+                  "name": "forecast",
+                  "status": "complete",
+                  "timing": "on_time",
+                  "completion_pct": 1.0,
+                  "latency_s": 6000,
+                  "leads_available": 1,
+                  "leads_expected": 1
+                }
+              ]
+            }
+          ],
+          "next_expected_init": "2026-07-25T06:00:00Z",
+          "next_expected_completion_at": "2026-07-25T07:23:20Z"
         }
       ]
     },

--- a/test/pipeline.test.mjs
+++ b/test/pipeline.test.mjs
@@ -21,6 +21,11 @@ import {
   clockTime,
   detailRows,
   displaySource,
+  isDynamicalRow,
+  lagAt,
+  lagPercentile,
+  lagSeries,
+  sourceRowsOf,
   etaLineText,
   facetRows,
   initColumnPx,
@@ -1047,6 +1052,231 @@ test("facet rows take the timing of the run they describe", () => {
   assert.deepEqual(
     facetRows(product).map(({ status, timing }) => ({ status, timing })),
     [{ status: "processing", timing: "on_time" }],
+  );
+});
+
+/* Ingestion lag. dynamical.org's own rows carry a null `source_label` and sit
+   in the group of the sources they read, so the frontend subtracts: both
+   latencies are seconds after the same init. */
+
+function sourceRow(label, latencies) {
+  return {
+    source_label: label,
+    recent_inits: Object.entries(latencies).map(([init_time, latency_s]) => ({
+      init_time,
+      status: latency_s == null ? "in_flight" : "complete",
+      latency_s,
+      lead_groups: [
+        { status: "complete", latency_s: 900 },
+        { status: latency_s == null ? "in_flight" : "complete", latency_s },
+      ],
+    })),
+  };
+}
+
+function dynamicalRow(latencies) {
+  return {
+    source_label: null,
+    row_label: "dynamical.org · virtual",
+    recent_inits: Object.entries(latencies).map(([init_time, latency_s]) => ({
+      init_time,
+      status: latency_s == null ? "in_flight" : "complete",
+      latency_s,
+      lead_groups: [
+        { status: latency_s == null ? "in_flight" : "complete", latency_s },
+      ],
+    })),
+    lead_group_stats: [{ label: "fc", p50_s: 4100, p95_s: 5000, p99_s: 6100 }],
+    latency_stats: { p50_s: 4100, p95_s: 5000, p99_s: 6100, sample_init_count: 24 },
+  };
+}
+
+test("reads the source rows of a group off the null source label", () => {
+  const aws = sourceRow("AWS", { "2026-07-25T00:00:00Z": 3400 });
+  const virtual = dynamicalRow({ "2026-07-25T00:00:00Z": 4000 });
+
+  assert.deepEqual(sourceRowsOf([aws, virtual]), [aws]);
+  assert.equal(isDynamicalRow(virtual), true);
+  assert.equal(isDynamicalRow(aws), false);
+});
+
+test("splits the HRRR group into its two mirrors and the virtual row", () => {
+  // the shape wxopticon publishes: dynamical's dataset sits in the group of
+  // the sources it reads, and only it carries a null source_label
+  const products = [
+    { id: "external-noaa-hrrr-aws", source_label: "AWS" },
+    { id: "external-noaa-hrrr-ftp", source_label: "NOMADS" },
+    { id: "noaa-hrrr-forecast-48-hour-virtual", source_label: null },
+  ];
+
+  assert.deepEqual(
+    sourceRowsOf(products).map(({ id }) => id),
+    ["external-noaa-hrrr-aws", "external-noaa-hrrr-ftp"],
+  );
+  assert.deepEqual(
+    products.filter(isDynamicalRow).map(({ id }) => id),
+    ["noaa-hrrr-forecast-48-hour-virtual"],
+  );
+});
+
+test("lags a dynamical init behind the earliest source completion", () => {
+  const at = "2026-07-25T00:00:00Z";
+  const aws = sourceRow("AWS", { [at]: 3400 });
+  const nomads = sourceRow("NOMADS", { [at]: 3200 });
+  const [init] = dynamicalRow({ [at]: 4000 }).recent_inits;
+
+  assert.equal(lagAt(init, [aws]), 600);
+  // the earliest publication is the one worth measuring from, so two mirrors
+  // lag from the faster of them
+  assert.equal(lagAt(init, [aws, nomads]), 800);
+  assert.equal(lagAt(init, [nomads, aws]), 800);
+
+  // dynamical can land before a mirror it is not reading
+  const [early] = dynamicalRow({ [at]: 3000 }).recent_inits;
+  assert.equal(lagAt(early, [aws]), -400);
+});
+
+test("has no lag without a completed pair for the init", () => {
+  const at = "2026-07-25T00:00:00Z";
+  const aws = sourceRow("AWS", { [at]: 3400 });
+  const [running] = dynamicalRow({ [at]: null }).recent_inits;
+  const [done] = dynamicalRow({ [at]: 4000 }).recent_inits;
+
+  assert.equal(lagAt(running, [aws]), null); // dynamical still in flight
+  assert.equal(lagAt(done, [sourceRow("AWS", { [at]: null })]), null); // source is
+  assert.equal(lagAt(done, [sourceRow("AWS", { "2026-07-25T06:00:00Z": 3400 })]), null);
+  assert.equal(lagAt(done, []), null);
+  assert.equal(lagAt(null, [aws]), null);
+});
+
+test("takes lag percentiles by nearest rank, and only from a real sample", () => {
+  const lags = [600, 540, 660, 480, 720, 600, 540, 300];
+  assert.equal(lagPercentile(lags, 0.5), 540);
+  assert.equal(lagPercentile(lags, 0.95), 720);
+  assert.equal(lagPercentile(lags, 0.99), 720);
+
+  // one run is a number, not a distribution
+  assert.equal(lagPercentile([600], 0.5), null);
+  assert.equal(lagPercentile([], 0.5), null);
+  assert.equal(lagPercentile([-300, 600], 0.5), -300);
+});
+
+test("details read a dynamical row as lag after its source", () => {
+  const inits = {
+    "2026-07-25T00:00:00Z": 3400,
+    "2026-07-25T06:00:00Z": 3600,
+    "2026-07-25T12:00:00Z": 3500,
+  };
+  const aws = sourceRow("AWS", inits);
+  const virtual = dynamicalRow({
+    "2026-07-25T00:00:00Z": 3400 + 600,
+    "2026-07-25T06:00:00Z": 3600 - 180,
+    "2026-07-25T12:00:00Z": 3500 + 120,
+  });
+  const details = detailRows(
+    virtual,
+    Date.parse("2026-07-25T14:00:00Z"),
+    false,
+    [aws, virtual],
+  );
+
+  assert.equal(details.statsHeader, "lag after source · 3 recent samples");
+  const [row] = details.rows;
+  // the duration column carries the lag; the time beside it still says when
+  // the run finished
+  assert.equal(row.last.duration, "2m");
+  assert.equal(row.last.time, "13:00");
+  assert.equal(lagSeries(virtual, [aws]).length, 3);
+  assert.deepEqual([row.p50, row.p95, row.p99], ["2m", "10m", "10m"]);
+
+  // a single lagged run names its sample in the singular and reports no spread
+  const lone = dynamicalRow({ "2026-07-25T00:00:00Z": 4000 });
+  const only = detailRows(lone, Date.parse("2026-07-25T14:00:00Z"), false, [
+    sourceRow("AWS", { "2026-07-25T00:00:00Z": 3400 }),
+    lone,
+  ]);
+  assert.equal(only.statsHeader, "lag after source · 1 recent sample");
+  assert.deepEqual(
+    [only.rows[0].last.duration, only.rows[0].p50],
+    ["10m", "—"],
+  );
+});
+
+test("renders a negative lag with a sign", () => {
+  const at = "2026-07-25T00:00:00Z";
+  const virtual = dynamicalRow({ [at]: 3220 });
+  const details = detailRows(
+    virtual,
+    Date.parse("2026-07-25T14:00:00Z"),
+    false,
+    [sourceRow("AWS", { [at]: 3400 }), virtual],
+  );
+  assert.equal(details.rows[0].last.duration, "\u22123m");
+});
+
+test("keeps time after init where a row has no source beside it", () => {
+  const at = "2026-07-25T00:00:00Z";
+  const virtual = dynamicalRow({ [at]: 4000 });
+
+  // a dynamical row alone in its group, and the default with no group at all
+  for (const group of [[virtual], undefined]) {
+    const details = detailRows(
+      virtual,
+      Date.parse("2026-07-25T14:00:00Z"),
+      false,
+      group,
+    );
+    assert.equal(details.statsHeader, "time after init · 24 samples");
+    assert.deepEqual(
+      [details.rows[0].last.duration, details.rows[0].p50],
+      ["1h 7m", "1h 8m"],
+    );
+  }
+});
+
+test("leaves an upstream row untouched by a dynamical sibling", () => {
+  const at = "2026-07-25T00:00:00Z";
+  const aws = {
+    ...sourceRow("AWS", { [at]: 3600 }),
+    lead_group_stats: [{ label: "1d", p50_s: 1200, p95_s: 1800, p99_s: 2400 }],
+    latency_stats: { p50_s: 1200, p95_s: 1800, p99_s: 2400, sample_init_count: 30 },
+  };
+  const virtual = dynamicalRow({ [at]: 4000 });
+  const now = Date.parse("2026-07-25T14:00:00Z");
+
+  assert.deepEqual(
+    detailRows(aws, now, false, [aws, virtual]),
+    detailRows(aws, now, false),
+  );
+  assert.equal(
+    detailRows(aws, now, false, [aws, virtual]).statsHeader,
+    "time after init · 30 samples",
+  );
+});
+
+test("local preview fixture carries a dynamical row lagging its source", () => {
+  const fixture = JSON.parse(
+    readFileSync(
+      new URL("./fixtures/pipeline-dashboard.json", import.meta.url),
+      "utf8",
+    ),
+  );
+  validateDashboard(fixture);
+  const group = fixture.groups.find(({ id }) => id === "noaa-gfs");
+  const product = group.products.find(({ source_label }) => source_label == null);
+  assert.equal(product.row_label, "dynamical.org · virtual");
+
+  const details = detailRows(
+    product,
+    Date.parse("2026-07-25T18:00:00Z"),
+    false,
+    group.products,
+  );
+  assert.equal(details.statsHeader, "lag after source · 8 recent samples");
+  assert.equal(details.rows[0].last.duration, "5m");
+  assert.deepEqual(
+    [details.rows[0].p50, details.rows[0].p95, details.rows[0].p99],
+    ["9m", "12m", "12m"],
   );
 });
 


### PR DESCRIPTION
Companion to dynamical-org/wxopticon#214, which publishes dynamical.org's *virtual* dataset rows into `dashboard.json` under the same model heading as the upstream sources they read (e.g. `noaa-hrrr` = AWS, NOMADS, dynamical.org · virtual). Part of dynamical-org/meta#92.

## What changes

For a dynamical.org row (`source_label` null) that has upstream rows in its group, the "more details" table shows **ingestion lag** instead of time after init:

- per run, `lag = dynamical latency_s − min(upstream latency_s)` for the same `init_time`, using only completed runs on both sides; the earliest mirror is the reference, since a lagging mirror says nothing about when the data was available;
- the duration column carries the lag (signed: a virtual store can finish before the stricter full-run definition of the source), the time column keeps the wall-clock completion;
- p50/p95/p99 are nearest-rank percentiles over the ≤10 runs in the payload, and the header says so: `lag after source · N recent samples`. Run-level only: a dynamical row's single lead group and a source's several do not line up, so there is no per-horizon lag.

Only the expanded details table changes. Grid colouring, timing words, the ETA line and the headline row status remain wxopticon's time-after-init classification; this is an observed full-run lag for reading, not an SLA status. A dynamical row with no upstream sibling in its group (the 18-hour HRRR virtual, once wxopticon#215 admits it) and every upstream row keep today's behaviour exactly.

Against the live payload plus the new HRRR virtual row: last run lag 2m, p50 1m, p95/p99 19m (with ten samples p95 and p99 both sit at the maximum; that is the sample size, not a bug).

## Notes

- The percentile baseline is the runs on screen, not wxopticon's published history (that history is time-after-init and cannot be subtracted). If a published lag baseline is wanted later, wxopticon can add it; the header naming its sample keeps the difference visible.
- An in-flight dynamical run shows `—` for duration rather than a counting clock, since the column now measures lag.
- Deploy order: this can go first; without the wxopticon rows it is a no-op.

## Validation

- `npm test` — 178 pass
- `npx playwright test test/e2e/pipeline.spec.mjs` — 15 pass (fixture gained a dynamical row in the `noaa-gfs` group)
- Rendered the live page in headless Chromium with this script and the new payload routed in; no page or console errors.
