### PR TITLE
Describe a late scorecard refresh as a delay, not an outage

### DIFF
--- a/public/status.mjs
+++ b/public/status.mjs
@@ -216,14 +216,20 @@ export function uptimeDescription(measured, days) {
   return measured.delayed > 0 ? `${window} (${measured.delayed}% degraded)` : window;
 }
 
-// What an entry means for a reader, keyed by component id. The impact language
-// is the page's job, not the log's: the log records states; this says what the
-// state did to the thing you use. A component the publisher adds before this
-// page learns it falls back to generic phrasing rather than rendering nothing.
+// Row labels that say what a state means for a particular component, keyed by
+// component id then status. The scorecard updater is a cron whose late or failed
+// run leaves dynamical.org/scorecard serving stale data: a delay, not a
+// degradation of the page. Colour and data-status stay with the state.
 const LABELS = {
   scorecard: { degraded: "Delayed" },
 };
 
+// What an entry means for a reader, keyed by component id. The impact language
+// is the page's job, not the log's: the log records states; this says what the
+// state did to the thing you use. A component the publisher adds before this
+// page learns it falls back to generic phrasing rather than rendering nothing.
+// An `<kind>Ongoing` variant replaces the generic "— ongoing." for an open entry
+// where forward-looking copy is more useful than a dash.
 const IMPACT = {
   "dynamical-org": { outage: "The status page was unreachable" },
   "scorecard-site": { outage: "The scorecard page was unreachable" },

--- a/public/status.mjs
+++ b/public/status.mjs
@@ -162,6 +162,8 @@ export function statusLabel(entry) {
   ) {
     return "Planned outage";
   }
+  const componentLabel = LABELS[entry.id]?.[entry.status];
+  if (componentLabel) return componentLabel;
   return {
     operational: "Operational",
     degraded: "Degraded",
@@ -218,8 +220,13 @@ export function uptimeDescription(measured, days) {
 // is the page's job, not the log's: the log records states; this says what the
 // state did to the thing you use. A component the publisher adds before this
 // page learns it falls back to generic phrasing rather than rendering nothing.
+const LABELS = {
+  scorecard: { degraded: "Delayed" },
+};
+
 const IMPACT = {
   "dynamical-org": { outage: "The status page was unreachable" },
+  "scorecard-site": { outage: "The scorecard page was unreachable" },
   "stac-catalog": { outage: "The STAC catalog API was unreachable" },
   "data-product-reads": {
     outage: "Reads of dynamical.org data failed their canary checks",
@@ -238,7 +245,9 @@ const IMPACT = {
   },
   scorecard: {
     outage: "The scorecard stopped refreshing",
-    delay: "The scorecard refreshed late",
+    delay: "The scorecard updater missed a refresh, leaving its data stale",
+    delayOngoing:
+      "The scorecard updater missed a refresh; data will be delayed until the next successful run",
   },
 };
 
@@ -473,6 +482,8 @@ export function incidentDescription(entry, name) {
   const impact =
     IMPACT[entry.component]?.[kind] ??
     (kind === "delay" ? `${name} ran behind` : `${name} was down`);
+  const ongoingImpact = IMPACT[entry.component]?.[`${kind}Ongoing`];
+  if (!entry.end && ongoingImpact) return `${ongoingImpact}.`;
   return entry.end
     ? `${impact} for ${formatDuration(entry.start, entry.end)}.`
     : `${impact} — ongoing.`;

--- a/test/status.test.mjs
+++ b/test/status.test.mjs
@@ -244,6 +244,18 @@ test("labels a degraded component as a live monitoring gap", () => {
   );
 });
 
+test("labels a degraded scorecard updater as delayed", () => {
+  assert.equal(
+    statusLabel({
+      id: "scorecard",
+      name: "scorecard updater",
+      group: "tool",
+      status: "degraded",
+    }),
+    "Delayed",
+  );
+});
+
 test("rejects malformed live observation metadata", () => {
   const entry = {
     id: "data-product-reads",
@@ -540,6 +552,30 @@ test("incident descriptions say what the state did to the thing you use", () => 
       "Data product reads",
     ),
     "Reads of dynamical.org data failed their canary checks for 10 minutes.",
+  );
+});
+
+test("incident descriptions distinguish scorecard delays from page outages", () => {
+  const scorecardDelay = {
+    component: "scorecard",
+    kind: "delay",
+    start: Date.parse("2026-07-29T17:10:00Z"),
+    end: Date.parse("2026-07-29T17:20:00Z"),
+  };
+  assert.equal(
+    incidentDescription(scorecardDelay, "scorecard updater"),
+    "The scorecard updater missed a refresh, leaving its data stale for 10 minutes.",
+  );
+  assert.equal(
+    incidentDescription({ ...scorecardDelay, end: null }, "scorecard updater"),
+    "The scorecard updater missed a refresh; data will be delayed until the next successful run.",
+  );
+  assert.equal(
+    incidentDescription(
+      { ...scorecardDelay, component: "scorecard-site", kind: "outage" },
+      "scorecard page",
+    ),
+    "The scorecard page was unreachable for 10 minutes.",
   );
 });
 


### PR DESCRIPTION
Companion to dynamical-org/dynamical.org-data#35, which scores a late or failed
`scorecard-daily` run as `degraded` (the row becomes "scorecard updater") and
reserves a `scorecard-site` component for a future uptime detector on
`/scorecard/`.

## Changes

- `scorecard` degraded rows are labelled **Delayed**; colour and `data-status`
  are unchanged.
- Incident-log copy for an ongoing scorecard delay: "The scorecard updater
  missed a refresh; data will be delayed until the next successful run."
  Ended delays read "…missed a refresh, leaving its data stale for 3 hours."
- Historical `scorecard` outages keep "The scorecard stopped refreshing": those
  spans were worker failures recorded under the old policy, and must not be
  relabelled as page outages.
- `scorecard-site` outages read "The scorecard page was unreachable".
- `incidentDescription` gains an optional `<kind>Ongoing` impact variant; all
  existing fallbacks are unchanged.

## Verification

`npm test`: 170 pass, 0 fail.