### PR TITLE
Let the publisher decide which components are public

### DIFF
--- a/public/status.mjs
+++ b/public/status.mjs
@@ -140,20 +140,6 @@ export function validateStatusData(data) {
   };
 }
 
-// wxopticon keeps publishing into the feed — we still measure it — but it is
-// experimental, so its components stay off this page until they are stable
-// enough to sit behind an uptime claim.
-const EXPERIMENTAL_PREFIX = "wxopticon";
-
-export function withoutExperimentalComponents(data) {
-  return {
-    ...data,
-    endpoints: data.endpoints.filter(
-      (entry) => !entry.id.startsWith(EXPERIMENTAL_PREFIX),
-    ),
-  };
-}
-
 export function isStatusDataStale(generatedAt, now = new Date()) {
   const age = now.getTime() - Date.parse(generatedAt);
   return !Number.isFinite(age) || age > STALE_AFTER_MS;
@@ -842,9 +828,7 @@ async function loadStatus(root, update) {
     if (!response.ok) {
       throw new Error(`Status request failed: ${response.status}`);
     }
-    const data = withoutExperimentalComponents(
-      validateStatusData(await response.json()),
-    );
+    const data = validateStatusData(await response.json());
     const loadedHistory = await history;
     const currentHistory =
       loadedHistory && isHistoryCurrent(loadedHistory.asOf, data.generated_at)

--- a/test/fixtures/status.json
+++ b/test/fixtures/status.json
@@ -104,25 +104,11 @@
       "status": "operational"
     },
     {
-      "id": "wxopticon-arrivals",
-      "name": "pipeline observability",
-      "group": "tool",
-      "status": "operational"
-    },
-    {
-      "id": "wxopticon-webhooks",
-      "name": "pipeline webhooks",
-      "group": "tool",
-      "status": "operational"
-    },
-    {
       "id": "dynamical-org",
       "name": "status page",
       "group": "tool",
       "status": "operational"
     }
   ],
-  "component_aliases": {
-    "wxopticon-pipeline": "wxopticon-arrivals"
-  }
+  "component_aliases": {}
 }

--- a/test/status.test.mjs
+++ b/test/status.test.mjs
@@ -16,7 +16,6 @@ import {
   summarizeOverallStatus,
   uptimeDescription,
   validateStatusData,
-  withoutExperimentalComponents,
 } from "../public/status.mjs";
 import { systemHealth } from "../public/status-health.mjs";
 
@@ -53,56 +52,22 @@ test("accepts the published feed shape", () => {
   // publisher deliberately excludes contrib datasets and source archivers.
   assert.equal(fixture.datasets.length, 14);
   // Core resources followed by the reader-facing tools; datasets remain in the
-  // feed even though the page does not render them yet.
+  // feed even though the page does not render them yet. The experimental
+  // wxopticon components are absent because the publisher omits them: what is
+  // public is decided once, upstream, so this page, its health rollups, and the
+  // incident RSS feed cannot disagree about it.
   assert.deepEqual(
     fixture.endpoints.map((entry) => [entry.id, entry.group]),
     [
       ["stac-catalog", "endpoint"],
       ["data-product-reads", "endpoint"],
       ["scorecard", "tool"],
-      ["wxopticon-arrivals", "tool"],
-      ["wxopticon-webhooks", "tool"],
       ["dynamical-org", "tool"],
     ],
   );
   assert.deepEqual(summarizeOverallStatus(fixture), {
     status: "down",
     incidents: [{ name: "Data product reads", status: "down" }],
-  });
-});
-
-test("keeps the experimental wxopticon components off the page", () => {
-  // The publisher keeps measuring them; this page drops them until they are
-  // stable enough to sit behind an uptime claim.
-  const data = withoutExperimentalComponents(validateStatusData(fixture));
-  assert.deepEqual(
-    data.endpoints.map((entry) => entry.id),
-    ["stac-catalog", "data-product-reads", "scorecard", "dynamical-org"],
-  );
-  // Dropping them from the component list is what hides their bars and their
-  // incident-log entries; the rest of the document stays as published.
-  assert.deepEqual(data.datasets, fixture.datasets);
-  assert.deepEqual(data.component_aliases, fixture.component_aliases);
-});
-
-test("an experimental component's state does not move the rollup", () => {
-  const feed = structuredClone(operationalData);
-  feed.endpoints.push({
-    id: "wxopticon-arrivals",
-    name: "pipeline observability",
-    group: "tool",
-    status: "down",
-  });
-  const data = withoutExperimentalComponents(validateStatusData(feed));
-
-  assert.deepEqual(summarizeOverallStatus(data), {
-    status: "operational",
-    incidents: [],
-  });
-  assert.deepEqual(systemHealth(data), {
-    state: "operational",
-    label: "all systems",
-    value: "operational",
   });
 });
 


### PR DESCRIPTION
Site half of a two-repo fix. Publisher half: https://github.com/dynamical-org/dynamical.org-data/pull/38 (must land first; until it does, this change would show the wxopticon rows on /status/).

## Cause

The status page hid the experimental wxopticon components with its own id-prefix rule (#196). The incident RSS feed (built in dynamical.org-data) and the pipeline page's "systems" health dot (which reads status.json unfiltered) never learned it, so the feed carried dozens of wxopticon items the page does not show.

## Plan

- [x] The publisher decides what is public: wxopticon leaves status.json entirely.
- [x] Delete `withoutExperimentalComponents` and its tests; trim the fixture to what the publisher emits.
- [x] `npm test` and the offline status browser spec pass.
- [x] Codex review: no findings on the site side.

Once the publisher lands, this is a pure deletion: the old filter would already be a no-op.

## Log

### 2026-09-05 — start
Kept the page's IMPACT copy for wxopticon components in place; it is dormant, not dead, and the publisher may re-add the rows.

### 2026-09-05 — review and retro
Reviewed together with the publisher PR; the site half drew no findings. Retro: the whole site change is a deletion, which is the shape the fix wanted from the start once the publisher owned the decision.

https://claude.ai/code/session_01ALkbjGMTPuCKBExKLAyBZZ
