### PR TITLE
Render the service status lists with Preact + htm

### DIFF
--- a/public/status.mjs
+++ b/public/status.mjs
@@ -98,6 +98,13 @@ export function validateStatusData(data) {
   if (![...data.datasets, ...data.endpoints].every(isStatusEntry)) {
     throw new TypeError("Invalid status entry");
   }
+  const endpointIds = data.endpoints.map(({ id }) => id);
+  if (
+    endpointIds.some((id) => id.length === 0) ||
+    new Set(endpointIds).size !== endpointIds.length
+  ) {
+    throw new TypeError("Invalid status entry id");
+  }
   if (
     data.component_aliases != null &&
     !isComponentAliases(data.component_aliases)

--- a/public/status.mjs
+++ b/public/status.mjs
@@ -1,3 +1,4 @@
+import { html, render, useMemo } from "./vendor/preact-htm.mjs";
 import {
   componentSpans,
   dailyBars,
@@ -495,40 +496,6 @@ export function incidentDescription(entry, name) {
     : `${impact} — ongoing.`;
 }
 
-function renderGroup(list, entries, bars, uptime, emptyCells) {
-  list.replaceChildren();
-  for (const entry of entries) {
-    const item = document.createElement("li");
-    const header = document.createElement("header");
-    const name = document.createElement("h3");
-    const state = document.createElement("span");
-    // The glyph duplicates the adjacent label, so keep it out of the
-    // accessibility tree instead of announcing "black circle Operational".
-    const mark = document.createElement("span");
-
-    item.dataset.status = entry.status;
-    if (entry.maintenance?.kind) item.dataset.kind = entry.maintenance.kind;
-    if (entry.observation?.kind) item.dataset.kind = entry.observation.kind;
-    name.textContent = entry.name;
-    state.className = "status-label";
-    mark.setAttribute("aria-hidden", "true");
-    mark.textContent = statusMark(entry);
-    state.append(mark, ` ${statusLabel(entry)}`);
-    header.append(name, state);
-    item.append(header);
-
-    const cells = bars?.get(entry.id) ?? emptyCells;
-    const measured = uptime?.get(entry.id);
-    if (cells?.length && measured) {
-      const detail = document.createElement("p");
-      detail.textContent = uptimeDescription(measured, cells.length);
-      item.append(detail);
-    }
-    if (cells?.length) item.append(barStrip(cells));
-    list.append(item);
-  }
-}
-
 export function barDescription(cells) {
   const planned = cells.filter(
     (cell) => cell.displayState === "planned",
@@ -565,30 +532,66 @@ const DAY_LABELS = {
   planned: "planned outage",
 };
 
-function barStrip(cells) {
-  const strip = document.createElement("div");
-  strip.className = "status-bars";
-  strip.setAttribute("role", "group");
-  strip.setAttribute("aria-label", barDescription(cells));
-  for (const cell of cells) {
-    const anchor = cell.incidentIds?.[0] ?? cell.delayIds?.[0];
-    const dayState = cell.displayState ?? cell.state;
-    const dayLabel = DAY_LABELS[dayState] ?? dayState;
-    const day = document.createElement(anchor ? "a" : "span");
-    day.dataset.day = dayState;
-    day.title = `${cell.date}: ${dayLabel}`;
-    if (anchor) {
-      day.href = `#${anchor}`;
-      day.setAttribute(
-        "aria-label",
-        `${cell.date}: ${dayLabel}; view details`,
-      );
-    } else {
-      day.setAttribute("aria-hidden", "true");
-    }
-    strip.append(day);
-  }
-  return strip;
+function Day({ cell }) {
+  const anchor = cell.incidentIds?.[0] ?? cell.delayIds?.[0];
+  const dayState = cell.displayState ?? cell.state;
+  const dayLabel = DAY_LABELS[dayState] ?? dayState;
+  const Tag = anchor ? "a" : "span";
+  return html`<${Tag}
+    data-day=${dayState}
+    title=${`${cell.date}: ${dayLabel}`}
+    href=${anchor ? `#${anchor}` : null}
+    aria-label=${anchor
+      ? `${cell.date}: ${dayLabel}; view details`
+      : null}
+    aria-hidden=${anchor ? null : "true"}
+  />`;
+}
+
+function BarStrip({ cells }) {
+  return html`<div
+    class="status-bars"
+    role="group"
+    aria-label=${barDescription(cells)}
+  >
+    ${cells.map((cell) => html`<${Day} key=${cell.date} cell=${cell} />`)}
+  </div>`;
+}
+
+function StatusRow({ entry, bars, uptime, emptyCells }) {
+  const cells = bars?.get(entry.id) ?? emptyCells;
+  const measured = uptime?.get(entry.id);
+  const strip = useMemo(
+    () => (cells?.length ? html`<${BarStrip} cells=${cells} />` : null),
+    [cells],
+  );
+  return html`<li
+    data-status=${entry.status}
+    data-kind=${entry.observation?.kind ?? entry.maintenance?.kind ?? null}
+  >
+    <header>
+      <h3>${entry.name}</h3>
+      <span class="status-label">
+        <span aria-hidden="true">${statusMark(entry)}</span>${` ${statusLabel(entry)}`}
+      </span>
+    </header>
+    ${cells?.length && measured
+      ? html`<p>${uptimeDescription(measured, cells.length)}</p>`
+      : null}
+    ${strip}
+  </li>`;
+}
+
+function StatusGroup({ entries, bars, uptime, emptyCells }) {
+  return entries.map(
+    (entry) => html`<${StatusRow}
+      key=${entry.id}
+      entry=${entry}
+      bars=${bars}
+      uptime=${uptime}
+      emptyCells=${emptyCells}
+    />`,
+  );
 }
 
 export function buildHistory(eventsText, metaText) {
@@ -645,82 +648,13 @@ async function loadHistory(root) {
   }
 }
 
-function renderStatus(root, data, loadedHistory, local) {
-  const overallPanel = root.querySelector("#status-overall");
-  const asOf = root.querySelector("#status-as-of");
-  const updated = asOf.querySelector('[data-slot="status-updated"]');
-  const timeControl = asOf.querySelector('[data-slot="time-control"]');
-  const historyNotice = root.querySelector("#status-history");
-  const groups = root.querySelector("#status-groups");
-
-  renderHealth(root, "system-health", systemHealth(data));
-  overallPanel.hidden = true;
-
-  const stale = isStatusDataStale(data.generated_at);
-  asOf.classList.toggle("status-stale", stale);
-  timeControl.hidden = stale;
+function Updated({ data, local, stale }) {
+  if (!data) return "As of —";
   if (stale) {
-    const icon = document.createElement("span");
-    icon.setAttribute("aria-hidden", "true");
-    icon.textContent = "⚠";
-    const label = document.createElement("strong");
-    label.textContent = "Stale:";
-    updated.replaceChildren(
-      icon,
-      " ",
-      label,
-      STALE_MESSAGE.slice("Stale:".length),
-    );
-  } else {
-    const generatedTime = document.createElement("time");
-    generatedTime.dateTime = data.generated_at;
-    generatedTime.textContent = formatTimestamp(
-      data.generated_at,
-      local,
-      false,
-    );
-    updated.replaceChildren("As of ", generatedTime);
+    return html`<span aria-hidden="true">⚠</span>${" "}<strong>Stale:</strong>${STALE_MESSAGE.slice("Stale:".length)}`;
   }
-  const currentHistory =
-    loadedHistory && isHistoryCurrent(loadedHistory.asOf, data.generated_at)
-      ? loadedHistory
-      : null;
-  const history = applyIncidentGroups(
-    currentHistory,
-    data.incident_groups ?? [],
-  );
-  const emptyCells = dailyBars(new Map([["", []]]), {
-    asOf: history?.asOf ?? new Date(data.generated_at),
-    days: BAR_DAYS,
-  }).get("");
-  setHistoryNotice(
-    historyNotice,
-    history
-      ? null
-      : loadedHistory
-        ? "Uptime history is stale and has been hidden."
-        : "Uptime history is temporarily unavailable.",
-  );
-  groups.hidden = false;
-  // Datasets remain in the feed for a later page-side section.
-  for (const [selector, group] of [
-    ["#status-endpoints", "endpoint"],
-    ["#status-tools", "tool"],
-  ]) {
-    renderGroup(
-      root.querySelector(selector),
-      data.endpoints.filter((entry) => entry.group === group),
-      history?.cells,
-      history?.uptime,
-      emptyCells,
-    );
-  }
-  renderIncidentLog(root, history, data, local);
-}
-
-function setHistoryNotice(element, message) {
-  element.hidden = message === null;
-  element.textContent = message ?? "";
+  return html`${"As of "}<time datetime=${data.generated_at}
+    >${formatTimestamp(data.generated_at, local, false)}</time>`;
 }
 
 function sentenceList(items) {
@@ -752,7 +686,10 @@ export function groupedIncidentDescription(incident, names, end) {
     : `${impact} — ongoing for ${measured}.`;
 }
 
-function renderIncidentLog(root, history, data, local) {
+// PR #225 replaces this final imperative view with a keyed component. Keeping
+// the adapter called only from paint gives that PR one clean seam without
+// hiding incident-node restoration in this service-list port.
+function renderIncidentLogAdapter(root, history, data, local) {
   const list = root.querySelector("#status-incident-log");
   const empty = root.querySelector("#status-incident-empty");
   list.replaceChildren();
@@ -858,23 +795,7 @@ function renderIncidentLog(root, history, data, local) {
   }
 }
 
-function renderUnavailable(root) {
-  const overallPanel = root.querySelector("#status-overall");
-  overallPanel.hidden = false;
-  root.querySelector("#status-summary").textContent =
-    "The status feed could not be loaded. Try again shortly.";
-  root.querySelector("#status-incidents").hidden = true;
-  setHistoryNotice(root.querySelector("#status-history"), null);
-  root.querySelector("#status-groups").hidden = true;
-  renderIncidentLog(root, null, { endpoints: [] }, true);
-  const asOf = root.querySelector("#status-as-of");
-  asOf.classList.remove("status-stale");
-  asOf.querySelector('[data-slot="status-updated"]').textContent = "As of —";
-  asOf.querySelector('[data-slot="time-control"]').hidden = true;
-  renderHealth(root, "system-health", systemHealth(null));
-}
-
-async function loadStatus(root, render) {
+async function loadStatus(root, update) {
   const history = loadHistory(root);
   try {
     const response = await fetch(root.dataset.statusUrl, {
@@ -888,15 +809,36 @@ async function loadStatus(root, render) {
     const data = withoutExperimentalComponents(
       validateStatusData(await response.json()),
     );
-    render(data, await history);
+    const loadedHistory = await history;
+    const currentHistory =
+      loadedHistory && isHistoryCurrent(loadedHistory.asOf, data.generated_at)
+        ? loadedHistory
+        : null;
+    update({
+      data,
+      loadedHistory,
+      history: applyIncidentGroups(currentHistory, data.incident_groups ?? []),
+      error: null,
+      unavailable: false,
+      loaded: true,
+    });
   } catch (error) {
     console.error("Unable to load public status", error);
-    render(null, null);
+    update({
+      data: null,
+      loadedHistory: null,
+      history: null,
+      error,
+      unavailable: true,
+      loaded: true,
+      overallSummary: "The status feed could not be loaded. Try again shortly.",
+    });
   }
 }
 
-async function loadAgencyHealth(root) {
+async function loadAgencyHealth(root, update) {
   const url = root.querySelector(".status-health").dataset.pipelineUrl;
+  let health;
   try {
     const response = await fetch(url, {
       cache: "no-store",
@@ -905,34 +847,130 @@ async function loadAgencyHealth(root) {
     });
     if (!response.ok) throw new Error(`Agency request failed: ${response.status}`);
     const data = await response.json();
-    renderHealth(root, "agency-health", agencyHealth(data.advisories));
+    health = agencyHealth(data.advisories);
   } catch {
-    renderHealth(root, "agency-health", agencyHealth(null));
+    health = agencyHealth(null);
   }
+  update({ agencyHealth: health });
+}
+
+function createStore(initial, paint) {
+  let state = initial;
+  let queued = false;
+  return {
+    update(patch) {
+      state = {
+        ...state,
+        ...(typeof patch === "function" ? patch(state) : patch),
+      };
+      if (queued) return;
+      queued = true;
+      queueMicrotask(() => {
+        queued = false;
+        paint(state);
+      });
+    },
+  };
+}
+
+function start(root) {
+  const asOf = root.querySelector("#status-as-of");
+  const overallPanel = root.querySelector("#status-overall");
+  const timeControl = asOf.querySelector('[data-slot="time-control"]');
+  const timeToggle = root.querySelector("#status-time-toggle");
+  const groups = root.querySelector("#status-groups");
+  const slots = {
+    updated: asOf.querySelector('[data-slot="status-updated"]'),
+    summary: root.querySelector("#status-summary"),
+    incidents: root.querySelector("#status-incidents"),
+    historyNotice: root.querySelector("#status-history"),
+    endpoints: root.querySelector("#status-endpoints"),
+    tools: root.querySelector("#status-tools"),
+  };
+
+  function paint(state) {
+    timeToggle.value = state.local ? "local" : "utc";
+    if (state.agencyHealth) {
+      renderHealth(root, "agency-health", state.agencyHealth);
+    }
+    if (!state.loaded) return;
+
+    const { data, history, loadedHistory } = state;
+    const stale = data ? isStatusDataStale(data.generated_at) : false;
+    asOf.classList.toggle("status-stale", stale);
+    timeControl.hidden = !data || stale;
+    overallPanel.hidden = !state.unavailable;
+    slots.incidents.hidden = true;
+    groups.hidden = !data;
+    render(state.overallSummary, slots.summary);
+    render(null, slots.incidents);
+    render(
+      html`<${Updated} data=${data} local=${state.local} stale=${stale} />`,
+      slots.updated,
+    );
+    renderHealth(root, "system-health", systemHealth(data));
+
+    const historyMessage = state.unavailable
+      ? null
+      : history
+        ? null
+        : loadedHistory
+          ? "Uptime history is stale and has been hidden."
+          : "Uptime history is temporarily unavailable.";
+    slots.historyNotice.hidden = historyMessage === null;
+    render(historyMessage ?? "", slots.historyNotice);
+
+    if (data) {
+      const emptyCells = dailyBars(new Map([["", []]]), {
+        asOf: history?.asOf ?? new Date(data.generated_at),
+        days: BAR_DAYS,
+      }).get("");
+      for (const [slot, group] of [
+        [slots.endpoints, "endpoint"],
+        [slots.tools, "tool"],
+      ]) {
+        render(
+          html`<${StatusGroup}
+            entries=${data.endpoints.filter((entry) => entry.group === group)}
+            bars=${history?.cells}
+            uptime=${history?.uptime}
+            emptyCells=${emptyCells}
+          />`,
+          slot,
+        );
+      }
+      renderIncidentLogAdapter(root, history, data, state.local);
+    } else {
+      renderIncidentLogAdapter(root, null, { endpoints: [] }, true);
+    }
+  }
+
+  const store = createStore(
+    {
+      data: null,
+      loadedHistory: null,
+      history: null,
+      error: null,
+      unavailable: false,
+      loaded: false,
+      local: true,
+      agencyHealth: null,
+      overallSummary: "Loading the latest monitor results.",
+    },
+    paint,
+  );
+  const update = (patch) => store.update(patch);
+
+  store.update({
+    local: setupTimeToggle(timeToggle, (local) => store.update({ local })),
+  });
+  loadStatus(root, update);
+  loadAgencyHealth(root, update);
+  setInterval(() => loadStatus(root, update), REFRESH_INTERVAL_MS);
+  setInterval(() => loadAgencyHealth(root, update), REFRESH_INTERVAL_MS);
 }
 
 if (typeof document !== "undefined") {
   const root = document.querySelector("[data-status-page]");
-  if (root) {
-    let data = null;
-    let history = null;
-    let local = true;
-    const render = (nextData, nextHistory) => {
-      data = nextData;
-      history = nextHistory;
-      if (data) renderStatus(root, data, history, local);
-      else renderUnavailable(root);
-    };
-    local = setupTimeToggle(
-      root.querySelector("#status-time-toggle"),
-      (nextLocal) => {
-        local = nextLocal;
-        if (data) renderStatus(root, data, history, local);
-      },
-    );
-    loadStatus(root, render);
-    loadAgencyHealth(root);
-    setInterval(() => loadStatus(root, render), REFRESH_INTERVAL_MS);
-    setInterval(() => loadAgencyHealth(root), REFRESH_INTERVAL_MS);
-  }
+  if (root) start(root);
 }

--- a/test/e2e/status.spec.mjs
+++ b/test/e2e/status.spec.mjs
@@ -1,0 +1,200 @@
+import { readFileSync } from "node:fs";
+
+import { expect, test } from "@playwright/test";
+
+const PATH = "/status/";
+const REFRESH_INTERVAL_MS = 5 * 60 * 1000;
+const STATUS = JSON.parse(
+  readFileSync(new URL("../fixtures/status.json", import.meta.url)),
+);
+const EVENTS = readFileSync(
+  new URL("../fixtures/events.jsonl", import.meta.url),
+  "utf8",
+);
+const DASHBOARD = JSON.parse(
+  readFileSync(new URL("../fixtures/pipeline-dashboard.json", import.meta.url)),
+);
+const EVENT_COUNT = EVENTS.split("\n").filter((line) => line.trim()).length;
+const META = {
+  v: 1,
+  reconciled_at: STATUS.generated_at,
+  events_count: EVENT_COUNT,
+};
+const JSON_HEADERS = { "access-control-allow-origin": "*" };
+
+async function stubStatus(page, mutate = (payload) => payload) {
+  let served = 0;
+  await page.route("**/status.json", (route) => {
+    served += 1;
+    const payload = mutate(structuredClone(STATUS), served);
+    return route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      headers: JSON_HEADERS,
+      body: JSON.stringify(payload),
+    });
+  });
+  await page.route("**/events.jsonl", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/x-ndjson",
+      headers: JSON_HEADERS,
+      body: EVENTS,
+    }),
+  );
+  await page.route("**/meta.json", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      headers: JSON_HEADERS,
+      body: JSON.stringify(META),
+    }),
+  );
+  await page.route("**/dashboard.json", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      headers: JSON_HEADERS,
+      body: JSON.stringify(DASHBOARD),
+    }),
+  );
+}
+
+async function openStatus(page, mutate) {
+  await stubStatus(page, mutate);
+  const response = await page.goto(PATH);
+  expect(response?.status(), `${PATH} did not return 200`).toBe(200);
+  await expect(page.locator("#status-endpoints > li").first()).toBeVisible();
+  await expect(page.locator("#status-history")).toBeHidden();
+}
+
+function componentRow(page, name) {
+  return page.locator(".status-list > li").filter({ hasText: name });
+}
+
+test.describe("service-list state survives a refresh", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.clock.install({
+      time: new Date(Date.parse(STATUS.generated_at) + 2 * 60 * 1000),
+    });
+  });
+
+  test("keeps the endpoint, day, focus, selection, and page scroll", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 900, height: 500 });
+    await openStatus(page, (payload, served) => {
+      if (served > 1) payload.endpoints[1].status = "operational";
+      return payload;
+    });
+
+    const row = componentRow(page, "STAC catalog");
+    const endpoint = await row.elementHandle();
+    const day = await row
+      .locator('.status-bars > a[href^="#incident-"]')
+      .elementHandle();
+    await day.focus();
+    const selected = await row.locator("h3").evaluate((node) => {
+      getSelection().selectAllChildren(node);
+      return getSelection().toString();
+    });
+    const scrollY = await page.evaluate(() => {
+      scrollTo(0, document.documentElement.scrollHeight - innerHeight - 40);
+      return window.scrollY;
+    });
+    expect(scrollY).toBeGreaterThan(0);
+
+    await page.clock.runFor(REFRESH_INTERVAL_MS);
+
+    await expect(
+      componentRow(page, "Data product reads").locator(".status-label"),
+    ).toHaveText("● Operational");
+    expect(await endpoint.evaluate((node) => node.isConnected)).toBe(true);
+    expect(await day.evaluate((node) => node.isConnected)).toBe(true);
+    expect(await day.evaluate((node) => node === document.activeElement)).toBe(true);
+    expect(await page.evaluate(() => getSelection().toString())).toBe(selected);
+    expect(await page.evaluate(() => window.scrollY)).toBe(scrollY);
+  });
+
+  test("moves a keyed endpoint below a newly inserted one", async ({ page }) => {
+    await openStatus(page, (payload, served) => {
+      if (served > 1) {
+        payload.endpoints.unshift({
+          id: "new-core-endpoint",
+          name: "New core endpoint",
+          group: "endpoint",
+          status: "operational",
+        });
+      }
+      return payload;
+    });
+    const row = componentRow(page, "STAC catalog");
+    const endpoint = await row.elementHandle();
+    const day = await row.locator(".status-bars > *").last().elementHandle();
+
+    await page.clock.runFor(REFRESH_INTERVAL_MS);
+
+    await expect(page.locator("#status-endpoints > li h3").first()).toHaveText(
+      "New core endpoint",
+    );
+    expect(await endpoint.evaluate((node) => node.isConnected)).toBe(true);
+    expect(await endpoint.evaluate((node) => node.querySelector("h3").textContent)).toBe(
+      "STAC catalog",
+    );
+    expect(await day.evaluate((node) => node.isConnected)).toBe(true);
+  });
+});
+
+test("the time-zone action reformats time without replacing service nodes", async ({
+  page,
+}) => {
+  await page.clock.install({
+    time: new Date(Date.parse(STATUS.generated_at) + 2 * 60 * 1000),
+  });
+  await page.addInitScript(() => localStorage.setItem("wxopticon:time-mode", "utc"));
+  await stubStatus(page);
+  await page.goto(PATH);
+  const row = componentRow(page, "STAC catalog");
+  const endpoint = await row.elementHandle();
+  const day = await row.locator(".status-bars > *").last().elementHandle();
+  const before = await page.locator('[data-slot="status-updated"]').textContent();
+
+  await page.selectOption("#status-time-toggle", "local");
+
+  await expect(page.locator('[data-slot="status-updated"]')).not.toHaveText(before);
+  expect(await endpoint.evaluate((node) => node.isConnected)).toBe(true);
+  expect(await day.evaluate((node) => node.isConnected)).toBe(true);
+});
+
+test("an unavailable status feed renders the established fallback", async ({ page }) => {
+  await page.route("**/status.json", (route) =>
+    route.fulfill({ status: 503, contentType: "text/plain", body: "unavailable" }),
+  );
+  await page.route("**/events.jsonl", (route) =>
+    route.fulfill({ status: 200, contentType: "application/x-ndjson", body: EVENTS }),
+  );
+  await page.route("**/meta.json", (route) =>
+    route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify(META) }),
+  );
+  await page.route("**/dashboard.json", (route) =>
+    route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify(DASHBOARD) }),
+  );
+
+  await page.goto(PATH);
+
+  await expect(page.locator("#status-summary")).toHaveText(
+    "The status feed could not be loaded. Try again shortly.",
+  );
+  await expect(page.locator("#status-incidents")).toBeHidden();
+  await expect(page.locator("#status-history")).toBeHidden();
+  await expect(page.locator("#status-groups")).toBeHidden();
+  await expect(page.locator("#status-incident-empty")).toHaveText(
+    "Incident history is temporarily unavailable.",
+  );
+  await expect(page.locator('[data-slot="status-updated"]')).toHaveText("As of —");
+  await expect(page.locator('[data-slot="time-control"]')).toBeHidden();
+  await expect(page.locator('[data-slot="system-health"]')).toHaveAttribute(
+    "data-state",
+    "unavailable",
+  );
+});

--- a/test/e2e/status.spec.mjs
+++ b/test/e2e/status.spec.mjs
@@ -145,25 +145,32 @@ test.describe("service-list state survives a refresh", () => {
   });
 });
 
-test("the time-zone action reformats time without replacing service nodes", async ({
-  page,
-}) => {
-  await page.clock.install({
-    time: new Date(Date.parse(STATUS.generated_at) + 2 * 60 * 1000),
+test.describe("in a non-UTC time zone", () => {
+  test.use({ timezoneId: "America/Chicago", locale: "en-US" });
+
+  test("the time-zone action reformats time without replacing service nodes", async ({
+    page,
+  }) => {
+    await page.clock.install({
+      time: new Date(Date.parse(STATUS.generated_at) + 2 * 60 * 1000),
+    });
+    await page.addInitScript(() =>
+      localStorage.setItem("wxopticon:time-mode", "utc"),
+    );
+    await stubStatus(page);
+    await page.goto(PATH);
+    const row = componentRow(page, "STAC catalog");
+    const endpoint = await row.elementHandle();
+    const day = await row.locator(".status-bars > *").last().elementHandle();
+    const updated = page.locator('[data-slot="status-updated"]');
+    await expect(updated).toHaveText("As of Jul 24, 2026, 7:55 PM");
+
+    await page.selectOption("#status-time-toggle", "local");
+
+    await expect(updated).toHaveText("As of Jul 24, 2026, 2:55 PM");
+    expect(await endpoint.evaluate((node) => node.isConnected)).toBe(true);
+    expect(await day.evaluate((node) => node.isConnected)).toBe(true);
   });
-  await page.addInitScript(() => localStorage.setItem("wxopticon:time-mode", "utc"));
-  await stubStatus(page);
-  await page.goto(PATH);
-  const row = componentRow(page, "STAC catalog");
-  const endpoint = await row.elementHandle();
-  const day = await row.locator(".status-bars > *").last().elementHandle();
-  const before = await page.locator('[data-slot="status-updated"]').textContent();
-
-  await page.selectOption("#status-time-toggle", "local");
-
-  await expect(page.locator('[data-slot="status-updated"]')).not.toHaveText(before);
-  expect(await endpoint.evaluate((node) => node.isConnected)).toBe(true);
-  expect(await day.evaluate((node) => node.isConnected)).toBe(true);
 });
 
 test("an unavailable status feed renders the established fallback", async ({ page }) => {

--- a/test/status.test.mjs
+++ b/test/status.test.mjs
@@ -712,7 +712,7 @@ test("status page passes its timestamp into the shared subnav row", () => {
     template,
     /\.status-incident\[data-kind="planned"\][^}]*var\(--pill-degraded-bg\)/s,
   );
-  assert.doesNotMatch(script, /textContent = "Today"|day.*ago/);
+  assert.doesNotMatch(script, /\bToday\b|\bday.*ago/);
   assert.doesNotMatch(
     template,
     /Current health of dynamical\.org public endpoints, tools, and resources\./,

--- a/test/status.test.mjs
+++ b/test/status.test.mjs
@@ -170,6 +170,20 @@ test("refuses a contentless document instead of reporting all clear", () => {
   );
 });
 
+test("rejects empty or globally duplicated endpoint ids", () => {
+  const empty = structuredClone(operationalData);
+  empty.endpoints[0].id = "";
+  assert.throws(() => validateStatusData(empty), /invalid status entry id/i);
+
+  const duplicate = structuredClone(operationalData);
+  duplicate.endpoints.push({
+    ...duplicate.endpoints[0],
+    name: "duplicate status page",
+    group: "endpoint",
+  });
+  assert.throws(() => validateStatusData(duplicate), /invalid status entry id/i);
+});
+
 test("does not require the deferred dataset section", () => {
   assert.doesNotThrow(() =>
     validateStatusData({ ...operationalData, datasets: [] }),


### PR DESCRIPTION
# Render the service status lists with Preact + htm (PR #224)

## Why

`public/status.mjs` replaces the service rows and their 90-day cells after every
five-minute status/history refresh. That discards reader state held by those
nodes. This PR establishes the page's single store and renders the service
status roots with keyed Preact components while leaving the incident-history
view behind one explicit imperative adapter for the next stacked PR.

## Decisions

- Keep the no-build relative-module architecture established by PR #223.
- Keep one immutable page-state snapshot containing the validated status data,
  raw history, incident-group-derived history, availability/error state, time
  mode, and agency health.
- Let `paint(state)` own every application render and the template-host side
  effects: overall/history/group visibility, stale styling, time-control
  visibility, time select value, body time mode, and health host state.
- Render endpoint/tool rows keyed by component id and day cells keyed by UTC
  date. Memoise each 90-day strip on its cells.
- Preserve concurrent status/history loading and both five-minute intervals.
- Keep `status-log.mjs` pure and unchanged.
- Keep incident-history DOM construction behind a clearly named adapter called
  only from `paint`; PR #225 replaces it.

## Intentional differences

- Status payloads with an empty endpoint id or duplicate endpoint ids are now
  rejected as unavailable. The old imperative page rendered them, but ids are
  global history-map keys and sibling Preact keys, so accepting them makes row
  identity and history attribution ambiguous.
- This PR preserves the incident adapter's current fragment replay behavior;
  PR #225 narrows replay to initial/deferred navigation.

## Tasks

- [x] Add offline status e2e coverage for service-row/day identity, focus,
  selection, page scroll, insertion/reorder, time-zone formatting, and feed
  unavailability.
- [x] Prove the service survival specs fail against origin/main.
- [x] Port the as-of, overall, history notice, endpoint, and tool roots to
  Preact + htm with one store and one paint entry point.
- [x] Keep the incident log behind the imperative paint adapter.
- [x] Keep all pure exports and unit tests green; update source-shape assertions
  to state their post-port intent.
- [x] Run the status and pipeline browser specs against port 8084.
- [x] DOM-diff origin/main and this branch in default, local, unavailable, and
  fragment URL modes with a frozen clock.
- [x] Commit, push, open the stacked draft PR, move this plan into its
  description, and delete this local file.

## Log

### 2026-09-03 — kickoff

Branch `preact/status` starts at `preact/pipeline` (`dbf729bbd`, PR #223).
Revision 2 assigns service-list survival to this PR and defers incident-node
identity and replay behavior to the incident-history PR.

### 2026-09-03 — implementation complete

- Added the offline status spec. Its three service-state survival cases fail on
  origin/main because the original endpoint handles are disconnected; the
  fallback parity case passes there.
- Ported the service rows, keyed day cells, as-of content, overall roots, and
  history notice to Preact. Raw and incident-group-derived histories live in
  the store; concurrent history/status loading and both five-minute intervals
  are unchanged.
- `npm test`: 10/10 files passed. Browser checks: status 4/4 and pipeline 20/20.
- Frozen-clock DOM comparison: no differences in default, local, unavailable,
  or incident-fragment modes.

### 2026-09-03 — PR feedback

- Rebased onto `preact/pipeline` at `df10c61b3`.
- Reject empty and globally duplicated endpoint ids before they can collide in
  the history maps or keyed service rows; the unit case covers both forms.
- Pin the time-zone browser case to `America/Chicago`/`en-US` and assert its
  exact UTC and local output.
- Final stacked-tip checks: `npm test` 10/10, status e2e 9/9, and pipeline e2e
  23/23.

### 2026-09-03 — retro

The clean PR seam is the view boundary, not the history data boundary: the
service bars already need grouped incident history, so PR 2 owns that state
while the imperative incident adapter remains deliberately disposable. No
template or pure history-module changes were needed.

https://claude.ai/code/session_01QSnekHLdtdPnRbBURdFyRw
