### PR TITLE
Keep pipeline details scrolled across the live refresh

### DIFF
--- a/public/pipeline.mjs
+++ b/public/pipeline.mjs
@@ -1249,8 +1249,15 @@ function replaceDetails(details, node) {
 // its state line says why, so the silence does not read as on time
 export function timingBaselineNote(product) {
   const baseline = product.timing_baseline;
-  if (baseline?.status !== "insufficient_history") return null;
-  return `insufficient history (${baseline.history_days}/${baseline.required_history_days} days)`;
+  if (
+    baseline?.status !== "insufficient_history" ||
+    !Number.isInteger(baseline.history_days) ||
+    !Number.isInteger(baseline.required_history_days)
+  ) {
+    return null;
+  }
+  const { history_days: days, required_history_days: required } = baseline;
+  return `insufficient history (${days}/${required} days)`;
 }
 
 function buildDetails(product, now, local, groupProducts) {

--- a/public/pipeline.mjs
+++ b/public/pipeline.mjs
@@ -1006,10 +1006,13 @@ function statsHeader(sampleInitCount, note = null) {
 
 // A lag has no published baseline behind it, so its sample is the handful of
 // runs the payload carries — named apart from the upstream rows' own count.
-function lagStatsHeader(sampleCount) {
+// The note beside it is about the row's own arrival baseline, not the lag
+// sample: the lag stays, but without that baseline the run gets no timing.
+function lagStatsHeader(sampleCount, note = null) {
   if (!sampleCount) return "lag after source";
   const samples = sampleCount === 1 ? "recent sample" : "recent samples";
-  return `lag after source · ${sampleCount.toLocaleString("en-US")} ${samples}`;
+  const header = `lag after source · ${sampleCount.toLocaleString("en-US")} ${samples}`;
+  return note ? `${header} · ${note}` : header;
 }
 
 const NO_RUN = Object.freeze({
@@ -1151,7 +1154,7 @@ export function detailRows(product, now, local, groupProducts = []) {
       ? labelledRun("current run", active.init_time, local)
       : labelledRun("upcoming run", upcoming, local),
     statsHeader: lagged
-      ? lagStatsHeader(lags.length)
+      ? lagStatsHeader(lags.length, timingBaselineNote(product))
       : statsHeader(
           product.latency_stats?.sample_init_count,
           timingBaselineNote(product),

--- a/public/pipeline.mjs
+++ b/public/pipeline.mjs
@@ -1233,6 +1233,26 @@ function scrollable(table) {
   return element("div", { class: "table-container" }, [table]);
 }
 
+// open details are rebuilt once a second so their durations tick; each rebuild
+// would otherwise hand the reader a fresh scroll box parked at the left edge
+function replaceDetails(details, node) {
+  const offsets = [...details.querySelectorAll(".table-container")].map(
+    (container) => container.scrollLeft,
+  );
+  details.replaceChildren(node);
+  details.querySelectorAll(".table-container").forEach((container, index) => {
+    if (offsets[index]) container.scrollLeft = offsets[index];
+  });
+}
+
+// a product too new for a statistical delayed threshold publishes no timing;
+// its state line says why, so the silence does not read as on time
+export function timingBaselineNote(product) {
+  const baseline = product.timing_baseline;
+  if (baseline?.status !== "insufficient_history") return null;
+  return `insufficient history (${baseline.history_days}/${baseline.required_history_days} days)`;
+}
+
 function buildDetails(product, now, local, groupProducts) {
   const details = detailRows(product, now, local, groupProducts);
   const groupHead = element("tr", null, [
@@ -1363,7 +1383,7 @@ function hydrateRow(row, product, now, local, available, groupProducts) {
   const details = row.querySelector('[data-slot="details"]');
   if (product.lead_group_stats?.length || facetRows(product).length) {
     button.hidden = false;
-    details.replaceChildren(buildDetails(product, now, local, groupProducts));
+    replaceDetails(details, buildDetails(product, now, local, groupProducts));
   } else {
     button.hidden = true;
     details.hidden = true;
@@ -1390,6 +1410,8 @@ function hydrateEta(row, product, now, local) {
         stateSlot.dataset.timing = target.init.timing;
       } else {
         delete stateSlot.dataset.timing;
+        const note = timingBaselineNote(product);
+        if (note) stateSlot.textContent += ` · ${note}`;
       }
     } else {
       const seconds = Math.floor((Date.parse(target.initTime) - now) / 1000);
@@ -1612,7 +1634,8 @@ function start(app) {
       hydrateEta(row, product, now, local);
       const details = row.querySelector('[data-slot="details"]');
       if (!details.hidden) {
-        details.replaceChildren(
+        replaceDetails(
+          details,
           buildDetails(product, now, local, siblings.get(product.id)),
         );
       }

--- a/public/pipeline.mjs
+++ b/public/pipeline.mjs
@@ -996,10 +996,12 @@ export function etaLineText(target, now, local) {
 
 // The percentile columns summarise every init in the historical baseline, not
 // just the runs the grid draws, so the header names the sample they came from.
-function statsHeader(sampleInitCount) {
+function statsHeader(sampleInitCount, note = null) {
   if (!sampleInitCount) return "time after init";
   const samples = sampleInitCount === 1 ? "sample" : "samples";
-  return `time after init · ${sampleInitCount.toLocaleString("en-US")} ${samples}`;
+  const header = `time after init · ${sampleInitCount.toLocaleString("en-US")} ${samples}`;
+  // the sample is thin, so the columns beside it come with no timing verdict
+  return note ? `${header} · ${note}` : header;
 }
 
 // A lag has no published baseline behind it, so its sample is the handful of
@@ -1150,7 +1152,10 @@ export function detailRows(product, now, local, groupProducts = []) {
       : labelledRun("upcoming run", upcoming, local),
     statsHeader: lagged
       ? lagStatsHeader(lags.length)
-      : statsHeader(product.latency_stats?.sample_init_count),
+      : statsHeader(
+          product.latency_stats?.sample_init_count,
+          timingBaselineNote(product),
+        ),
     rows: (product.lead_group_stats ?? []).map((stats, index) => {
       return {
         label: stats.label,

--- a/test/e2e/pipeline.spec.mjs
+++ b/test/e2e/pipeline.spec.mjs
@@ -481,6 +481,53 @@ test("the same status reads the same color in both details tables", async ({
   expect(new Set(colors)).toEqual(new Set(["rgb(91, 197, 74)"]));
 });
 
+// Open details are rebuilt once a second so their elapsed durations tick; the
+// rebuild used to recreate each table's scroll box and so snap it back to the
+// left edge every tick, which made a wide table impossible to read.
+test("details keep their horizontal scroll across the live refresh", async ({
+  page,
+}) => {
+  const row = await openPipeline(page);
+  await row.locator('[data-slot="details-button"]').click();
+  const table = row.locator(".pipeline-row-details .table-container").first();
+
+  const scrolled = await table.evaluate((node) => {
+    node.scrollLeft = 120;
+    return node.scrollLeft;
+  });
+  expect(scrolled).toBeGreaterThan(0);
+  // long enough for the countdown to rebuild the details more than once
+  await page.waitForTimeout(2500);
+  await expect(table).toHaveJSProperty("scrollLeft", scrolled);
+});
+
+// A product too new for a statistical delayed threshold publishes no timing at
+// all; the state line says why rather than reading as if the run were on time.
+test("a product without enough history says so instead of a timing", async ({
+  page,
+}) => {
+  const row = await openPipeline(page, (payload) => {
+    const product = payload.groups[0].products[0];
+    product.timing_baseline = {
+      status: "insufficient_history",
+      history_days: 23,
+      required_history_days: 30,
+    };
+    const running = product.recent_inits.findLast(
+      (init) => init.status === "in_flight",
+    );
+    delete running.timing;
+    for (const group of running.lead_groups ?? []) delete group.timing;
+    return payload;
+  });
+
+  const state = row.locator('[data-slot="eta-state"]');
+  await expect(state).toHaveText(
+    "processing · insufficient history (23/30 days)",
+  );
+  await expect(state).not.toHaveAttribute("data-timing");
+});
+
 test("pipeline exposes no history scrubber", async ({ page }) => {
   await openPipeline(page);
   await expect(page.locator("#pipeline-history-toggle")).toHaveCount(0);

--- a/test/e2e/pipeline.spec.mjs
+++ b/test/e2e/pipeline.spec.mjs
@@ -405,7 +405,7 @@ test("a dynamical row reports lag after its source, not time after init", async 
   const table = row.locator(".pipeline-row-details .table-container").first();
 
   await expect(table.locator("thead tr:first-child th").nth(3)).toHaveText(
-    "lag after source · 8 recent samples",
+    "lag after source · 8 recent samples · insufficient history (24/30 days)",
   );
   // the lag replaces the duration column; the time beside it stays wall-clock
   const cells = table.locator("tbody tr:first-child td");

--- a/test/e2e/pipeline.spec.mjs
+++ b/test/e2e/pipeline.spec.mjs
@@ -499,6 +499,11 @@ test("details keep their horizontal scroll across the live refresh", async ({
   // long enough for the countdown to rebuild the details more than once
   await page.waitForTimeout(2500);
   await expect(table).toHaveJSProperty("scrollLeft", scrolled);
+
+  // the poll and view cycling rebuild the row through another path
+  await row.locator(".pipeline-viz").click();
+  await expect(row).toHaveAttribute("data-view", "1");
+  await expect(table).toHaveJSProperty("scrollLeft", scrolled);
 });
 
 // A product too new for a statistical delayed threshold publishes no timing at

--- a/test/e2e/pipeline.spec.mjs
+++ b/test/e2e/pipeline.spec.mjs
@@ -496,11 +496,14 @@ test("details keep their horizontal scroll across the live refresh", async ({
     return node.scrollLeft;
   });
   expect(scrolled).toBeGreaterThan(0);
-  // long enough for the countdown to rebuild the details more than once
-  await page.waitForTimeout(2500);
+  // wait for the countdown's rebuild to have actually replaced the table,
+  // rather than for the clock, then read the position off its replacement
+  const before = await table.elementHandle();
+  await page.waitForFunction((node) => !node.isConnected, before);
   await expect(table).toHaveJSProperty("scrollLeft", scrolled);
 
-  // the poll and view cycling rebuild the row through another path
+  // view cycling rebuilds the row through hydrateRow, the path the dashboard
+  // poll, a resize, and the time-zone toggle share
   await row.locator(".pipeline-viz").click();
   await expect(row).toHaveAttribute("data-view", "1");
   await expect(table).toHaveJSProperty("scrollLeft", scrolled);

--- a/test/fixtures/pipeline-dashboard.json
+++ b/test/fixtures/pipeline-dashboard.json
@@ -83,7 +83,13 @@
             "p50_s": 3600,
             "p95_s": 5400,
             "p99_s": 6000,
-            "sample_init_count": 30
+            "sample_init_count": 30,
+            "sample_day_count": 30
+          },
+          "timing_baseline": {
+            "status": "established",
+            "history_days": 30,
+            "required_history_days": 30
           },
           "lead_group_stats": [
             {
@@ -1952,7 +1958,13 @@
             "p50_s": 4100,
             "p95_s": 5000,
             "p99_s": 6100,
-            "sample_init_count": 24
+            "sample_init_count": 24,
+            "sample_day_count": 24
+          },
+          "timing_baseline": {
+            "status": "insufficient_history",
+            "history_days": 24,
+            "required_history_days": 30
           },
           "lead_group_stats": [
             {
@@ -1968,14 +1980,12 @@
             {
               "init_time": "2026-07-23T06:00:00Z",
               "status": "complete",
-              "timing": "on_time",
               "completion_pct": 1.0,
               "latency_s": 4020,
               "lead_groups": [
                 {
                   "name": "forecast",
                   "status": "complete",
-                  "timing": "on_time",
                   "completion_pct": 1.0,
                   "latency_s": 4020,
                   "leads_available": 1,
@@ -1986,14 +1996,12 @@
             {
               "init_time": "2026-07-23T12:00:00Z",
               "status": "complete",
-              "timing": "on_time",
               "completion_pct": 1.0,
               "latency_s": 4050,
               "lead_groups": [
                 {
                   "name": "forecast",
                   "status": "complete",
-                  "timing": "on_time",
                   "completion_pct": 1.0,
                   "latency_s": 4050,
                   "leads_available": 1,
@@ -2004,14 +2012,12 @@
             {
               "init_time": "2026-07-23T18:00:00Z",
               "status": "complete",
-              "timing": "on_time",
               "completion_pct": 1.0,
               "latency_s": 4140,
               "lead_groups": [
                 {
                   "name": "forecast",
                   "status": "complete",
-                  "timing": "on_time",
                   "completion_pct": 1.0,
                   "latency_s": 4140,
                   "leads_available": 1,
@@ -2022,14 +2028,12 @@
             {
               "init_time": "2026-07-24T00:00:00Z",
               "status": "complete",
-              "timing": "on_time",
               "completion_pct": 1.0,
               "latency_s": 4030,
               "lead_groups": [
                 {
                   "name": "forecast",
                   "status": "complete",
-                  "timing": "on_time",
                   "completion_pct": 1.0,
                   "latency_s": 4030,
                   "leads_available": 1,
@@ -2040,14 +2044,12 @@
             {
               "init_time": "2026-07-24T06:00:00Z",
               "status": "complete",
-              "timing": "on_time",
               "completion_pct": 1.0,
               "latency_s": 4330,
               "lead_groups": [
                 {
                   "name": "forecast",
                   "status": "complete",
-                  "timing": "on_time",
                   "completion_pct": 1.0,
                   "latency_s": 4330,
                   "leads_available": 1,
@@ -2058,14 +2060,12 @@
             {
               "init_time": "2026-07-24T12:00:00Z",
               "status": "complete",
-              "timing": "on_time",
               "completion_pct": 1.0,
               "latency_s": 4100,
               "lead_groups": [
                 {
                   "name": "forecast",
                   "status": "complete",
-                  "timing": "on_time",
                   "completion_pct": 1.0,
                   "latency_s": 4100,
                   "leads_available": 1,
@@ -2076,14 +2076,12 @@
             {
               "init_time": "2026-07-24T18:00:00Z",
               "status": "complete",
-              "timing": "on_time",
               "completion_pct": 1.0,
               "latency_s": 4230,
               "lead_groups": [
                 {
                   "name": "forecast",
                   "status": "complete",
-                  "timing": "on_time",
                   "completion_pct": 1.0,
                   "latency_s": 4230,
                   "leads_available": 1,
@@ -2094,14 +2092,12 @@
             {
               "init_time": "2026-07-25T00:00:00Z",
               "status": "complete",
-              "timing": "on_time",
               "completion_pct": 1.0,
               "latency_s": 6000,
               "lead_groups": [
                 {
                   "name": "forecast",
                   "status": "complete",
-                  "timing": "on_time",
                   "completion_pct": 1.0,
                   "latency_s": 6000,
                   "leads_available": 1,
@@ -2156,7 +2152,13 @@
             "p50_s": 13440,
             "p95_s": 13440,
             "p99_s": 13440,
-            "sample_init_count": 1
+            "sample_init_count": 1,
+            "sample_day_count": 1
+          },
+          "timing_baseline": {
+            "status": "insufficient_history",
+            "history_days": 1,
+            "required_history_days": 30
           },
           "lead_group_stats": [
             {
@@ -2188,14 +2190,12 @@
             {
               "init_time": "2026-07-24T12:00:00Z",
               "status": "complete",
-              "timing": "on_time",
               "completion_pct": 1.0,
               "latency_s": 13440,
               "lead_groups": [
                 {
                   "name": "f000",
                   "status": "complete",
-                  "timing": "on_time",
                   "completion_pct": 1.0,
                   "latency_s": 13200,
                   "leads_available": 1,
@@ -2204,7 +2204,6 @@
                 {
                   "name": "f024",
                   "status": "complete",
-                  "timing": "on_time",
                   "completion_pct": 1.0,
                   "latency_s": 13200,
                   "leads_available": 25,
@@ -2213,7 +2212,6 @@
                 {
                   "name": "f048",
                   "status": "complete",
-                  "timing": "on_time",
                   "completion_pct": 1.0,
                   "latency_s": 13440,
                   "leads_available": 49,
@@ -2224,14 +2222,12 @@
             {
               "init_time": "2026-07-24T18:00:00Z",
               "status": "complete",
-              "timing": "on_time",
               "completion_pct": 1.0,
               "latency_s": 13440,
               "lead_groups": [
                 {
                   "name": "f000",
                   "status": "complete",
-                  "timing": "on_time",
                   "completion_pct": 1.0,
                   "latency_s": 13200,
                   "leads_available": 1,
@@ -2240,7 +2236,6 @@
                 {
                   "name": "f024",
                   "status": "complete",
-                  "timing": "on_time",
                   "completion_pct": 1.0,
                   "latency_s": 13200,
                   "leads_available": 25,
@@ -2249,7 +2244,6 @@
                 {
                   "name": "f048",
                   "status": "complete",
-                  "timing": "on_time",
                   "completion_pct": 1.0,
                   "latency_s": 13440,
                   "leads_available": 49,
@@ -2260,14 +2254,12 @@
             {
               "init_time": "2026-07-25T00:00:00Z",
               "status": "complete",
-              "timing": "on_time",
               "completion_pct": 1.0,
               "latency_s": 13440,
               "lead_groups": [
                 {
                   "name": "f000",
                   "status": "complete",
-                  "timing": "on_time",
                   "completion_pct": 1.0,
                   "latency_s": 13200,
                   "leads_available": 1,
@@ -2276,7 +2268,6 @@
                 {
                   "name": "f024",
                   "status": "complete",
-                  "timing": "on_time",
                   "completion_pct": 1.0,
                   "latency_s": 13200,
                   "leads_available": 25,
@@ -2285,7 +2276,6 @@
                 {
                   "name": "f048",
                   "status": "complete",
-                  "timing": "on_time",
                   "completion_pct": 1.0,
                   "latency_s": 13440,
                   "leads_available": 49,
@@ -2296,14 +2286,12 @@
             {
               "init_time": "2026-07-25T06:00:00Z",
               "status": "complete",
-              "timing": "on_time",
               "completion_pct": 1.0,
               "latency_s": 13440,
               "lead_groups": [
                 {
                   "name": "f000",
                   "status": "complete",
-                  "timing": "on_time",
                   "completion_pct": 1.0,
                   "latency_s": 13200,
                   "leads_available": 1,
@@ -2312,7 +2300,6 @@
                 {
                   "name": "f024",
                   "status": "complete",
-                  "timing": "on_time",
                   "completion_pct": 1.0,
                   "latency_s": 13200,
                   "leads_available": 25,
@@ -2321,7 +2308,6 @@
                 {
                   "name": "f048",
                   "status": "complete",
-                  "timing": "on_time",
                   "completion_pct": 1.0,
                   "latency_s": 13440,
                   "leads_available": 49,
@@ -2332,14 +2318,12 @@
             {
               "init_time": "2026-07-25T12:00:00Z",
               "status": "complete",
-              "timing": "on_time",
               "completion_pct": 1.0,
               "latency_s": 13440,
               "lead_groups": [
                 {
                   "name": "f000",
                   "status": "complete",
-                  "timing": "on_time",
                   "completion_pct": 1.0,
                   "latency_s": 13200,
                   "leads_available": 1,
@@ -2348,7 +2332,6 @@
                 {
                   "name": "f024",
                   "status": "complete",
-                  "timing": "on_time",
                   "completion_pct": 1.0,
                   "latency_s": 13200,
                   "leads_available": 25,
@@ -2357,7 +2340,6 @@
                 {
                   "name": "f048",
                   "status": "complete",
-                  "timing": "on_time",
                   "completion_pct": 1.0,
                   "latency_s": 13440,
                   "leads_available": 49,

--- a/test/pipeline.test.mjs
+++ b/test/pipeline.test.mjs
@@ -1335,12 +1335,6 @@ test("local preview fixture carries a source-only group", () => {
 
   const [product] = group.products;
   assert.equal(product.row_label, "MSC Datamart");
-  // one sample is no baseline: the header says so where the percentiles sit,
-  // which is the only place the product explains itself between runs
-  assert.equal(
-    detailRows(product, Date.parse("2026-07-25T18:00:00Z"), false).statsHeader,
-    "time after init · 1 sample · insufficient history (1/30 days)",
-  );
   assert.equal(displaySource(product.source), "dd.weather.gc.ca");
   assert.equal(product.facet_groups, undefined);
   assert.equal(viewsOf(product).length, 1);
@@ -1348,9 +1342,11 @@ test("local preview fixture carries a source-only group", () => {
     (product.lead_group_stats ?? []).map(({ label }) => label),
     ["0h", "1d", "2d"],
   );
+  // one sample is no baseline: the header says so where the percentiles sit,
+  // the one place the product explains itself between runs
   assert.equal(
     detailRows(product, Date.parse("2026-07-25T18:00:00Z"), false).statsHeader,
-    "time after init \u00b7 1 sample",
+    "time after init \u00b7 1 sample \u00b7 insufficient history (1/30 days)",
   );
 });
 

--- a/test/pipeline.test.mjs
+++ b/test/pipeline.test.mjs
@@ -1335,6 +1335,12 @@ test("local preview fixture carries a source-only group", () => {
 
   const [product] = group.products;
   assert.equal(product.row_label, "MSC Datamart");
+  // one sample is no baseline: the header says so where the percentiles sit,
+  // which is the only place the product explains itself between runs
+  assert.equal(
+    detailRows(product, Date.parse("2026-07-25T18:00:00Z"), false).statsHeader,
+    "time after init · 1 sample · insufficient history (1/30 days)",
+  );
   assert.equal(displaySource(product.source), "dd.weather.gc.ca");
   assert.equal(product.facet_groups, undefined);
   assert.equal(viewsOf(product).length, 1);

--- a/test/pipeline.test.mjs
+++ b/test/pipeline.test.mjs
@@ -31,6 +31,7 @@ import {
   initColumnPx,
   initParts,
   selectedTimeZone,
+  timingBaselineNote,
   validateDashboard,
 } from "../public/pipeline.mjs";
 import { onRequestGet } from "../functions/pipeline-staging/[[path]].js";
@@ -1252,6 +1253,27 @@ test("leaves an upstream row untouched by a dynamical sibling", () => {
     detailRows(aws, now, false, [aws, virtual]).statsHeader,
     "time after init · 30 samples",
   );
+});
+
+test("a product without enough history says so, and an established one says nothing", () => {
+  assert.equal(
+    timingBaselineNote({
+      timing_baseline: {
+        status: "insufficient_history",
+        history_days: 23,
+        required_history_days: 30,
+      },
+    }),
+    "insufficient history (23/30 days)",
+  );
+  assert.equal(
+    timingBaselineNote({
+      timing_baseline: { status: "established", history_days: 41, required_history_days: 30 },
+    }),
+    null,
+  );
+  // a payload from before the baseline was published
+  assert.equal(timingBaselineNote({}), null);
 });
 
 test("local preview fixture carries a dynamical row lagging its source", () => {

--- a/test/pipeline.test.mjs
+++ b/test/pipeline.test.mjs
@@ -1299,7 +1299,11 @@ test("local preview fixture carries a dynamical row lagging its source", () => {
     false,
     group.products,
   );
-  assert.equal(details.statsHeader, "lag after source · 8 recent samples");
+  // the lag stays; the note says why the run beside it carries no timing
+  assert.equal(
+    details.statsHeader,
+    "lag after source · 8 recent samples · insufficient history (24/30 days)",
+  );
   assert.equal(details.rows[0].last.duration, "5m");
   assert.deepEqual(
     [details.rows[0].p50, details.rows[0].p95, details.rows[0].p99],

--- a/test/pipeline.test.mjs
+++ b/test/pipeline.test.mjs
@@ -1272,8 +1272,13 @@ test("a product without enough history says so, and an established one says noth
     }),
     null,
   );
-  // a payload from before the baseline was published
+  // a payload from before the baseline was published, or a malformed one,
+  // renders as it always has rather than as "undefined/undefined days"
   assert.equal(timingBaselineNote({}), null);
+  assert.equal(
+    timingBaselineNote({ timing_baseline: { status: "insufficient_history" } }),
+    null,
+  );
 });
 
 test("local preview fixture carries a dynamical row lagging its source", () => {


### PR DESCRIPTION
## Plan

Two items on `/status/pipeline/`.

### 1. Details table scroll resets every second

- [x] **Root cause.** `public/pipeline.mjs` `updateLiveCountdowns` runs on a 1s `setInterval` and, for every row whose details are open, calls `details.replaceChildren(buildDetails(...))`. `buildDetails` wraps each table in a fresh `.table-container`, so the scrolled element is thrown away and its replacement starts at `scrollLeft = 0`. `hydrateRow` (the 15s dashboard poll and view cycling) rebuilds the same way.
- [x] **Fix.** One `replaceDetails(details, node)` helper records each `.table-container`'s `scrollLeft` by index, swaps the children, and restores the offsets. Used at both call sites.
- [x] **Verified in a browser.** New Playwright spec "details keep their horizontal scroll across the live refresh": opens details, scrolls the lead table, waits 2.5s (two rebuilds), asserts the offset survived. It fails on `main` (received `0`) and passes with the fix.

### 2. Say when a product's history is too thin for a timing

Companion to the wxopticon change that withholds the statistical `delayed` threshold until a product has 30 days of inits (see the linked wxopticon PR). That side publishes a product-level `timing_baseline` `{status, history_days, required_history_days}` in `dashboard.json`.

- [x] `timingBaselineNote(product)` renders `insufficient history (23/30 days)` when `status` is `insufficient_history`; `hydrateEta` appends it to the run state line in place of the timing, with no `data-timing` colour. A payload without the field renders exactly as before.
- [x] Fixture: `timing_baseline` and `sample_day_count` on every product; the two thin products (24 and 1 samples) are `insufficient_history` and, consistently, carry no `timing` on their runs.
- [x] Tests: unit test for the note; e2e spec "a product without enough history says so instead of a timing".

### Verification

- `npm test`: 181 pass.
- `npx playwright test test/e2e/pipeline.spec.mjs`: 17 pass (offline, fixture-stubbed).

### Log

#### 2026-09-03 — opened
- [x] Codex review: no blocking findings. Two should-fixes applied: the note also appears in the details statistics header for source rows (the state line only exists while a run is active), and the e2e waits for the old table node to be detached instead of sleeping. Noted, not changed: a details block collapsed and reopened across a rebuild does not keep its scroll (hidden nodes read `scrollLeft` 0); the reported bug is the open block.
- Companion: dynamical-org/wxopticon#221 publishes `timing_baseline`.

#### 2026-09-03 — user feedback
- [x] Dynamical rows carry the note on their lag header too (`lag after source · 8 recent samples · insufficient history (24/30 days)`): the lag stays the right statistic there, and the note explains why the run beside it has no timing between runs.

#### 2026-09-03 — retro
The bug reproduced in Playwright on the first try (scroll box read `0` after the one-second rebuild) and the fix is one helper at two call sites. Review added the between-runs surface for the history note and replaced a timed sleep with a wait on the old node detaching.

https://claude.ai/code/session_01Q8345eLe6aXFzrvxFjRZDK

