### PR TITLE
Group scorecard web and updater status

### DIFF
--- a/content/status.njk
+++ b/content/status.njk
@@ -25,6 +25,9 @@ statusSection: uptime
   .status-list h3 {
     margin: 0;
   }
+  .status-component-group-member {
+    margin-top: 1rem;
+  }
   .status-list p {
     margin: 0.4rem 0 0;
     color: var(--muted-text);

--- a/public/status.mjs
+++ b/public/status.mjs
@@ -495,36 +495,82 @@ export function incidentDescription(entry, name) {
     : `${impact} — ongoing.`;
 }
 
+const SCORECARD_PARTS = [
+  ["scorecard-site", "web"],
+  ["scorecard", "updater"],
+];
+
+export function statusEntryGroups(entries) {
+  const byId = new Map(entries.map((entry) => [entry.id, entry]));
+  if (!SCORECARD_PARTS.every(([id]) => byId.has(id))) {
+    return entries.map((entry) => ({ entries: [entry] }));
+  }
+
+  const groupedIds = new Set(SCORECARD_PARTS.map(([id]) => id));
+  const first = entries.findIndex((entry) => groupedIds.has(entry.id));
+  return entries.flatMap((entry, index) => {
+    if (index === first) {
+      return [
+        {
+          name: "scorecard",
+          entries: SCORECARD_PARTS.map(([id, name]) => ({
+            ...byId.get(id),
+            name,
+          })),
+        },
+      ];
+    }
+    return groupedIds.has(entry.id) ? [] : [{ entries: [entry] }];
+  });
+}
+
+function renderStatusEntry(container, entry, bars, uptime, emptyCells, grouped) {
+  const header = document.createElement("header");
+  const name = document.createElement(grouped ? "span" : "h3");
+  const state = document.createElement("span");
+  // The glyph duplicates the adjacent label, so keep it out of the
+  // accessibility tree instead of announcing "black circle Operational".
+  const mark = document.createElement("span");
+
+  container.dataset.status = entry.status;
+  if (entry.maintenance?.kind) container.dataset.kind = entry.maintenance.kind;
+  if (entry.observation?.kind) container.dataset.kind = entry.observation.kind;
+  name.textContent = entry.name;
+  state.className = "status-label";
+  mark.setAttribute("aria-hidden", "true");
+  mark.textContent = statusMark(entry);
+  state.append(mark, ` ${statusLabel(entry)}`);
+  header.append(name, state);
+  container.append(header);
+
+  const cells = bars?.get(entry.id) ?? emptyCells;
+  const measured = uptime?.get(entry.id);
+  if (cells?.length && measured) {
+    const detail = document.createElement("p");
+    detail.textContent = uptimeDescription(measured, cells.length);
+    container.append(detail);
+  }
+  if (cells?.length) container.append(barStrip(cells));
+}
+
 function renderGroup(list, entries, bars, uptime, emptyCells) {
   list.replaceChildren();
-  for (const entry of entries) {
+  for (const group of statusEntryGroups(entries)) {
     const item = document.createElement("li");
-    const header = document.createElement("header");
-    const name = document.createElement("h3");
-    const state = document.createElement("span");
-    // The glyph duplicates the adjacent label, so keep it out of the
-    // accessibility tree instead of announcing "black circle Operational".
-    const mark = document.createElement("span");
-
-    item.dataset.status = entry.status;
-    if (entry.maintenance?.kind) item.dataset.kind = entry.maintenance.kind;
-    if (entry.observation?.kind) item.dataset.kind = entry.observation.kind;
-    name.textContent = entry.name;
-    state.className = "status-label";
-    mark.setAttribute("aria-hidden", "true");
-    mark.textContent = statusMark(entry);
-    state.append(mark, ` ${statusLabel(entry)}`);
-    header.append(name, state);
-    item.append(header);
-
-    const cells = bars?.get(entry.id) ?? emptyCells;
-    const measured = uptime?.get(entry.id);
-    if (cells?.length && measured) {
-      const detail = document.createElement("p");
-      detail.textContent = uptimeDescription(measured, cells.length);
-      item.append(detail);
+    if (group.name) {
+      const name = document.createElement("h3");
+      name.textContent = group.name;
+      item.className = "status-component-group";
+      item.append(name);
+      for (const entry of group.entries) {
+        const component = document.createElement("div");
+        component.className = "status-component-group-member";
+        renderStatusEntry(component, entry, bars, uptime, emptyCells, true);
+        item.append(component);
+      }
+    } else {
+      renderStatusEntry(item, group.entries[0], bars, uptime, emptyCells, false);
     }
-    if (cells?.length) item.append(barStrip(cells));
     list.append(item);
   }
 }

--- a/test/fixtures/events.jsonl
+++ b/test/fixtures/events.jsonl
@@ -11,4 +11,5 @@
 {"ts":"2026-07-19T19:55:00Z","kind":"coverage","component":"scorecard","monitored":true,"state":"operational"}
 {"ts":"2026-07-21T13:55:00Z","kind":"transition","component":"stac-catalog","to":"down"}
 {"ts":"2026-07-21T14:55:00Z","kind":"transition","component":"stac-catalog","to":"operational"}
+{"ts":"2026-07-24T14:55:00Z","kind":"coverage","component":"scorecard-site","monitored":true,"state":"operational"}
 {"ts":"2026-07-24T14:55:00Z","kind":"transition","component":"data-product-reads","to":"down"}

--- a/test/fixtures/status.json
+++ b/test/fixtures/status.json
@@ -98,8 +98,14 @@
       "status": "down"
     },
     {
-      "id": "scorecard",
+      "id": "scorecard-site",
       "name": "scorecard",
+      "group": "tool",
+      "status": "operational"
+    },
+    {
+      "id": "scorecard",
+      "name": "scorecard updater",
       "group": "tool",
       "status": "operational"
     },

--- a/test/status.test.mjs
+++ b/test/status.test.mjs
@@ -11,6 +11,7 @@ import {
   isHistoryCurrent,
   isStatusDataStale,
   overlappingEntries,
+  statusEntryGroups,
   statusLabel,
   STALE_MESSAGE,
   summarizeOverallStatus,
@@ -59,6 +60,7 @@ test("accepts the published feed shape", () => {
     [
       ["stac-catalog", "endpoint"],
       ["data-product-reads", "endpoint"],
+      ["scorecard-site", "tool"],
       ["scorecard", "tool"],
       ["wxopticon-arrivals", "tool"],
       ["wxopticon-webhooks", "tool"],
@@ -77,12 +79,49 @@ test("keeps the experimental wxopticon components off the page", () => {
   const data = withoutExperimentalComponents(validateStatusData(fixture));
   assert.deepEqual(
     data.endpoints.map((entry) => entry.id),
-    ["stac-catalog", "data-product-reads", "scorecard", "dynamical-org"],
+    [
+      "stac-catalog",
+      "data-product-reads",
+      "scorecard-site",
+      "scorecard",
+      "dynamical-org",
+    ],
   );
   // Dropping them from the component list is what hides their bars and their
   // incident-log entries; the rest of the document stays as published.
   assert.deepEqual(data.datasets, fixture.datasets);
   assert.deepEqual(data.component_aliases, fixture.component_aliases);
+});
+
+test("groups scorecard web and updater rows under one scorecard heading", () => {
+  const web = {
+    id: "scorecard-site",
+    name: "scorecard",
+    group: "tool",
+    status: "operational",
+  };
+  const updater = {
+    id: "scorecard",
+    name: "scorecard updater",
+    group: "tool",
+    status: "degraded",
+  };
+  const statusPage = operationalData.endpoints[0];
+
+  assert.deepEqual(statusEntryGroups([web, updater, statusPage]), [
+    {
+      name: "scorecard",
+      entries: [
+        { ...web, name: "web" },
+        { ...updater, name: "updater" },
+      ],
+    },
+    { entries: [statusPage] },
+  ]);
+  assert.deepEqual(statusEntryGroups([updater, statusPage]), [
+    { entries: [updater] },
+    { entries: [statusPage] },
+  ]);
 });
 
 test("an experimental component's state does not move the rollup", () => {


### PR DESCRIPTION
Companion presentation change for dynamical-org/dynamical.org-data#36.

## Change

- Group `scorecard-site` and `scorecard` into one status-list item headed **scorecard**.
- Render the two components as plain-text **web** and **updater** subrows.
- Keep each subrow's independent state pill, uptime description, and 90-day bars.
- Fall back to the existing standalone row when an older feed provides only one component.
- Update the local status fixtures to exercise both scorecard components and their histories.

The feed schema, component IDs, incident history, and uptime calculations are unchanged.

## Verification

- `npm test`
- Fixture-backed Eleventy build
- Desktop browser screenshot verified: labels appear directly above their respective uptime descriptions and bars
