### PR TITLE
Render the incident history with Preact + htm

### DIFF
--- a/public/status.mjs
+++ b/public/status.mjs
@@ -1,4 +1,11 @@
-import { html, render, useMemo } from "./vendor/preact-htm.mjs";
+import {
+  Fragment,
+  html,
+  render,
+  useEffect,
+  useMemo,
+  useRef,
+} from "./vendor/preact-htm.mjs";
 import {
   componentSpans,
   dailyBars,
@@ -120,6 +127,11 @@ export function validateStatusData(data) {
       !data.incident_groups.every(isIncidentGroup))
   ) {
     throw new TypeError("Invalid incident group");
+  }
+  const incidentGroupIds =
+    data.incident_groups?.map(({ id }) => id) ?? [];
+  if (new Set(incidentGroupIds).size !== incidentGroupIds.length) {
+    throw new TypeError("Invalid incident group id");
   }
   return {
     ...data,
@@ -693,17 +705,13 @@ export function groupedIncidentDescription(incident, names, end) {
     : `${impact} — ongoing for ${measured}.`;
 }
 
-// PR #225 replaces this final imperative view with a keyed component. Keeping
-// the adapter called only from paint gives that PR one clean seam without
-// hiding incident-node restoration in this service-list port.
-function renderIncidentLogAdapter(root, history, data, local) {
-  const list = root.querySelector("#status-incident-log");
-  const empty = root.querySelector("#status-incident-empty");
-  list.replaceChildren();
+function incidentView(history, data) {
   if (!history) {
-    empty.textContent = "Incident history is temporarily unavailable.";
-    empty.hidden = false;
-    return;
+    return {
+      empty: "Incident history is temporarily unavailable.",
+      names: new Map(),
+      visible: [],
+    };
   }
 
   const names = new Map(data.endpoints.map(({ id, name }) => [id, name]));
@@ -717,89 +725,110 @@ function renderIncidentLogAdapter(root, history, data, local) {
         : names.has(incident.component),
     )
     .reverse();
-  empty.textContent = "No incidents or delays recorded.";
-  empty.hidden = visible.length > 0;
+  return {
+    empty: "No incidents or delays recorded.",
+    names,
+    visible,
+  };
+}
 
-  for (const incident of visible) {
-    const item = document.createElement("li");
-    const header = document.createElement("header");
-    const name = document.createElement("h3");
-    const state = document.createElement("strong");
-    const summary = document.createElement("p");
-    const timing = document.createElement("p");
-    const kind = incident.kind ?? "outage";
-    const kindLabel =
-      kind === "planned"
-        ? "planned outage"
-        : kind === "observation"
-          ? "observation gap"
-          : kind;
-    // A coalesced entry stands for several windows, so it says so twice over:
-    // a plural state line, and a timing line that counts them.
-    const label = incident.windows ? `${kindLabel}s` : kindLabel;
-    const end = incident.end ?? history.asOf.getTime();
-    const measured = formatDuration(0, measuredDuration(incident, end));
+function Incident({ incident, visible, names, asOf, local }) {
+  const kind = incident.kind ?? "outage";
+  const kindLabel =
+    kind === "planned"
+      ? "planned outage"
+      : kind === "observation"
+        ? "observation gap"
+        : kind;
+  // A coalesced entry stands for several windows, so it says so twice over:
+  // a plural state line, and a timing line that counts them.
+  const label = incident.windows ? `${kindLabel}s` : kindLabel;
+  const end = incident.end ?? asOf;
+  const measured = formatDuration(0, measuredDuration(incident, end));
+  const description = incident.components
+    ? groupedIncidentDescription(incident, names, end)
+    : incidentDescription(incident, names.get(incident.component));
+  const overlapping = overlappingEntries(incident, visible, asOf);
+  const spent = incident.windows
+    ? `${incident.windows.length} ${label} totaling ${measured}`
+    : measured;
+  const timing =
+    incident.ending === "observation-ended"
+      ? `${formatTimestamp(incident.start, local)} – ${formatTimestamp(incident.end, local)} · ${spent}. Recovery was not witnessed.`
+      : `${formatTimestamp(incident.start, local)} – ${incident.end ? formatTimestamp(incident.end, local) : "ongoing"} · ${spent}.`;
 
-    item.id = incident.id;
-    item.className = "status-incident";
-    item.dataset.kind = kind;
-    // The name wears a <mark> that stays invisible until this entry is the
-    // :target — arriving from a day cell lights up the header rather than
-    // boxing the whole entry.
-    const highlight = document.createElement("mark");
-    highlight.textContent = incidentName(incident, names);
-    name.append(highlight);
-    state.textContent = `${label} · ${
-      incident.ending === "resolved"
-        ? "resolved"
-        : incident.ending === "observation-ended"
-          ? "observation ended"
-          : "ongoing"
-    }`;
-    summary.textContent = incident.components
-      ? groupedIncidentDescription(incident, names, end)
-      : incidentDescription(incident, names.get(incident.component));
-    const overlapping = overlappingEntries(
-      incident,
-      visible,
-      history.asOf.getTime(),
-    );
-    if (overlapping.length) {
-      summary.append(" Coincided with ");
-      overlapping.forEach((other, index) => {
-        const link = document.createElement("a");
-        link.href = `#${other.id}`;
-        const otherKind =
-          other.kind === "planned" ? "planned outage" : other.kind ?? "outage";
-        link.textContent = `the ${incidentName(other, names)} ${otherKind}`;
-        if (index > 0) summary.append(", ");
-        summary.append(link);
-      });
-      summary.append(".");
-    }
-    const spent = incident.windows
-      ? `${incident.windows.length} ${label} totaling ${measured}`
-      : measured;
-    timing.textContent =
-      incident.ending === "observation-ended"
-        ? `${formatTimestamp(incident.start, local)} – ${formatTimestamp(incident.end, local)} · ${spent}. Recovery was not witnessed.`
-        : `${formatTimestamp(incident.start, local)} – ${
-            incident.end ? formatTimestamp(incident.end, local) : "ongoing"
-          } · ${spent}.`;
-    header.append(name, state);
-    item.append(header, summary, timing);
-    list.append(item);
-  }
-  if (typeof location !== "undefined" && location.hash) {
-    const target = document.getElementById(
-      decodeURIComponent(location.hash.slice(1)),
-    );
-    // Re-run the fragment navigation rather than scrollIntoView: the entry
-    // rendered after the page navigated, so :target never matched and the
-    // header's <mark> would stay dormant on a shared link. replace() scrolls
-    // and re-evaluates :target without adding a history entry.
-    if (target) requestAnimationFrame(() => location.replace(location.hash));
-  }
+  return html`<li
+    id=${incident.id}
+    class="status-incident"
+    data-kind=${kind}
+  >
+    <header>
+      <h3><mark>${incidentName(incident, names)}</mark></h3>
+      <strong>${`${label} · ${
+        incident.ending === "resolved"
+          ? "resolved"
+          : incident.ending === "observation-ended"
+            ? "observation ended"
+            : "ongoing"
+      }`}</strong>
+    </header>
+    <p>
+      ${description}${overlapping.length
+        ? html`${" Coincided with "}${overlapping.map((other, index) => {
+            const otherKind =
+              other.kind === "planned"
+                ? "planned outage"
+                : other.kind ?? "outage";
+            return html`<${Fragment} key=${other.id}
+              >${index > 0 ? ", " : null}<a
+                href=${`#${other.id}`}
+              >${`the ${incidentName(other, names)} ${otherKind}`}</a><//>`;
+          })}${"."}`
+        : null}
+    </p>
+    <p>${timing}</p>
+  </li>`;
+}
+
+function IncidentLog({ visible, names, asOf, local }) {
+  const handledHash = useRef(null);
+  const signature = visible.map(({ id }) => id).join("\n");
+
+  useEffect(() => {
+    const handleHashChange = () => {
+      const hash = location.hash;
+      if (!hash) {
+        handledHash.current = hash;
+        return;
+      }
+      const target = document.getElementById(decodeURIComponent(hash.slice(1)));
+      handledHash.current = target ? hash : null;
+    };
+    window.addEventListener("hashchange", handleHashChange);
+    return () => window.removeEventListener("hashchange", handleHashChange);
+  }, []);
+
+  useEffect(() => {
+    const hash = location.hash;
+    if (!hash || handledHash.current === hash) return;
+    const target = document.getElementById(decodeURIComponent(hash.slice(1)));
+    if (!target) return;
+    // Record before replace: its hashchange, when a browser emits one for the
+    // same fragment, must not leave this navigation pending again.
+    handledHash.current = hash;
+    requestAnimationFrame(() => location.replace(hash));
+  }, [signature]);
+
+  return visible.map(
+    (incident) => html`<${Incident}
+      key=${incident.id}
+      incident=${incident}
+      visible=${visible}
+      names=${names}
+      asOf=${asOf}
+      local=${local}
+    />`,
+  );
 }
 
 async function loadStatus(root, update) {
@@ -893,6 +922,8 @@ function start(root) {
     historyNotice: root.querySelector("#status-history"),
     endpoints: root.querySelector("#status-endpoints"),
     tools: root.querySelector("#status-tools"),
+    incidentEmpty: root.querySelector("#status-incident-empty"),
+    incidentLog: root.querySelector("#status-incident-log"),
   };
 
   function paint(state) {
@@ -946,10 +977,20 @@ function start(root) {
           slot,
         );
       }
-      renderIncidentLogAdapter(root, history, data, state.local);
-    } else {
-      renderIncidentLogAdapter(root, null, { endpoints: [] }, true);
     }
+
+    const incidents = incidentView(history, data ?? { endpoints: [] });
+    slots.incidentEmpty.hidden = incidents.visible.length > 0;
+    render(incidents.empty, slots.incidentEmpty);
+    render(
+      html`<${IncidentLog}
+        visible=${incidents.visible}
+        names=${incidents.names}
+        asOf=${history?.asOf.getTime()}
+        local=${data ? state.local : true}
+      />`,
+      slots.incidentLog,
+    );
   }
 
   const store = createStore(

--- a/test/e2e/status.spec.mjs
+++ b/test/e2e/status.spec.mjs
@@ -21,8 +21,76 @@ const META = {
   events_count: EVENT_COUNT,
 };
 const JSON_HEADERS = { "access-control-allow-origin": "*" };
+const STAC_INCIDENT_ID =
+  `incident-stac-catalog-${Date.parse("2026-07-21T13:55:00Z") / 1000}`;
+const OVERLAP_INCIDENT_ID =
+  `incident-data-product-reads-${Date.parse("2026-07-21T14:00:00Z") / 1000}`;
+const INSERTED_OVERLAP_INCIDENT_ID =
+  `incident-scorecard-${Date.parse("2026-07-21T14:10:00Z") / 1000}`;
+const DEFERRED_INCIDENT_ID =
+  `incident-scorecard-${Date.parse("2026-07-23T10:00:00Z") / 1000}`;
 
-async function stubStatus(page, mutate = (payload) => payload) {
+function withEvents(events, additions) {
+  return `${events.trim()}\n${additions.map(JSON.stringify).join("\n")}\n`;
+}
+
+const OVERLAPPING_EVENTS = withEvents(EVENTS, [
+  {
+    ts: "2026-07-21T14:00:00Z",
+    kind: "transition",
+    component: "data-product-reads",
+    to: "down",
+  },
+  {
+    ts: "2026-07-21T14:30:00Z",
+    kind: "transition",
+    component: "data-product-reads",
+    to: "operational",
+  },
+]);
+
+const INSERTED_OVERLAP_EVENTS = withEvents(OVERLAPPING_EVENTS, [
+  {
+    ts: "2026-07-21T14:10:00Z",
+    kind: "transition",
+    component: "scorecard",
+    to: "down",
+  },
+  {
+    ts: "2026-07-21T14:20:00Z",
+    kind: "transition",
+    component: "scorecard",
+    to: "operational",
+  },
+]);
+
+const DEFERRED_EVENTS = withEvents(EVENTS, [
+  {
+    ts: "2026-07-23T10:00:00Z",
+    kind: "transition",
+    component: "scorecard",
+    to: "down",
+  },
+  {
+    ts: "2026-07-23T10:10:00Z",
+    kind: "transition",
+    component: "scorecard",
+    to: "operational",
+  },
+]);
+
+const WITHOUT_STAC_EVENTS = `${EVENTS.split("\n")
+  .filter(
+    (line) =>
+      line.trim() && JSON.parse(line).component !== "stac-catalog",
+  )
+  .join("\n")}\n`;
+
+async function stubStatus(
+  page,
+  mutate = (payload) => payload,
+  mutateHistory = (events) => events,
+) {
   let served = 0;
   await page.route("**/status.json", (route) => {
     served += 1;
@@ -34,22 +102,30 @@ async function stubStatus(page, mutate = (payload) => payload) {
       body: JSON.stringify(payload),
     });
   });
-  await page.route("**/events.jsonl", (route) =>
-    route.fulfill({
+  let eventsServed = 0;
+  await page.route("**/events.jsonl", (route) => {
+    eventsServed += 1;
+    return route.fulfill({
       status: 200,
       contentType: "application/x-ndjson",
       headers: JSON_HEADERS,
-      body: EVENTS,
-    }),
-  );
-  await page.route("**/meta.json", (route) =>
-    route.fulfill({
+      body: mutateHistory(EVENTS, eventsServed),
+    });
+  });
+  let metaServed = 0;
+  await page.route("**/meta.json", (route) => {
+    metaServed += 1;
+    const events = mutateHistory(EVENTS, metaServed);
+    return route.fulfill({
       status: 200,
       contentType: "application/json",
       headers: JSON_HEADERS,
-      body: JSON.stringify(META),
-    }),
-  );
+      body: JSON.stringify({
+        ...META,
+        events_count: events.split("\n").filter((line) => line.trim()).length,
+      }),
+    });
+  });
   await page.route("**/dashboard.json", (route) =>
     route.fulfill({
       status: 200,
@@ -60,10 +136,10 @@ async function stubStatus(page, mutate = (payload) => payload) {
   );
 }
 
-async function openStatus(page, mutate) {
-  await stubStatus(page, mutate);
-  const response = await page.goto(PATH);
-  expect(response?.status(), `${PATH} did not return 200`).toBe(200);
+async function openStatus(page, mutate, mutateHistory, path = PATH) {
+  await stubStatus(page, mutate, mutateHistory);
+  const response = await page.goto(path);
+  expect(response?.status(), `${path} did not return 200`).toBe(200);
   await expect(page.locator("#status-endpoints > li").first()).toBeVisible();
   await expect(page.locator("#status-history")).toBeHidden();
 }
@@ -170,6 +246,182 @@ test.describe("in a non-UTC time zone", () => {
     await expect(updated).toHaveText("As of Jul 24, 2026, 2:55 PM");
     expect(await endpoint.evaluate((node) => node.isConnected)).toBe(true);
     expect(await day.evaluate((node) => node.isConnected)).toBe(true);
+  });
+});
+
+test.describe("incident-history state survives a refresh", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.clock.install({
+      time: new Date(Date.parse(STATUS.generated_at) + 2 * 60 * 1000),
+    });
+  });
+
+  test("keeps the incident, cross-reference focus, and incident selection", async ({
+    page,
+  }) => {
+    await openStatus(
+      page,
+      (payload, served) => {
+        if (served > 1) payload.endpoints[1].status = "operational";
+        return payload;
+      },
+      (events, served) =>
+        served > 1 ? INSERTED_OVERLAP_EVENTS : OVERLAPPING_EVENTS,
+    );
+    const incident = page.locator(`#${STAC_INCIDENT_ID}`);
+    const item = await incident.elementHandle();
+    const crossReference = await incident
+      .locator(`a[href="#${OVERLAP_INCIDENT_ID}"]`)
+      .elementHandle();
+    await crossReference.focus();
+    const selected = await incident.locator("h3").evaluate((node) => {
+      getSelection().selectAllChildren(node);
+      return getSelection().toString();
+    });
+
+    await page.clock.runFor(REFRESH_INTERVAL_MS);
+
+    await expect(
+      incident.locator(`a[href="#${INSERTED_OVERLAP_INCIDENT_ID}"]`),
+    ).toBeVisible();
+    await expect(
+      componentRow(page, "Data product reads").locator(".status-label"),
+    ).toHaveText("● Operational");
+    expect(await item.evaluate((node) => node.isConnected)).toBe(true);
+    expect(await crossReference.evaluate((node) => node.isConnected)).toBe(true);
+    expect(
+      await crossReference.evaluate((node) => node === document.activeElement),
+    ).toBe(true);
+    expect(await page.evaluate(() => getSelection().toString())).toBe(selected);
+  });
+});
+
+test.describe("incident times in a non-UTC time zone", () => {
+  test.use({ timezoneId: "America/Chicago", locale: "en-US" });
+
+  test("the time-zone action retains incident nodes while reformatting them", async ({
+    page,
+  }) => {
+    await page.clock.install({
+      time: new Date(Date.parse(STATUS.generated_at) + 2 * 60 * 1000),
+    });
+    await page.addInitScript(() =>
+      localStorage.setItem("wxopticon:time-mode", "utc"),
+    );
+    await openStatus(page, undefined, () => OVERLAPPING_EVENTS);
+    const incident = page.locator(`#${STAC_INCIDENT_ID}`);
+    const item = await incident.elementHandle();
+    const timing = incident.locator("p").last();
+    await expect(timing).toHaveText(
+      "Jul 21, 2026, 1:55 PM UTC – Jul 21, 2026, 2:55 PM UTC · 1h.",
+    );
+
+    await page.selectOption("#status-time-toggle", "local");
+
+    await expect(timing).toHaveText(
+      "Jul 21, 2026, 8:55 AM CDT – Jul 21, 2026, 9:55 AM CDT · 1h.",
+    );
+    expect(await item.evaluate((node) => node.isConnected)).toBe(true);
+  });
+});
+
+test.describe("incident fragment replay", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.clock.install({
+      time: new Date(Date.parse(STATUS.generated_at) + 2 * 60 * 1000),
+    });
+  });
+
+  test("replays an initial fragment once without dragging the next poll", async ({
+    page,
+  }) => {
+    await openStatus(
+      page,
+      undefined,
+      (events, served) => (served > 1 ? DEFERRED_EVENTS : events),
+      `${PATH}#${STAC_INCIDENT_ID}`,
+    );
+    await expect(page.locator(`#${STAC_INCIDENT_ID}:target`)).toBeVisible();
+    expect(await page.evaluate(() => scrollY)).toBeGreaterThan(0);
+    await page.evaluate(() => scrollTo(0, 0));
+
+    await page.clock.runFor(REFRESH_INTERVAL_MS);
+    await expect(page.locator(`#${DEFERRED_INCIDENT_ID}`)).toBeVisible();
+    await page.waitForTimeout(100);
+
+    expect(await page.evaluate(() => scrollY)).toBe(0);
+  });
+
+  test("replays a pending fragment when its incident arrives later", async ({
+    page,
+  }) => {
+    await openStatus(
+      page,
+      undefined,
+      (events, served) => (served > 1 ? DEFERRED_EVENTS : events),
+      `${PATH}#${DEFERRED_INCIDENT_ID}`,
+    );
+    await expect(page.locator(`#${DEFERRED_INCIDENT_ID}`)).toHaveCount(0);
+
+    await page.clock.runFor(REFRESH_INTERVAL_MS);
+
+    await expect(page.locator(`#${DEFERRED_INCIDENT_ID}:target`)).toBeVisible();
+    expect(await page.evaluate(() => scrollY)).toBeGreaterThan(0);
+  });
+
+  test("native fragment navigation is not replayed after the reader scrolls away", async ({
+    page,
+  }) => {
+    await openStatus(
+      page,
+      undefined,
+      (events, served) => (served > 1 ? DEFERRED_EVENTS : events),
+    );
+    await componentRow(page, "STAC catalog")
+      .locator(`.status-bars > a[href="#${STAC_INCIDENT_ID}"]`)
+      .click();
+    await expect(page.locator(`#${STAC_INCIDENT_ID}:target`)).toBeVisible();
+    expect(await page.evaluate(() => scrollY)).toBeGreaterThan(0);
+    await page.evaluate(() => scrollTo(0, 0));
+
+    await page.clock.runFor(REFRESH_INTERVAL_MS);
+    await expect(page.locator(`#${DEFERRED_INCIDENT_ID}`)).toBeVisible();
+    await page.waitForTimeout(100);
+
+    expect(await page.evaluate(() => scrollY)).toBe(0);
+  });
+
+  test("replays a revisited handled fragment after its incident returns", async ({
+    page,
+  }) => {
+    await openStatus(
+      page,
+      undefined,
+      (events, served) => {
+        if (served === 2) return WITHOUT_STAC_EVENTS;
+        return events;
+      },
+    );
+    await componentRow(page, "STAC catalog")
+      .locator(`.status-bars > a[href="#${STAC_INCIDENT_ID}"]`)
+      .click();
+    await expect(page.locator(`#${STAC_INCIDENT_ID}:target`)).toBeVisible();
+
+    await page.clock.runFor(REFRESH_INTERVAL_MS);
+    await expect(page.locator(`#${STAC_INCIDENT_ID}`)).toHaveCount(0);
+    await page.evaluate(
+      ({ deferred, stac }) => {
+        location.hash = deferred;
+        location.hash = stac;
+      },
+      { deferred: DEFERRED_INCIDENT_ID, stac: STAC_INCIDENT_ID },
+    );
+    await page.evaluate(() => scrollTo(0, 0));
+
+    await page.clock.runFor(REFRESH_INTERVAL_MS);
+
+    await expect(page.locator(`#${STAC_INCIDENT_ID}:target`)).toBeVisible();
+    expect(await page.evaluate(() => scrollY)).toBeGreaterThan(0);
   });
 });
 

