### PR TITLE
Simplify virtual dataset pipeline labels

### DIFF
--- a/public/pipeline.mjs
+++ b/public/pipeline.mjs
@@ -156,6 +156,10 @@ export function displaySource(source) {
   return source?.replace(/^https?:\/\//, "") ?? "—";
 }
 
+export function displayRowLabel(label) {
+  return label === "dynamical.org · virtual" ? "dynamical.org" : label;
+}
+
 function productsOf(dashboard) {
   return dashboard.groups.flatMap((group) => group.products);
 }
@@ -1406,7 +1410,7 @@ function Row({
     data-view=${String(index)}
   >
     <div>
-      <strong>${product.row_label}</strong>
+      <strong>${displayRowLabel(product.row_label)}</strong>
       <div class="pipeline-source-meta">
         <div>${displaySource(product.source)}</div>
         <div>${`${product.cadence_hours ?? "—"}h init cadence`}</div>

--- a/test/e2e/pipeline.spec.mjs
+++ b/test/e2e/pipeline.spec.mjs
@@ -475,9 +475,10 @@ test("a dynamical row reports lag after its source, not time after init", async 
   page,
 }) => {
   await openPipeline(page);
-  const row = page
-    .locator(".pipeline-row")
-    .filter({ hasText: "dynamical.org · virtual" });
+  const row = page.locator(
+    '.pipeline-row[data-product-id="noaa-gfs-forecast-virtual"]',
+  );
+  await expect(row.locator("strong").first()).toHaveText("dynamical.org");
   await row.locator('[data-slot="details-button"]').click();
   const table = row.locator(".pipeline-row-details .table-container").first();
 

--- a/test/pipeline.test.mjs
+++ b/test/pipeline.test.mjs
@@ -20,6 +20,7 @@ import {
   runsThatFitFacetRows,
   clockTime,
   detailRows,
+  displayRowLabel,
   displaySource,
   isDynamicalRow,
   lagAt,
@@ -65,6 +66,11 @@ function dashboard() {
 
 test("accepts the granular dashboard contract", () => {
   assert.equal(validateDashboard(dashboard()).groups[0].id, "noaa-gfs");
+});
+
+test("labels dynamical.org virtual datasets without the implementation detail", () => {
+  assert.equal(displayRowLabel("dynamical.org · virtual"), "dynamical.org");
+  assert.equal(displayRowLabel("AWS"), "AWS");
 });
 
 test("rejects the lead-only schema it replaced", () => {


### PR DESCRIPTION
## Summary

- display dynamical.org virtual dataset rows as `dynamical.org`
- preserve upstream source labels and the pipeline payload contract
- add unit and browser regression coverage

## Tests

- `npm test`
- `npm run test:e2e` (31 passed)
- `git diff --check`