### PR TITLE
Name the reference point over the pipeline details duration column

### DIFF
--- a/public/pipeline.css
+++ b/public/pipeline.css
@@ -360,9 +360,10 @@
   font-size: 1.2rem;
 }
 
-/* nine nowrap measurement columns need more room than the content column has;
-   the facet table's five fit, so it is sized by its content */
-.pipeline-row-details table:not(.pipeline-facets) {
+/* the lead table's nine nowrap measurement columns need more room than the
+   content column has; the lag and facet tables' few fit, so they are sized by
+   their content */
+.pipeline-row-details .table-container:first-child table {
   min-width: 90rem;
 }
 

--- a/public/pipeline.mjs
+++ b/public/pipeline.mjs
@@ -984,9 +984,9 @@ function statsHeader(sampleInitCount, note = null) {
 // The note beside it is about the row's own arrival baseline, not the lag
 // sample: the lag stays, but without that baseline the run gets no timing.
 function lagStatsHeader(sampleCount, note = null) {
-  if (!sampleCount) return "lag after source";
+  if (!sampleCount) return "lag vs earliest source";
   const samples = sampleCount === 1 ? "recent sample" : "recent samples";
-  const header = `lag after source · ${sampleCount.toLocaleString("en-US")} ${samples}`;
+  const header = `lag vs earliest source · ${sampleCount.toLocaleString("en-US")} ${samples}`;
   return note ? `${header} · ${note}` : header;
 }
 
@@ -1136,8 +1136,10 @@ export function detailRows(product, now, local, groupProducts = []) {
         ),
     // the run columns' third cell measures from a different point on a lagged
     // row, and the stats header naming it sits a scroll away; the sub-header
-    // names the reference point where the number is
-    durationHeader: lagged ? "after source" : "after init",
+    // names the reference point where the number is, "vs" because the lag is
+    // signed and "earliest" because the comparator is whichever mirror landed
+    // first for that init
+    durationHeader: lagged ? "vs earliest source" : "after init",
     rows: (product.lead_group_stats ?? []).map((stats, index) => {
       return {
         name: stats.name,

--- a/public/pipeline.mjs
+++ b/public/pipeline.mjs
@@ -1134,6 +1134,10 @@ export function detailRows(product, now, local, groupProducts = []) {
           product.latency_stats?.sample_init_count,
           timingBaselineNote(product),
         ),
+    // the run columns' third cell measures from a different point on a lagged
+    // row, and the stats header naming it sits a scroll away; the sub-header
+    // names the reference point where the number is
+    durationHeader: lagged ? "after source" : "after init",
     rows: (product.lead_group_stats ?? []).map((stats, index) => {
       return {
         name: stats.name,
@@ -1246,10 +1250,10 @@ function Details({ product, now, local, groupProducts }) {
         <tr>
           <th>status</th>
           <th>time</th>
-          <th>duration</th>
+          <th>${details.durationHeader}</th>
           <th>status</th>
           <th>time</th>
-          <th>duration</th>
+          <th>${details.durationHeader}</th>
           <th>p50</th>
           <th>p95</th>
           <th>p99</th>

--- a/public/pipeline.mjs
+++ b/public/pipeline.mjs
@@ -981,13 +981,10 @@ function statsHeader(sampleInitCount, note = null) {
 
 // A lag has no published baseline behind it, so its sample is the handful of
 // runs the payload carries — named apart from the upstream rows' own count.
-// The note beside it is about the row's own arrival baseline, not the lag
-// sample: the lag stays, but without that baseline the run gets no timing.
-function lagStatsHeader(sampleCount, note = null) {
-  if (!sampleCount) return "lag vs earliest source";
+function lagStatsHeader(sampleCount) {
+  if (!sampleCount) return "lag after source";
   const samples = sampleCount === 1 ? "recent sample" : "recent samples";
-  const header = `lag vs earliest source · ${sampleCount.toLocaleString("en-US")} ${samples}`;
-  return note ? `${header} · ${note}` : header;
+  return `lag after source · ${sampleCount.toLocaleString("en-US")} ${samples}`;
 }
 
 const NO_RUN = Object.freeze({
@@ -1049,10 +1046,10 @@ function labelledRun(label, initTime, local) {
 }
 
 /* Ingestion lag. dynamical.org's own rows sit in the same group as the upstream
-   sources they read, and their `source_label` is null; what matters for them is
-   not time after init but how long after the source published the dataset
-   landed. Both latencies are seconds after the same init, so the init cancels
-   out of the subtraction. */
+   sources they read, and their `source_label` is null; beside their time after
+   init, what matters for them is how long after the source published the
+   dataset landed. Both latencies are seconds after the same init, so the init
+   cancels out of the subtraction. */
 
 export function sourceRowsOf(products) {
   return (products ?? []).filter(({ source_label }) => source_label != null);
@@ -1117,78 +1114,58 @@ export function detailRows(product, now, local, groupProducts = []) {
   const last = activeIndex >= 0 ? recent[activeIndex - 1] : recent.at(-1);
   const upcoming = active ? null : product.next_expected_init;
   const sources = isDynamicalRow(product) ? sourceRowsOf(groupProducts) : [];
-  const lagged = sources.length > 0;
-  // the lag is a property of the whole run, so every lead-group row of a
-  // lagged product reports the same series
-  const lags = lagged ? lagSeries(product, sources) : null;
-  const lastLag = lagAt(last, sources);
-  const runLag = lagAt(active, sources);
   return {
     lastHeader: labelledRun("last run", last?.init_time, local),
     runHeader: active
       ? labelledRun("current run", active.init_time, local)
       : labelledRun("upcoming run", upcoming, local),
-    statsHeader: lagged
-      ? lagStatsHeader(lags.length, timingBaselineNote(product))
-      : statsHeader(
-          product.latency_stats?.sample_init_count,
-          timingBaselineNote(product),
-        ),
-    // the run columns' third cell measures from a different point on a lagged
-    // row, and the stats header naming it sits a scroll away; the sub-header
-    // names the reference point where the number is, "vs" because the lag is
-    // signed and "earliest" because the comparator is whichever mirror landed
-    // first for that init
-    durationHeader: lagged ? "vs earliest source" : "after init",
-    rows: (product.lead_group_stats ?? []).map((stats, index) => {
-      return {
-        name: stats.name,
-        label: stats.label,
-        last: withLag(
-          observedRunDetail(
-            last,
-            last?.lead_groups?.[index],
+    statsHeader: statsHeader(
+      product.latency_stats?.sample_init_count,
+      timingBaselineNote(product),
+    ),
+    rows: (product.lead_group_stats ?? []).map((stats, index) => ({
+      name: stats.name,
+      label: stats.label,
+      last: observedRunDetail(
+        last,
+        last?.lead_groups?.[index],
+        stats,
+        now,
+        local,
+        false,
+      ),
+      run: active
+        ? observedRunDetail(
+            active,
+            active.lead_groups?.[index],
             stats,
             now,
             local,
-            false,
-          ),
-          lagged,
-          lastLag,
-        ),
-        run: withLag(
-          active
-            ? observedRunDetail(
-                active,
-                active.lead_groups?.[index],
-                stats,
-                now,
-                local,
-                true,
-              )
-            : upcomingRunDetail(upcoming, stats, local),
-          lagged,
-          runLag,
-        ),
-        p50: lags
-          ? formatSignedLatency(lagPercentile(lags, 0.5))
-          : formatLatency(stats.p50_s),
-        p95: lags
-          ? formatSignedLatency(lagPercentile(lags, 0.95))
-          : formatLatency(stats.p95_s),
-        p99: lags
-          ? formatSignedLatency(lagPercentile(lags, 0.99))
-          : formatLatency(stats.p99_s),
-      };
-    }),
+            true,
+          )
+        : upcomingRunDetail(upcoming, stats, local),
+      p50: formatLatency(stats.p50_s),
+      p95: formatLatency(stats.p95_s),
+      p99: formatLatency(stats.p99_s),
+    })),
+    lag: sources.length > 0 ? lagRow(product, sources, last) : null,
   };
 }
 
-// On a lagged row the lag replaces the duration column outright — the
-// wall-clock time beside it still says when the run finished, and a lag of
-// null (no completed pair for that init) reads as "—".
-function withLag(detail, lagged, lag) {
-  return lagged ? { ...detail, duration: formatSignedLatency(lag) } : detail;
+// The lag is a property of the whole run, not of a horizon, so it gets one
+// row of its own beneath the lead table rather than a column repeated down
+// it. Only the last run has one: the current run is by definition not
+// complete, and a lag needs both sides landed — a last run whose source is
+// still out reads "—".
+function lagRow(product, sources, last) {
+  const lags = lagSeries(product, sources);
+  return {
+    header: lagStatsHeader(lags.length),
+    last: formatSignedLatency(lagAt(last, sources)),
+    p50: formatSignedLatency(lagPercentile(lags, 0.5)),
+    p95: formatSignedLatency(lagPercentile(lags, 0.95)),
+    p99: formatSignedLatency(lagPercentile(lags, 0.99)),
+  };
 }
 
 export function facetRows(product) {
@@ -1238,8 +1215,8 @@ export function timingBaselineNote(product) {
 
 function Details({ product, now, local, groupProducts }) {
   const details = detailRows(product, now, local, groupProducts);
-  // two keyed siblings, no wrapper: a facet table that arrives or leaves with
-  // a later run must not change what node the lead table scrolls in
+  // keyed siblings, no wrapper: a lag or facet table that arrives or leaves
+  // with a later run must not change what node the lead table scrolls in
   const leadTable = html`<div key="lead" class="table-container">
     <table>
       <thead>
@@ -1252,10 +1229,10 @@ function Details({ product, now, local, groupProducts }) {
         <tr>
           <th>status</th>
           <th>time</th>
-          <th>${details.durationHeader}</th>
+          <th>after init</th>
           <th>status</th>
           <th>time</th>
-          <th>${details.durationHeader}</th>
+          <th>after init</th>
           <th>p50</th>
           <th>p95</th>
           <th>p99</th>
@@ -1279,10 +1256,36 @@ function Details({ product, now, local, groupProducts }) {
       </tbody>
     </table>
   </div>`;
+  // the lag table names the same last run the lead table does, one number
+  const lagTable =
+    details.lag &&
+    html`<div key="lag" class="table-container">
+      <table>
+        <thead>
+          <tr>
+            <th colspan="4">${details.lag.header}</th>
+          </tr>
+          <tr>
+            <th>${details.lastHeader}</th>
+            <th>p50</th>
+            <th>p95</th>
+            <th>p99</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>${details.lag.last}</td>
+            <td>${details.lag.p50}</td>
+            <td>${details.lag.p95}</td>
+            <td>${details.lag.p99}</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>`;
   const facets = facetRows(product);
-  if (facets.length === 0) return leadTable;
+  if (facets.length === 0) return html`${leadTable}${lagTable}`;
 
-  return html`${leadTable}
+  return html`${leadTable}${lagTable}
     <div key="facets" class="table-container">
       <table class="pipeline-facets">
         <thead>

--- a/test/e2e/pipeline.spec.mjs
+++ b/test/e2e/pipeline.spec.mjs
@@ -488,7 +488,7 @@ test("details distinguish last, current or upcoming, and historical timings", as
   ]);
 });
 
-test("a dynamical row reports lag after its source, not time after init", async ({
+test("a dynamical row reports its lag after the source beneath its time after init", async ({
   page,
 }) => {
   await openPipeline(page);
@@ -497,23 +497,34 @@ test("a dynamical row reports lag after its source, not time after init", async 
   );
   await expect(row.locator("strong").first()).toHaveText("dynamical.org");
   await row.locator('[data-slot="details-button"]').click();
-  const table = row.locator(".pipeline-row-details .table-container").first();
+  const tables = row.locator(".pipeline-row-details .table-container");
+  await expect(tables).toHaveCount(2);
 
-  await expect(table.locator("thead tr:first-child th").nth(3)).toHaveText(
-    "lag vs earliest source · 8 recent samples · insufficient history (24/30 days)",
+  // the lead table reads like any other row's, note included
+  const lead = tables.first();
+  await expect(lead.locator("thead tr:first-child th").nth(3)).toHaveText(
+    "time after init · 24 samples · insufficient history (24/30 days)",
   );
-  // the lag replaces the duration column under a header that says so; the
-  // time beside it stays wall-clock
-  await expect(table.locator("thead tr:last-child th").nth(2)).toHaveText(
-    "vs earliest source",
+  await expect(lead.locator("thead tr:last-child th").nth(2)).toHaveText(
+    "after init",
   );
-  await expect(table.locator("thead tr:last-child th").nth(5)).toHaveText(
-    "vs earliest source",
+  await expect(lead.locator("tbody tr:first-child td").nth(3)).toHaveText(
+    "1h 40m",
   );
-  const cells = table.locator("tbody tr:first-child td");
-  await expect(cells.nth(2)).toHaveText(/^\d{2}:\d{2}$/);
-  await expect(cells.nth(3)).toHaveText("5m");
-  await expect(cells.nth(7)).toHaveText("9m");
+
+  // the lag is one row under the same run headers, with its own sample
+  const lag = tables.nth(1);
+  await expect(lag.locator("thead tr:first-child th")).toHaveText(
+    "lag after source · 8 recent samples",
+  );
+  const heads = lag.locator("thead tr:last-child th");
+  await expect(heads.nth(0)).toHaveText(/^last run · /);
+  await expect(heads.nth(1)).toHaveText("p50");
+  const cells = lag.locator("tbody tr td");
+  await expect(cells).toHaveCount(4);
+  await expect(cells.nth(0)).toHaveText("5m");
+  await expect(cells.nth(1)).toHaveText("9m");
+  await expect(cells.nth(2)).toHaveText("12m");
 });
 
 test("each details table scrolls itself, under a header that names its column", async ({

--- a/test/e2e/pipeline.spec.mjs
+++ b/test/e2e/pipeline.spec.mjs
@@ -500,15 +500,15 @@ test("a dynamical row reports lag after its source, not time after init", async 
   const table = row.locator(".pipeline-row-details .table-container").first();
 
   await expect(table.locator("thead tr:first-child th").nth(3)).toHaveText(
-    "lag after source · 8 recent samples · insufficient history (24/30 days)",
+    "lag vs earliest source · 8 recent samples · insufficient history (24/30 days)",
   );
   // the lag replaces the duration column under a header that says so; the
   // time beside it stays wall-clock
   await expect(table.locator("thead tr:last-child th").nth(2)).toHaveText(
-    "after source",
+    "vs earliest source",
   );
   await expect(table.locator("thead tr:last-child th").nth(5)).toHaveText(
-    "after source",
+    "vs earliest source",
   );
   const cells = table.locator("tbody tr:first-child td");
   await expect(cells.nth(2)).toHaveText(/^\d{2}:\d{2}$/);

--- a/test/e2e/pipeline.spec.mjs
+++ b/test/e2e/pipeline.spec.mjs
@@ -469,6 +469,23 @@ test("details distinguish last, current or upcoming, and historical timings", as
   expect(headings[1]).toMatch(/^last run(?: · |$)/);
   expect(headings[2]).toMatch(/^(?:current|upcoming) run(?: · |$)/);
   expect(headings[3]).toMatch(/^time after init · [\d,]+ samples$/);
+  // the run columns name the same reference point the stats do
+  const subheadings = await row
+    .locator(
+      ".pipeline-row-details .table-container:first-child thead tr:last-child th",
+    )
+    .allTextContents();
+  expect(subheadings).toEqual([
+    "status",
+    "time",
+    "after init",
+    "status",
+    "time",
+    "after init",
+    "p50",
+    "p95",
+    "p99",
+  ]);
 });
 
 test("a dynamical row reports lag after its source, not time after init", async ({
@@ -485,7 +502,14 @@ test("a dynamical row reports lag after its source, not time after init", async 
   await expect(table.locator("thead tr:first-child th").nth(3)).toHaveText(
     "lag after source · 8 recent samples · insufficient history (24/30 days)",
   );
-  // the lag replaces the duration column; the time beside it stays wall-clock
+  // the lag replaces the duration column under a header that says so; the
+  // time beside it stays wall-clock
+  await expect(table.locator("thead tr:last-child th").nth(2)).toHaveText(
+    "after source",
+  );
+  await expect(table.locator("thead tr:last-child th").nth(5)).toHaveText(
+    "after source",
+  );
   const cells = table.locator("tbody tr:first-child td");
   await expect(cells.nth(2)).toHaveText(/^\d{2}:\d{2}$/);
   await expect(cells.nth(3)).toHaveText("5m");

--- a/test/pipeline.test.mjs
+++ b/test/pipeline.test.mjs
@@ -1215,10 +1215,10 @@ test("details read a dynamical row as lag after its source", () => {
     [aws, virtual],
   );
 
-  assert.equal(details.statsHeader, "lag after source · 3 recent samples");
+  assert.equal(details.statsHeader, "lag vs earliest source · 3 recent samples");
   // the duration column carries the lag and its header says so; the time
   // beside it still says when the run finished
-  assert.equal(details.durationHeader, "after source");
+  assert.equal(details.durationHeader, "vs earliest source");
   const [row] = details.rows;
   assert.equal(row.last.duration, "2m");
   assert.equal(row.last.time, "13:00");
@@ -1231,7 +1231,7 @@ test("details read a dynamical row as lag after its source", () => {
     sourceRow("AWS", { "2026-07-25T00:00:00Z": 3400 }),
     lone,
   ]);
-  assert.equal(only.statsHeader, "lag after source · 1 recent sample");
+  assert.equal(only.statsHeader, "lag vs earliest source · 1 recent sample");
   assert.deepEqual(
     [only.rows[0].last.duration, only.rows[0].p50],
     ["10m", "—"],
@@ -1248,6 +1248,25 @@ test("renders a negative lag with a sign", () => {
     [sourceRow("AWS", { [at]: 3400 }), virtual],
   );
   assert.equal(details.rows[0].last.duration, "\u22123m");
+});
+
+test("a lagged run in flight shows no lag, not its elapsed time", () => {
+  const done = "2026-07-25T00:00:00Z";
+  const running = "2026-07-25T06:00:00Z";
+  const virtual = dynamicalRow({ [done]: 3400 + 600, [running]: null });
+  const details = detailRows(
+    virtual,
+    Date.parse("2026-07-25T06:20:00Z"),
+    false,
+    [sourceRow("AWS", { [done]: 3400, [running]: 3300 }), virtual],
+  );
+
+  // the header says the column is a lag, so the init-relative counter an
+  // ordinary active run would show must not sit beneath it
+  assert.equal(details.durationHeader, "vs earliest source");
+  assert.equal(details.rows[0].last.duration, "10m");
+  assert.equal(details.rows[0].run.status, "processing");
+  assert.equal(details.rows[0].run.duration, "\u2014");
 });
 
 test("keeps time after init where a row has no source beside it", () => {
@@ -1338,7 +1357,7 @@ test("local preview fixture carries a dynamical row lagging its source", () => {
   // the lag stays; the note says why the run beside it carries no timing
   assert.equal(
     details.statsHeader,
-    "lag after source · 8 recent samples · insufficient history (24/30 days)",
+    "lag vs earliest source · 8 recent samples · insufficient history (24/30 days)",
   );
   assert.equal(details.rows[0].last.duration, "5m");
   assert.deepEqual(

--- a/test/pipeline.test.mjs
+++ b/test/pipeline.test.mjs
@@ -837,6 +837,7 @@ test("retains live horizon status, time, and duration in details", () => {
       lastHeader: "last run · 07-26 06z",
       runHeader: "current run · 07-26 12z",
       statsHeader: "time after init",
+      durationHeader: "after init",
       rows: [
         {
           name: "f024",
@@ -1215,9 +1216,10 @@ test("details read a dynamical row as lag after its source", () => {
   );
 
   assert.equal(details.statsHeader, "lag after source · 3 recent samples");
+  // the duration column carries the lag and its header says so; the time
+  // beside it still says when the run finished
+  assert.equal(details.durationHeader, "after source");
   const [row] = details.rows;
-  // the duration column carries the lag; the time beside it still says when
-  // the run finished
   assert.equal(row.last.duration, "2m");
   assert.equal(row.last.time, "13:00");
   assert.equal(lagSeries(virtual, [aws]).length, 3);
@@ -1261,6 +1263,7 @@ test("keeps time after init where a row has no source beside it", () => {
       group,
     );
     assert.equal(details.statsHeader, "time after init · 24 samples");
+    assert.equal(details.durationHeader, "after init");
     assert.deepEqual(
       [details.rows[0].last.duration, details.rows[0].p50],
       ["1h 7m", "1h 8m"],

--- a/test/pipeline.test.mjs
+++ b/test/pipeline.test.mjs
@@ -837,7 +837,6 @@ test("retains live horizon status, time, and duration in details", () => {
       lastHeader: "last run · 07-26 06z",
       runHeader: "current run · 07-26 12z",
       statsHeader: "time after init",
-      durationHeader: "after init",
       rows: [
         {
           name: "f024",
@@ -882,6 +881,7 @@ test("retains live horizon status, time, and duration in details", () => {
           p99: "1h 20m",
         },
       ],
+      lag: null,
     },
   );
 });
@@ -1215,15 +1215,21 @@ test("details read a dynamical row as lag after its source", () => {
     [aws, virtual],
   );
 
-  assert.equal(details.statsHeader, "lag vs earliest source · 3 recent samples");
-  // the duration column carries the lag and its header says so; the time
-  // beside it still says when the run finished
-  assert.equal(details.durationHeader, "vs earliest source");
+  // the lead rows keep the row's own time after init; the lag is a row of
+  // its own beneath them
+  assert.equal(details.statsHeader, "time after init · 24 samples");
   const [row] = details.rows;
-  assert.equal(row.last.duration, "2m");
+  assert.equal(row.last.duration, "1h");
   assert.equal(row.last.time, "13:00");
+  assert.deepEqual([row.p50, row.p95, row.p99], ["1h 8m", "1h 23m", "1h 42m"]);
   assert.equal(lagSeries(virtual, [aws]).length, 3);
-  assert.deepEqual([row.p50, row.p95, row.p99], ["2m", "10m", "10m"]);
+  assert.deepEqual(details.lag, {
+    header: "lag after source · 3 recent samples",
+    last: "2m",
+    p50: "2m",
+    p95: "10m",
+    p99: "10m",
+  });
 
   // a single lagged run names its sample in the singular and reports no spread
   const lone = dynamicalRow({ "2026-07-25T00:00:00Z": 4000 });
@@ -1231,11 +1237,8 @@ test("details read a dynamical row as lag after its source", () => {
     sourceRow("AWS", { "2026-07-25T00:00:00Z": 3400 }),
     lone,
   ]);
-  assert.equal(only.statsHeader, "lag vs earliest source · 1 recent sample");
-  assert.deepEqual(
-    [only.rows[0].last.duration, only.rows[0].p50],
-    ["10m", "—"],
-  );
+  assert.equal(only.lag.header, "lag after source · 1 recent sample");
+  assert.deepEqual([only.lag.last, only.lag.p50], ["10m", "—"]);
 });
 
 test("renders a negative lag with a sign", () => {
@@ -1247,10 +1250,10 @@ test("renders a negative lag with a sign", () => {
     false,
     [sourceRow("AWS", { [at]: 3400 }), virtual],
   );
-  assert.equal(details.rows[0].last.duration, "\u22123m");
+  assert.equal(details.lag.last, "\u22123m");
 });
 
-test("a lagged run in flight shows no lag, not its elapsed time", () => {
+test("a lagged run in flight counts up after init and has no lag yet", () => {
   const done = "2026-07-25T00:00:00Z";
   const running = "2026-07-25T06:00:00Z";
   const virtual = dynamicalRow({ [done]: 3400 + 600, [running]: null });
@@ -1261,12 +1264,11 @@ test("a lagged run in flight shows no lag, not its elapsed time", () => {
     [sourceRow("AWS", { [done]: 3400, [running]: 3300 }), virtual],
   );
 
-  // the header says the column is a lag, so the init-relative counter an
-  // ordinary active run would show must not sit beneath it
-  assert.equal(details.durationHeader, "vs earliest source");
-  assert.equal(details.rows[0].last.duration, "10m");
   assert.equal(details.rows[0].run.status, "processing");
-  assert.equal(details.rows[0].run.duration, "\u2014");
+  assert.equal(details.rows[0].run.duration, "20m 0s");
+  // a lag needs both sides complete, so only the last run carries one
+  assert.equal(details.lag.last, "10m");
+  assert.equal("run" in details.lag, false);
 });
 
 test("keeps time after init where a row has no source beside it", () => {
@@ -1282,7 +1284,7 @@ test("keeps time after init where a row has no source beside it", () => {
       group,
     );
     assert.equal(details.statsHeader, "time after init · 24 samples");
-    assert.equal(details.durationHeader, "after init");
+    assert.equal(details.lag, null);
     assert.deepEqual(
       [details.rows[0].last.duration, details.rows[0].p50],
       ["1h 7m", "1h 8m"],
@@ -1354,16 +1356,18 @@ test("local preview fixture carries a dynamical row lagging its source", () => {
     false,
     group.products,
   );
-  // the lag stays; the note says why the run beside it carries no timing
+  // the note sits on the baseline it describes, not on the lag sample
   assert.equal(
     details.statsHeader,
-    "lag vs earliest source · 8 recent samples · insufficient history (24/30 days)",
+    "time after init · 24 samples · insufficient history (24/30 days)",
   );
-  assert.equal(details.rows[0].last.duration, "5m");
-  assert.deepEqual(
-    [details.rows[0].p50, details.rows[0].p95, details.rows[0].p99],
-    ["9m", "12m", "12m"],
-  );
+  assert.deepEqual(details.lag, {
+    header: "lag after source · 8 recent samples",
+    last: "5m",
+    p50: "9m",
+    p95: "12m",
+    p99: "12m",
+  });
 });
 
 test("local preview fixture exercises dashboard v2 facet rendering", () => {


### PR DESCRIPTION
On `/status/pipeline/`, the "more details" table of a dynamical.org row that shares a group with its upstream sources (today `noaa-hrrr-forecast-48-hour-virtual`, beside AWS and NOMADS) reported **lag after the source** (#219) in place of time after init, while every other row — the sources, and the 18-hour HRRR virtual row alone in its group — reported **time after init**. Both dynamical rows display as "dynamical.org" (#227), the "duration" sub-header read the same word in both cases, and the only header that said which reference point applied sat off-screen at the default width. So an 8m lag and a 53m latency looked like the same kind of number, and the lagged row's own published time-after-init figures were shown nowhere.

## Plan

### What each number meant before this change

| column | source row, or dynamical row with no source beside it | dynamical row with sources ("lagged") |
| --- | --- | --- |
| status | wxopticon's lead-group status; timing colour is init-relative | same |
| time | wall-clock completion of that lead group (init + latency_s), or ETA (init + that group's p95) | same |
| duration | that lead group's latency_s after init; elapsed since init while running | whole-run lag = own latency_s − earliest source latency_s for the same init, signed, "—" while running; identical on every horizon row |
| p50 / p95 / p99 | wxopticon's per-lead-group baseline over `sample_init_count` inits ("time after init · N samples") | nearest-rank percentiles over the ≤10 payload runs with a completed pair ("lag after source · N recent samples"); identical on every horizon row |

The switch is `source_label == null` **and** the group has a labelled sibling — not "virtual". The 18-hour virtual row sits alone in its group because wxopticon publishes no 18-hour source rows yet (`PIPELINE_GROUP_BY_DATASET` files only the 48-hour virtual under `noaa-hrrr`), so there is nothing for the page to subtract; dynamical-org/wxopticon#225 adds the parallel hourly 18-hour AWS/NOMADS source products and groups the virtual row beside them.

### Approach: show both

- [x] the lead table reads **time after init** on every row: sub-headers `status | time | after init`, per-horizon p50/p95/p99 from the row's own `lead_group_stats`, and the insufficient-history note on the baseline it describes
- [x] a lagged row gets one more table under the lead table: `lag after source · N recent samples` over `last run · <init> | p50 | p95 | p99`, one row. The current run gets no cell: it is by definition not complete, and a lag needs both sides landed
- [x] `detailRows` returns `lag: null | { header, last, p50, p95, p99 }`; `Details` renders three keyed siblings (lead, lag, facets) so a table arriving or leaving with a later run cannot change what node the lead table scrolls in
- [x] the 90rem min-width is scoped to the first table container by structure, so the lag table is sized by content with no class minted
- [x] unit tests: lagged rows read init-relative in the lead rows and carry `lag`; singleton row has `lag: null`; in-flight lagged run counts up after init and carries only a last-run lag; negative lag keeps its sign; fixture test asserts both sides
- [x] browser spec: both tables on the fixture's lagged GFS row, headers and cells; the source row's sub-headers
- [x] built with the live `dashboard.json` and checked HRRR 48h virtual (two tables), HRRR AWS and HRRR 18h virtual (one table each)
- [x] Codex review — presentation, keyed reconciliation across a poll (lag table arriving and leaving, lead scroll box kept), CSS scoping and conventions checked; two findings on pre-existing code declined as out of scope, listed below

### Log

**2026-09-04.** First pass was header wording only: `after init` / `vs earliest source` in the run sub-headers, on advice from a Codex second-look and reviewer that "−3m after source" read as a contradiction and "source" hid the earliest-mirror comparator. Reviewed and approved.

**2026-09-05.** Direction from marsh: show both figures, "after source" is fine (each virtual dataset points to one source; multiple sources is a later concern), 18h and 48h should not differ. Reworked to the layout above; the second-look caught that a current-run lag cell can never fill and it was dropped. Declined from the second-look: "recent paired runs" wording, a note on the singleton 18-hour row (the wxopticon source rows fix the asymmetry at the source), naming the sources in the header.

### Noticed, not touched

- `observedRunDetail` gates the current run's elapsed "after init" counter on the lead group's p95 being published, so a bootstrap payload with null percentiles shows "—" under `after init` while the run is in flight. Pre-existing; not reachable with today's payload.
- `statsHeader` returns before appending the insufficient-history note when `sample_init_count` is 0. Pre-existing.
- `formatLatency` can render "1h 60m" (minutes round up to 60; visible on the HRRR 48h virtual p99 today).
- `time after init · N samples` takes N from the product-level count while the percentiles are per lead group; the payload publishes no per-group count.

## Validation

- `npm test` — 188 pass
- `npx playwright test test/e2e/pipeline.spec.mjs` — 24 pass
- Built with the live payload and opened the three rows in headless Chromium: the lagged row shows the lead table plus a four-column lag table; the other two show the lead table only; nothing widens the page.

https://claude.ai/code/session_018TE9hiqANupb8K28NoYU3g