--- a/test/status.test.mjs
+++ b/test/status.test.mjs
@@ -184,6 +184,32 @@ test("rejects empty or globally duplicated endpoint ids", () => {
   assert.throws(() => validateStatusData(duplicate), /invalid status entry id/i);
 });
 
+test("rejects same-id incident groups that do not coalesce", () => {
+  const group = {
+    id: "publisher-outage",
+    kind: "outage",
+    summary: "Publisher outage",
+    started_at: "2026-07-21T13:55:00Z",
+    ended_at: "2026-07-21T14:55:00Z",
+    components: ["dynamical-org"],
+  };
+  const duplicate = {
+    ...group,
+    summary: "Separate publisher outage",
+    started_at: "2026-07-22T13:55:00Z",
+    ended_at: "2026-07-22T14:55:00Z",
+  };
+
+  assert.throws(
+    () =>
+      validateStatusData({
+        ...operationalData,
+        incident_groups: [group, duplicate],
+      }),
+    /invalid incident group id/i,
+  );
+});
+
 test("does not require the deferred dataset section", () => {
   assert.doesNotThrow(() =>
     validateStatusData({ ...operationalData, datasets: [] }),


### PR DESCRIPTION
# Render the incident history with Preact + htm (PR #225)

## Why

PR #224 established `/status/`'s one store and keyed service roots, but its
explicit `renderIncidentLogAdapter` still replaces every incident node on a
poll or time-zone action. This final stacked PR renders the incident-history
region from the same state so incident focus, selection, and identity survive.

## Decisions

- Keep `public/status-log.mjs` untouched: it is already the pure data layer,
  while the remaining incident DOM construction lives in `status.mjs`.
- Render incident rows keyed by incident id into `#status-incident-log`; render
  the empty message from the same state into its existing template slot.
- Preserve the existing incident markup, state/kind labels, `<mark>`, timing
  text, aliases, and “Coincided with” links.
- Replay an initial or deferred fragment only once its target exists, recording
  the handled hash before `location.replace`.
- Listen for native `hashchange`: mark an existing target handled so a later
  poll cannot drag the reader back, but leave a missing target pending so a
  later response can replay it. Remove the listener with the component effect.

## Intentional differences

- Fragment replay is no longer unconditional after every incident render. An
  initial or currently missing target is replayed once when it first exists;
  refreshes and time-zone changes do not re-scroll a reader who moved away.
- Status payloads with duplicate incident-group ids are now rejected as
  unavailable. The old page could derive multiple incident rows with the same
  DOM id; rejecting that payload keeps Preact keys and fragment targets unique.

## Tasks

- [x] Add incident identity/focus/selection and time-zone retention specs.
- [x] Add initial, deferred, and native-hash replay/no-replay coverage.
- [x] Prove the new incident survival/no-replay specs fail on origin/main.
- [x] Replace the imperative adapter with keyed incident components and the
  hashchange-aware one-time replay effect.
- [x] Keep unit tests green and run the full status and pipeline e2e specs on
  port 8084.
- [x] DOM-diff origin/main and this branch in all four required states.
- [x] Commit, push, open the stacked draft PR, move this plan into its
  description, and delete this local file.

## Log

### 2026-09-03 — kickoff

Branch `preact/status-log` starts at PR #224 (`fcbafc83f`). Revision 2 requires
native hash navigation to update replay bookkeeping in addition to the
post-commit target check.

### 2026-09-03 — implementation complete

- Added incident retention across a poll and time-zone change, including held
  incident/cross-reference handles, focus, and selected text.
- Added initial-fragment, deferred-target, and native-link replay coverage. On
  origin/main, four of the five focused PR 3 cases fail: both identity cases
  disconnect their held nodes, and both no-replay cases jump back to the target.
  Deferred-target replay passes there as the parity baseline.
- Replaced the final imperative DOM builder with keyed `Incident` rows. The
  effect records a handled hash before replay; its cleaned-up `hashchange`
  listener records native navigation only when the target already exists.
- `npm test`: 10/10 files passed. Browser checks on the isolated config:
  status 9/9 and pipeline 20/20.
- Frozen-clock DOM comparison: no differences in default, local, unavailable,
  or incident-fragment modes.

### 2026-09-03 — PR feedback

- Keyed each complete “Coincided with” fragment and added a poll regression
  that inserts an overlap ahead of the focused, held link.
- Made both no-drag polls change incident topology while retaining the target,
  and added recovery coverage for a handled fragment revisited while missing.
- Pinned incident timestamps to `America/Chicago`/`en-US` with exact UTC and
  local assertions.
- Reject duplicate incident-group ids before they become sibling keys and DOM
  fragment targets.
- Final checks: `npm test` 10/10, status e2e 10/10, and pipeline e2e 23/23.

### 2026-09-03 — retro

The topology signature is the right replay dependency: it retries when an
incident arrives without coupling fragment navigation to timestamp-only renders.
The hashchange listener closes the separate native-navigation gap identified in
Revision 2. `status-log.mjs` remained untouched because its data folds were
already pure and required no port.

https://claude.ai/code/session_01QSnekHLdtdPnRbBURdFyRw
